### PR TITLE
fix: Refresh the notifications on awake event

### DIFF
--- a/src/screens/Conversation/ConversationScreen.js
+++ b/src/screens/Conversation/ConversationScreen.js
@@ -40,7 +40,7 @@ import { getCurrentRouteName } from 'helpers/NavigationHelper';
 import { actions as labelActions } from 'reducer/labelSlice';
 import { SCREENS } from 'constants';
 
-// The screen list thats need to be checked for refresh conversation list
+// The screen list thats need to be checked for refresh notification list
 const REFRESH_SCREEN_LIST = [SCREENS.CONVERSATION, SCREENS.NOTIFICATION, SCREENS.SETTINGS];
 
 const ConversationScreen = () => {
@@ -90,7 +90,7 @@ const ConversationScreen = () => {
     const { accountId, userId } = await getUserDetails();
     ActionCable.init({ pubSubToken, webSocketUrl, accountId, userId });
   }, [webSocketUrl]);
-  // Update conversations when app comes to foreground from background
+  // Update notifications when app comes to foreground from background
   useEffect(() => {
     const appStateListener = AppState.addEventListener('change', nextAppState => {
       if (appState === 'background' && nextAppState === 'active') {


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-371/refresh-the-notifications-on-the-awake-event