### PR TITLE
feat: Add the support for installation url contains `https`

### DIFF
--- a/src/helpers/settingsHelper.js
+++ b/src/helpers/settingsHelper.js
@@ -1,0 +1,25 @@
+export const checkValidUrl = ({ url }) => {
+  try {
+    return Boolean(new URL(url));
+  } catch (e) {
+    return false;
+  }
+};
+
+export const extractDomain = ({ url }) => {
+  const isValidUrl = checkValidUrl({ url });
+
+  if (!isValidUrl) {
+    return url;
+  }
+  const domain = url.match(/:\/\/(www[0-9]?\.)?(.[^/:]+)/i);
+  if (
+    domain != null &&
+    domain.length > 2 &&
+    typeof domain[2] === 'string' &&
+    domain[2].length > 0
+  ) {
+    return domain[2];
+  }
+  return url;
+};

--- a/src/helpers/specs/settingsHelpers.spec.js
+++ b/src/helpers/specs/settingsHelpers.spec.js
@@ -3,9 +3,9 @@ import { extractDomain, checkValidUrl } from '../settingsHelper';
 describe('SettingsHelper', () => {
   describe('extractDomain', () => {
     it('should return the domain from a https url', () => {
-      const url = 'https://www.chatwoot.com';
+      const url = 'https://www.app.chatwoot.com';
       const domain = extractDomain({ url });
-      expect(domain).toEqual('chatwoot.com');
+      expect(domain).toEqual('app.chatwoot.com');
     });
 
     it('should return the domain', () => {

--- a/src/helpers/specs/settingsHelpers.spec.js
+++ b/src/helpers/specs/settingsHelpers.spec.js
@@ -31,6 +31,18 @@ describe('SettingsHelper', () => {
       const domain = extractDomain({ url });
       expect(domain).toEqual('mobile.chatwoot.app');
     });
+
+    it('should return the domain from subdomain 4', () => {
+      const url = 'subdomain.domain.tld';
+      const domain = extractDomain({ url });
+      expect(domain).toEqual('subdomain.domain.tld');
+    });
+
+    it('should return the domain from subdomain 5', () => {
+      const url = 'sub1.sub2.domain.tld';
+      const domain = extractDomain({ url });
+      expect(domain).toEqual('sub1.sub2.domain.tld');
+    });
   });
 
   describe('checkValidUrl', () => {

--- a/src/helpers/specs/settingsHelpers.spec.js
+++ b/src/helpers/specs/settingsHelpers.spec.js
@@ -1,0 +1,67 @@
+import { extractDomain, checkValidUrl } from '../settingsHelper';
+
+describe('SettingsHelper', () => {
+  describe('extractDomain', () => {
+    it('should return the domain from a https url', () => {
+      const url = 'https://www.chatwoot.com';
+      const domain = extractDomain({ url });
+      expect(domain).toEqual('chatwoot.com');
+    });
+
+    it('should return the domain', () => {
+      const url = 'app.chatwoot.com';
+      const domain = extractDomain({ url });
+      expect(domain).toEqual('app.chatwoot.com');
+    });
+
+    it('should return the domain from subdomain 1', () => {
+      const url = 'https://app.chatwoot.com';
+      const domain = extractDomain({ url });
+      expect(domain).toEqual('app.chatwoot.com');
+    });
+
+    it('should return the domain from subdomain 2', () => {
+      const url = 'https://mobile.chatwoot.app';
+      const domain = extractDomain({ url });
+      expect(domain).toEqual('mobile.chatwoot.app');
+    });
+
+    it('should return true for valid url 3', () => {
+      const url = 'mobile.chatwoot.app';
+      const domain = extractDomain({ url });
+      expect(domain).toEqual('mobile.chatwoot.app');
+    });
+  });
+
+  describe('checkValidUrl', () => {
+    it('should return true for valid url 1', () => {
+      const url = 'https://www.chatwoot.com';
+      const domain = checkValidUrl({ url });
+      expect(domain).toEqual(true);
+    });
+
+    it('should return true for valid url 2', () => {
+      const url = 'http://.chatwoot.com';
+      const domain = checkValidUrl({ url });
+      expect(domain).toEqual(true);
+    });
+
+    it('should return true for valid url 4', () => {
+      const url = 'ht://app.chatwoot.com';
+      const domain = checkValidUrl({ url });
+      expect(domain).toEqual(true);
+    });
+
+    it('should return false for invalid url 1', () => {
+      const url = 'app.chatwoot.com';
+      const domain = checkValidUrl({ url });
+      expect(domain).toEqual(false);
+    });
+
+    it('should return false for invalid url 2', () => {
+      const url = 'mobile.chatwoot.app';
+      const domain = checkValidUrl({ url });
+      expect(domain).toEqual(false);
+    });
+  });
+});

--- a/src/reducer/conversationSlice.js
+++ b/src/reducer/conversationSlice.js
@@ -135,6 +135,9 @@ const conversationSlice = createSlice({
       })
       .addCase(actions.fetchPreviousMessages.fulfilled, (state, { payload }) => {
         const { data, conversationId } = payload;
+        if (!state.entities[conversationId]) {
+          return;
+        }
         const conversation = state.entities[conversationId];
         conversation.messages.unshift(...data);
         state.loadingMessages = false;

--- a/src/reducer/settingsSlice.js
+++ b/src/reducer/settingsSlice.js
@@ -7,6 +7,7 @@ import { showToast } from 'helpers/ToastHelper';
 import I18n from 'i18n';
 import * as RootNavigation from 'helpers/NavigationHelper';
 import { checkServerSupport } from 'helpers/ServerHelper';
+import { extractDomain } from 'src/helpers/settingsHelper';
 
 const settingAdapter = createEntityAdapter();
 export const actions = {
@@ -14,14 +15,19 @@ export const actions = {
     'settings/setInstallationUrl',
     async ({ url }, { rejectWithValue }) => {
       try {
-        const INSTALLATION_URL = `${URL_TYPE}${url}/`;
+        const installationUrl = extractDomain({ url });
+        const INSTALLATION_URL = `${URL_TYPE}${installationUrl}/`;
         const WEB_SOCKET_URL = `wss://${url}/cable`;
         await axios.get(`${INSTALLATION_URL}api`);
         RootNavigation.navigate('Login');
-        return { installationUrl: INSTALLATION_URL, webSocketUrl: WEB_SOCKET_URL, baseUrl: url };
+        return {
+          installationUrl: INSTALLATION_URL,
+          webSocketUrl: WEB_SOCKET_URL,
+          baseUrl: installationUrl,
+        };
       } catch (error) {
         showToast({ message: I18n.t('CONFIGURE_URL.ERROR') });
-        return rejectWithValue(error);
+        return rejectWithValue();
       }
     },
   ),

--- a/src/screens/ConfigureURLScreen/ConfigureURLScreen.js
+++ b/src/screens/ConfigureURLScreen/ConfigureURLScreen.js
@@ -16,6 +16,7 @@ import TextInput from '../../components/TextInput';
 import { URL_WITHOUT_HTTP_REGEX } from '../../helpers/formHelper';
 import {
   selectIsSettingUrl,
+  selectBaseUrl,
   actions as settingsActions,
   resetSettings,
 } from 'reducer/settingsSlice';
@@ -41,6 +42,7 @@ const defaultProps = {
 };
 
 const ConfigureURLScreenComponent = ({ eva }) => {
+  const baseUrl = useSelector(selectBaseUrl);
   const isSettingUrl = useSelector(selectIsSettingUrl);
   const dispatch = useDispatch();
 
@@ -52,7 +54,7 @@ const ConfigureURLScreenComponent = ({ eva }) => {
     formState: { errors },
   } = useForm({
     defaultValues: {
-      url: appName === 'Chatwoot' ? 'app.chatwoot.com' : null,
+      url: baseUrl ? baseUrl : appName === 'Chatwoot' ? 'app.chatwoot.com' : '',
     },
   });
 


### PR DESCRIPTION
Fixes https://github.com/chatwoot/chatwoot-mobile-app/issues/557

This PR added the support for the following URL formats,

1. https://app.chatwoot.com
2. app.chatwoot.com
3. mobile.chatwoot.app
