### PR TITLE
fix: Double click issue while selecting canned response

### DIFF
--- a/src/screens/ChatScreen/components/CannedResponses.js
+++ b/src/screens/ChatScreen/components/CannedResponses.js
@@ -79,6 +79,7 @@ const CannedResponses = ({ cannedResponses, onClick }) => {
           />
         )}
         keyExtractor={item => item.id}
+        keyboardShouldPersistTaps={'handled'}
       />
     </View>
   );

--- a/src/screens/ConversationAction/ConversationAction.js
+++ b/src/screens/ConversationAction/ConversationAction.js
@@ -66,8 +66,8 @@ const ConversationActionComponent = ({ onPressAction, conversationDetails }) => 
           itemType="assignee"
           iconName="people-outline"
           colors={colors}
-          name={assignedAgent.name ? assignedAgent.name : i18n.t('AGENT.TITLE')}
-          thumbnail={assignedAgent.thumbnail}
+          name={assignedAgent?.name ? assignedAgent.name : i18n.t('AGENT.TITLE')}
+          thumbnail={assignedAgent?.thumbnail}
           availabilityStatus={assignedAgent?.availability_status}
         />
 


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-1879/it-needs-2-clicks-to-use-a-canned-response