### PR TITLE
Feature: Closes #232

### DIFF
--- a/src/components/ChatAttachmentItem.js
+++ b/src/components/ChatAttachmentItem.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { TouchableOpacity, View, Dimensions, Image } from 'react-native';
 import PropTypes from 'prop-types';
-import { withStyles, Icon } from '@ui-kitten/components';
+import { withStyles, Icon, Tooltip } from '@ui-kitten/components';
 
 const deviceWidth = Dimensions.get('window').width;
 const deviceHeight = Dimensions.get('window').height;
@@ -135,6 +135,8 @@ const propTypes = {
       data_url: PropTypes.string,
     }),
   ),
+  name: PropTypes.string,
+  tooltip: PropTypes.bool,
 };
 
 const FileIcon = (style) => {
@@ -145,60 +147,79 @@ const ChatAttachmentItemComponent = ({
   type,
   attachment,
   showAttachment,
+  name,
+  tooltip,
   eva: { style, theme },
 }) => {
   const [imageLoading, onLoadImage] = useState(false);
+  const [visible, setVisible] = React.useState(false);
 
   const { file_type: fileType, data_url: dataUrl } = attachment[0];
   const fileName = dataUrl ? dataUrl.split('/').reverse()[0] : '';
 
-  return (
-    <React.Fragment>
-      {fileType !== 'file' ? (
-        <TouchableOpacity
-          onPress={() => showAttachment({ type: 'image', dataUrl })}
-          style={type === 'outgoing' ? style.imageViewRight : style.imageViewLeft}>
-          <Image
-            style={style.image}
-            source={{
-              uri: dataUrl,
-            }}
-            onLoadStart={() => onLoadImage(true)}
-            onLoadEnd={() => {
-              onLoadImage(false);
-            }}
-          />
-          {imageLoading && <ImageLoader style={style.imageLoader} />}
-        </TouchableOpacity>
-      ) : (
-        <View style={type === 'outgoing' ? style.fileViewRight : style.fileViewLeft}>
-          <View style={style.fileAttachmentContainer}>
-            <View style={style.fileAttachmentView}>
-              <View style={style.attachmentIconView}>
-                <FileIcon
-                  fill={
-                    type === 'outgoing' ? theme['color-basic-100'] : theme['color-primary-default']
-                  }
-                />
-              </View>
-              <View style={style.attachmentTexView}>
-                <CustomText
-                  style={type === 'outgoing' ? style.filenameRightText : style.filenameLeftText}>
-                  {fileName.length < 25
-                    ? `${fileName}`
-                    : `...${fileName.substr(fileName.length - 15)}`}
-                </CustomText>
-                <TouchableOpacity onPress={() => showAttachment({ type: 'file', dataUrl })}>
+  const renderToggleButton = () => {
+    return (
+      <View>
+        {fileType !== 'file' ? (
+          <TouchableOpacity
+            onPress={() => showAttachment({ type: 'image', dataUrl })}
+            onLongPress={() => setVisible(true)}
+            onPressOut={() => setVisible(false)}
+            style={type === 'outgoing' ? style.imageViewRight : style.imageViewLeft}>
+            <Image
+              style={style.image}
+              source={{
+                uri: dataUrl,
+              }}
+              onLoadStart={() => onLoadImage(true)}
+              onLoadEnd={() => {
+                onLoadImage(false);
+              }}
+            />
+            {imageLoading && <ImageLoader style={style.imageLoader} />}
+          </TouchableOpacity>
+        ) : (
+          <View style={type === 'outgoing' ? style.fileViewRight : style.fileViewLeft}>
+            <View style={style.fileAttachmentContainer}>
+              <View style={style.fileAttachmentView}>
+                <View style={style.attachmentIconView}>
+                  <FileIcon
+                    fill={
+                      type === 'outgoing'
+                        ? theme['color-basic-100']
+                        : theme['color-primary-default']
+                    }
+                  />
+                </View>
+                <View style={style.attachmentTexView}>
                   <CustomText
-                    style={type === 'outgoing' ? style.downloadRightText : style.downloadLeftText}>
-                    {i18n.t('CONVERSATION.DOWNLOAD')}
+                    style={type === 'outgoing' ? style.filenameRightText : style.filenameLeftText}>
+                    {fileName.length < 25
+                      ? `${fileName}`
+                      : `...${fileName.substr(fileName.length - 15)}`}
                   </CustomText>
-                </TouchableOpacity>
+                  <TouchableOpacity onPress={() => showAttachment({ type: 'file', dataUrl })}>
+                    <CustomText
+                      style={
+                        type === 'outgoing' ? style.downloadRightText : style.downloadLeftText
+                      }>
+                      {i18n.t('CONVERSATION.DOWNLOAD')}
+                    </CustomText>
+                  </TouchableOpacity>
+                </View>
               </View>
             </View>
           </View>
-        </View>
-      )}
+        )}
+      </View>
+    );
+  };
+
+  return (
+    <React.Fragment>
+      <Tooltip anchor={renderToggleButton} visible={visible} placement="top end">
+        {`Sent by: ${name}`}
+      </Tooltip>
     </React.Fragment>
   );
 };

--- a/src/components/ChatMessage.js
+++ b/src/components/ChatMessage.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { View, Dimensions } from 'react-native';
 import PropTypes from 'prop-types';
 
-import { withStyles } from '@ui-kitten/components';
+import { withStyles, Button, Tooltip } from '@ui-kitten/components';
 
 import CustomText from './Text';
 
@@ -57,13 +57,19 @@ const styles = (theme) => ({
   },
 });
 
-const MessageContentComponent = ({ message, type, showAttachment, created_at }) => {
-  const { attachments } = message;
+const MessageContentComponent = ({ message, type, showAttachment, created_at, tooltip }) => {
+  const { attachments, sender } = message;
 
   return attachments ? (
-    <ChatAttachmentItem attachment={attachments} type={type} showAttachment={showAttachment} />
+    <ChatAttachmentItem
+      attachment={attachments}
+      type={type}
+      showAttachment={showAttachment}
+      name={sender.name}
+      tooltip={tooltip}
+    />
   ) : (
-    <ChatMessageItem message={message} type={type} created_at={created_at} />
+    <ChatMessageItem message={message} type={type} created_at={created_at} tooltip={tooltip} />
   );
 };
 
@@ -76,6 +82,7 @@ const OutGoingMessageComponent = ({ message, created_at, showAttachment }) => (
       created_at={created_at}
       type="outgoing"
       showAttachment={showAttachment}
+      tooltip={true}
     />
   </React.Fragment>
 );
@@ -89,6 +96,7 @@ const IncomingMessageComponent = ({ message, created_at, showAttachment }) => (
       created_at={created_at}
       type="incoming"
       showAttachment={showAttachment}
+      tooltip={false}
     />
   </React.Fragment>
 );


### PR DESCRIPTION
- `onLongPress` method invokes the tooltip on senders message.

- ` onPressOut` method hides it when you (i.e when you lift up your finger)

- Works seamlessly for text as well as attachment

- Can be easily be **disable/enabled** for **sender/reciever** by just changing the **tooltip** flag

**Sender:**
```
const OutGoingMessageComponent = ({ message, created_at, showAttachment }) => (
  <React.Fragment>
    <MessageContent
      message={message}
      created_at={created_at}
      type="outgoing"
      showAttachment={showAttachment}
      tooltip={true}
    />
  </React.Fragment>
);
```
**Reciever:**
```
const IncomingMessageComponent = ({ message, created_at, showAttachment }) => (
  <React.Fragment>
    <MessageContent
      message={message}
      created_at={created_at}
      type="incoming"
      showAttachment={showAttachment}
      tooltip={false}
    />
  </React.Fragment>
);
```

**Example:**
[https://drive.google.com/file/d/1g6jfjexc0F-_cPVg8i7Ht4852YMQmE0B/view?usp=sharing](url)