### PR TITLE
fix: Add the support for block quotes

### DIFF
--- a/src/screens/ChatScreen/components/ChatMessageItem.js
+++ b/src/screens/ChatScreen/components/ChatMessageItem.js
@@ -342,7 +342,7 @@ const ChatMessageItemComponent = ({ conversation, type, message, created_at, sho
           markdownit={MarkdownIt({
             linkify: true,
             typographer: true,
-          }).disable('blockquote')} // disable code block
+          })}
           onLinkPress={handleURL}
           style={{
             body: messageBodyStyle,
@@ -365,6 +365,10 @@ const ChatMessageItemComponent = ({ conversation, type, message, created_at, sho
             ordered_list_icon: {
               color: listIconColor(),
               marginTop: 1,
+            },
+            blockquote: {
+              backgroundColor: colors.primaryColor,
+              color: colors.blockColor,
             },
           }}>
           {message.content}

--- a/src/screens/ChatScreen/components/ReplyBox.js
+++ b/src/screens/ChatScreen/components/ReplyBox.js
@@ -291,6 +291,10 @@ const ReplyBox = ({ conversationId, inboxId, conversationDetails, enableReplyBut
               renderSuggestions,
               textStyle: { fontWeight: 'bold', color: 'white', backgroundColor: '#8c9eb6' },
             },
+            {
+              pattern: /\[([^\]]+)\]\(([^\)]+)\)/g,
+              textStyle: { color: colors.primaryColor },
+            },
           ]}
           multiline={true}
           placeholderTextColor={colors.textLighter}
@@ -348,7 +352,7 @@ const createStyles = theme => {
       borderTopWidth: 1,
     },
     inputView: {
-      fontSize: fontSize.md,
+      fontSize: fontSize.sm,
       color: colors.text,
       borderRadius: borderRadius.small,
       paddingTop: 10,

--- a/src/theme.js
+++ b/src/theme.js
@@ -50,6 +50,7 @@ export const palette = {
   text: '#37546D',
   textDark: '#293F51',
   textDarker: '#1f2d3d',
+  blockColor: '#d6ebff',
 
   borderDark: '#37546D',
   border: '#C9D7E3',


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-1894/blockquote-is-not-supported-in-the-message-rendering and https://linear.app/chatwoot/issue/CW-1880/rich-content-is-not-supported-in-the-link