### PR TITLE
chore: Add an analytics event if user enable the notifications

### DIFF
--- a/src/constants/analyticsEvents.js
+++ b/src/constants/analyticsEvents.js
@@ -17,6 +17,7 @@ export const CONVERSATION_EVENTS = Object.freeze({
   SELF_ASSIGN_CONVERSATION: 'Self assigned conversation',
   MARK_AS_UNREAD: 'Mark as unread',
   MARK_AS_READ: 'Mark as read',
+  ENABLE_PUSH_NOTIFICATION: 'Enabled push notification',
 });
 
 export const ACCOUNT_EVENTS = Object.freeze({


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-374/add-an-analytics-event-for-notifications-on-mobile-app