### PR TITLE
fix: Fix rendering mentions conversation screen

### DIFF
--- a/src/helpers/conversationHelpers.js
+++ b/src/helpers/conversationHelpers.js
@@ -120,3 +120,16 @@ export const buildCreatePayload = ({
   }
   return payload;
 };
+
+export const replaceMentionsWithUsernames = text => {
+  // eslint-disable-next-line no-useless-escape
+  const regex = /\[@([^\]]+)\]\(mention:\/\/user\/\d+\/([^\)]+)\)/g;
+  const matches = text.matchAll(regex);
+  let result = text;
+  for (const match of matches) {
+    const [fullMatch, username] = match;
+    const replacement = `@${decodeURIComponent(username)}`;
+    result = result.replace(fullMatch, replacement);
+  }
+  return result;
+};

--- a/src/helpers/specs/conversationHelpers.spec.js
+++ b/src/helpers/specs/conversationHelpers.spec.js
@@ -1,4 +1,9 @@
-import { applyFilters, getUuid, findLastMessage } from 'helpers/conversationHelpers';
+import {
+  applyFilters,
+  getUuid,
+  findLastMessage,
+  replaceMentionsWithUsernames,
+} from 'helpers/conversationHelpers';
 
 describe('conversation helpers', () => {
   it('should return true if conversation status matches filter status', () => {
@@ -136,5 +141,28 @@ describe('#lastMessage', () => {
       },
     };
     expect(findLastMessage(conversation)).toEqual(conversation.messages[1]);
+  });
+});
+
+describe('#replaceMentionsWithUsernames', () => {
+  it('should replace mentions with user name', () => {
+    const message = '[@Peter Don](mention://user/3994/Peter) Are you able to view this content?';
+    expect(replaceMentionsWithUsernames(message)).toEqual(
+      '@Peter Don Are you able to view this content?',
+    );
+  });
+
+  it('should replace mentions with user name have first name and last name', () => {
+    const message = '[@Jane Per](mention://user/21/%241) Are you able to view this content?';
+    expect(replaceMentionsWithUsernames(message)).toEqual(
+      '@Jane Per Are you able to view this content?',
+    );
+  });
+
+  it('should replace mentions with user name have only first name', () => {
+    const message = '[@Jane](mention://user/21/Jane) Are you able to view this content?';
+    expect(replaceMentionsWithUsernames(message)).toEqual(
+      '@Jane Are you able to view this content?',
+    );
   });
 });

--- a/src/screens/Conversation/components/ConversationItem/ConversationContent.js
+++ b/src/screens/Conversation/components/ConversationItem/ConversationContent.js
@@ -2,10 +2,11 @@ import React, { Fragment, useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useTheme } from '@react-navigation/native';
 import PropTypes from 'prop-types';
+
 import { Icon, Text } from 'components';
 import { MESSAGE_TYPES } from 'constants';
-
 import { getTextSubstringWithEllipsis } from 'helpers';
+import { replaceMentionsWithUsernames } from 'helpers/conversationHelpers';
 
 const createStyles = theme => {
   const { spacing } = theme;
@@ -37,9 +38,7 @@ const ConversationContent = ({ content, messageType, isPrivate, unReadCount }) =
   const theme = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const { colors } = theme;
-  const message = content
-    ? content.replace(/\[(@[\w_. ]+)\]\(mention:\/\/(?:user|team)\/\d+\/(.*?)+\)/gi, '$1').trim()
-    : '';
+  const message = replaceMentionsWithUsernames(content);
   return (
     <Fragment>
       {messageType === MESSAGE_TYPES.OUTGOING || messageType === MESSAGE_TYPES.ACTIVITY ? (


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-1831/rendering-issues-for-username-with-first-name-and-last-name