### PR TITLE
feat: Adds clickable Twitter sender name under the message

### DIFF
--- a/src/screens/ChatScreen/ChatScreen.js
+++ b/src/screens/ChatScreen/ChatScreen.js
@@ -149,9 +149,17 @@ class ChatScreenComponent extends Component {
     );
   };
 
-  renderMessage = item => (
-    <ChatMessage message={item.item} key={item.index} showAttachment={this.showAttachment} />
-  );
+  renderMessage = item => {
+    const { meta } = this.props.route.params;
+    return (
+      <ChatMessage
+        meta={meta}
+        message={item.item}
+        key={item.index}
+        showAttachment={this.showAttachment}
+      />
+    );
+  };
 
   scrollToBottom = () => {
     this.setState({

--- a/src/screens/ChatScreen/components/ChatMessage.js
+++ b/src/screens/ChatScreen/components/ChatMessage.js
@@ -55,7 +55,7 @@ const styles = theme => ({
   },
 });
 
-const MessageContentComponent = ({ message, type, showAttachment, created_at }) => {
+const MessageContentComponent = ({ meta, message, type, showAttachment, created_at }) => {
   const { attachments } = message;
 
   return attachments ? (
@@ -67,15 +67,16 @@ const MessageContentComponent = ({ message, type, showAttachment, created_at }) 
       created_at={created_at}
     />
   ) : (
-    <ChatMessageItem message={message} type={type} created_at={created_at} />
+    <ChatMessageItem meta={meta} message={message} type={type} created_at={created_at} />
   );
 };
 
 const MessageContent = withStyles(MessageContentComponent, styles);
 
-const OutGoingMessageComponent = ({ message, created_at, showAttachment }) => (
+const OutGoingMessageComponent = ({ meta, message, created_at, showAttachment }) => (
   <React.Fragment>
     <MessageContent
+      meta={meta}
       message={message}
       created_at={created_at}
       type="outgoing"
@@ -86,9 +87,10 @@ const OutGoingMessageComponent = ({ message, created_at, showAttachment }) => (
 
 const OutGoingMessage = withStyles(OutGoingMessageComponent, styles);
 
-const IncomingMessageComponent = ({ message, created_at, showAttachment }) => (
+const IncomingMessageComponent = ({ meta, message, created_at, showAttachment }) => (
   <React.Fragment>
     <MessageContent
+      meta={meta}
       message={message}
       created_at={created_at}
       type="incoming"
@@ -128,7 +130,7 @@ const defaultProps = {
   message: { content: null, date: null },
 };
 
-const ChatMessageComponent = ({ message, eva: { style }, showAttachment }) => {
+const ChatMessageComponent = ({ meta, message, eva: { style }, showAttachment }) => {
   const { message_type, created_at } = message;
 
   let alignment = message_type ? 'flex-end' : 'flex-start';
@@ -141,6 +143,7 @@ const ChatMessageComponent = ({ message, eva: { style }, showAttachment }) => {
       <View style={style.messageContainer}>
         {alignment === 'flex-start' ? (
           <IncomingMessage
+            meta={meta}
             message={message}
             created_at={created_at}
             type="incoming"
@@ -150,6 +153,7 @@ const ChatMessageComponent = ({ message, eva: { style }, showAttachment }) => {
           <ActivityMessage message={message} created_at={created_at} type="activity" />
         ) : (
           <OutGoingMessage
+            meta={meta}
             message={message}
             created_at={created_at}
             type="outgoing"


### PR DESCRIPTION
# Pull Request Template

## Description 

1. Added the Twitter user name under the message in the conversation.
2. Added a link to the sender's name.
3. Avatar and username are now clickable.

Fixes #337

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

**Screenshot**

<img width="429" alt="image" src="https://user-images.githubusercontent.com/64252451/168978266-ccd3f450-7198-48e9-b017-901aa2a921d8.png">


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested in both Android and iOS platform
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
