### PR TITLE
feat: Improved canned response list design

### DIFF
--- a/src/screens/ChatScreen/components/CannedResponses.js
+++ b/src/screens/ChatScreen/components/CannedResponses.js
@@ -9,24 +9,37 @@ const createStyles = theme => {
   return StyleSheet.create({
     mainView: {
       backgroundColor: colors.colorWhite,
-      borderRadius: borderRadius.micro,
-      paddingHorizontal: spacing.small,
+      marginHorizontal: spacing.smaller,
+      borderRadius: borderRadius.small,
+      shadowColor: colors.backdropColor,
+      shadowOffset: {
+        width: 0,
+        height: 8,
+      },
+      shadowOpacity: 0.1,
+      shadowRadius: 4,
+      elevation: 6,
       maxHeight: 200,
-      borderTopColor: colors.borderLight,
-      borderTopWidth: 1,
+      borderColor: colors.borderLight,
+      borderWidth: 0.6,
+      position: 'absolute',
+      bottom: 106,
+      zIndex: 1,
+    },
+    contentContainerStyle: {
+      paddingHorizontal: spacing.small,
+      paddingVertical: spacing.smaller,
     },
     itemView: {
-      flex: 1,
       flexDirection: 'row',
       paddingVertical: spacing.smaller,
-      paddingHorizontal: spacing.tiny,
     },
     lastItemView: {
-      borderBottomWidth: 1,
+      borderBottomWidth: 0.4,
       borderBottomColor: colors.borderLight,
     },
     content: {
-      flex: 1,
+      lineHeight: 18,
     },
   });
 };
@@ -39,11 +52,11 @@ const CannedResponseComponent = ({ shortCode, content, lastItem, onClick }) => {
     <Pressable
       style={[styles.itemView, !lastItem && styles.lastItemView]}
       onPress={() => onClick(content)}>
-      <Text bold color={colors.primaryColor}>
-        {shortCode} -
-      </Text>
-      <Text medium color={colors.primaryColor} style={styles.content}>
-        {content}
+      <Text semiBold sm color={colors.primaryColorDark} style={styles.content}>
+        {`${shortCode} - `}
+        <Text regular sm color={colors.textDark} style={styles.content}>
+          {content}
+        </Text>
       </Text>
     </Pressable>
   );
@@ -78,6 +91,7 @@ const CannedResponses = ({ cannedResponses, onClick }) => {
             onClick={onClick}
           />
         )}
+        contentContainerStyle={styles.contentContainerStyle}
         keyExtractor={item => item.id}
         keyboardShouldPersistTaps={'handled'}
       />

--- a/src/screens/ChatScreen/components/CannedResponses.js
+++ b/src/screens/ChatScreen/components/CannedResponses.js
@@ -1,11 +1,12 @@
 import React, { useMemo } from 'react';
 import { useTheme } from '@react-navigation/native';
 import { Text, Pressable } from 'components';
-import { View, FlatList, StyleSheet } from 'react-native';
+import { View, FlatList, StyleSheet, Dimensions } from 'react-native';
 import PropTypes from 'prop-types';
 
 const createStyles = theme => {
   const { spacing, borderRadius, colors } = theme;
+  const { width } = Dimensions.get('window');
   return StyleSheet.create({
     mainView: {
       backgroundColor: colors.colorWhite,
@@ -23,6 +24,7 @@ const createStyles = theme => {
       borderColor: colors.borderLight,
       borderWidth: 0.6,
       position: 'absolute',
+      width: width - spacing.smaller * 2,
       bottom: 106,
       zIndex: 1,
     },
@@ -80,21 +82,23 @@ const CannedResponses = ({ cannedResponses, onClick }) => {
   const theme = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
   return (
-    <View style={styles.mainView}>
-      <FlatList
-        data={cannedResponses}
-        renderItem={({ item, index }) => (
-          <CannedResponse
-            shortCode={item.shortCode}
-            content={item.content}
-            lastItem={cannedResponses.length - 1 === index}
-            onClick={onClick}
-          />
-        )}
-        contentContainerStyle={styles.contentContainerStyle}
-        keyExtractor={item => item.id}
-        keyboardShouldPersistTaps={'handled'}
-      />
+    <View style={[cannedResponses.length > 0 && styles.mainView]}>
+      {cannedResponses.length > 0 && (
+        <FlatList
+          data={cannedResponses}
+          renderItem={({ item, index }) => (
+            <CannedResponse
+              shortCode={item.shortCode}
+              content={item.content}
+              lastItem={cannedResponses.length - 1 === index}
+              onClick={onClick}
+            />
+          )}
+          contentContainerStyle={styles.contentContainerStyle}
+          keyExtractor={item => item.id}
+          keyboardShouldPersistTaps={'handled'}
+        />
+      )}
     </View>
   );
 };

--- a/src/screens/ChatScreen/components/CannedResponses.js
+++ b/src/screens/ChatScreen/components/CannedResponses.js
@@ -81,9 +81,11 @@ const propTypes = {
 const CannedResponses = ({ cannedResponses, onClick }) => {
   const theme = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const isCannedResponsesExist = cannedResponses.length > 0;
+
   return (
-    <View style={[cannedResponses.length > 0 && styles.mainView]}>
-      {cannedResponses.length > 0 && (
+    <View style={[isCannedResponsesExist && styles.mainView]}>
+      {isCannedResponsesExist && (
         <FlatList
           data={cannedResponses}
           renderItem={({ item, index }) => (

--- a/src/screens/ChatScreen/components/ReplyBox.js
+++ b/src/screens/ChatScreen/components/ReplyBox.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { useTheme } from '@react-navigation/native';
-import { View, Dimensions, TextInput, StyleSheet } from 'react-native';
+import { View, Dimensions, TextInput, StyleSheet, Platform } from 'react-native';
 import { Text, Icon, Pressable } from 'components';
 import { MentionInput } from 'react-native-controlled-mentions';
 import PropTypes from 'prop-types';
@@ -31,6 +31,8 @@ const propTypes = {
   inboxId: PropTypes.number,
   enableReplyButton: PropTypes.bool,
 };
+
+const isAndroid = Platform.OS === 'android';
 
 const ReplyBox = ({ conversationId, inboxId, conversationDetails, enableReplyButton }) => {
   const theme = useTheme();
@@ -218,117 +220,119 @@ const ReplyBox = ({ conversationId, inboxId, conversationDetails, enableReplyBut
   const enableReplyBox = (message || attachmentDetails) && enableReplyButton ? true : false;
   return (
     <React.Fragment>
-      {attachmentDetails && (
-        <View style={styles.attachmentWrap}>
-          <AttachmentPreview
-            attachmentDetails={attachmentDetails}
-            onRemoveAttachment={onRemoveAttachment}
-          />
-        </View>
-      )}
-      {cannedResponseSearchKey ? (
-        <CannedResponsesContainer
-          onClick={onCannedResponseSelect}
-          searchKey={cannedResponseSearchKey}
-        />
-      ) : null}
-      <ModalView
-        showModal={showUndefinedVariablesModal}
-        headerText={i18n.t('CONVERSATION.UNDEFINED_VARIABLES_TITLE')}
-        contentText={undefinedVariableText}
-        buttonText={i18n.t('CONVERSATION.UNDEFINED_VARIABLES_CLOSE')}
-        onPressClose={() => setUndefinedVariablesModal(false)}
-      />
-      {isAnEmailChannelAndNotInPrivateNote() && emailFields && (
-        <View style={styles.emailFields}>
-          <View style={styles.emailFieldsTextWrap}>
-            <Text medium sm color={colors.text} style={styles.emailFieldLabel}>
-              {'Cc'}
-            </Text>
-            <TextInput
-              style={styles.ccInputView}
-              value={ccEmails}
-              onChangeText={onCCMailChange}
-              placeholder="Emails separated by commas"
-              placeholderTextColor={colors.textLighter}
+      <View style={styles.replyBoxContainer}>
+        {attachmentDetails && (
+          <View style={styles.attachmentWrap}>
+            <AttachmentPreview
+              attachmentDetails={attachmentDetails}
+              onRemoveAttachment={onRemoveAttachment}
             />
           </View>
-          <View style={styles.emailFieldsTextWrap}>
-            <Text medium sm color={colors.text} style={styles.emailFieldLabel}>
-              {'Bcc'}
-            </Text>
-            <TextInput
-              style={styles.bccInputView}
-              value={bccEmails}
-              onChangeText={onBCCMailChange}
-              placeholder="Emails separated by commas"
-              placeholderTextColor={colors.textLighter}
-            />
-          </View>
-        </View>
-      )}
-
-      <View style={[isPrivate ? styles.privateView : styles.replyView, inputBorderColor()]}>
-        {isAnEmailChannelAndNotInPrivateNote() && !emailFields && (
-          <Text
-            medium
-            sm
-            color={colors.primaryColorDark}
-            style={styles.emailFieldToggleButton}
-            onPress={toggleCcBccInputs}>
-            {'Cc/Bcc'}
-          </Text>
         )}
-        <MentionInput
-          style={[styles.inputView, inputFieldColor()]}
-          value={message}
-          onChange={onNewMessageChange}
-          partTypes={[
-            {
-              allowedSpacesCount: 0,
-              isInsertSpaceAfterMention: true,
-              trigger: '@',
-              renderSuggestions,
-              textStyle: { fontWeight: 'bold', color: 'white', backgroundColor: '#8c9eb6' },
-            },
-            {
-              pattern: /\[([^\]]+)\]\(([^\)]+)\)/g,
-              textStyle: { color: colors.primaryColor },
-            },
-          ]}
-          multiline={true}
-          placeholderTextColor={colors.textLighter}
-          placeholder={
-            isPrivate
-              ? `${i18n.t('CONVERSATION.PRIVATE_MSG_INPUT')}`
-              : `${i18n.t('CONVERSATION.TYPE_MESSAGE')}`
-          }
-          onBlur={onBlur}
-          onFocus={onFocus}
+        {cannedResponseSearchKey ? (
+          <CannedResponsesContainer
+            onClick={onCannedResponseSelect}
+            searchKey={cannedResponseSearchKey}
+          />
+        ) : null}
+        <ModalView
+          showModal={showUndefinedVariablesModal}
+          headerText={i18n.t('CONVERSATION.UNDEFINED_VARIABLES_TITLE')}
+          contentText={undefinedVariableText}
+          buttonText={i18n.t('CONVERSATION.UNDEFINED_VARIABLES_CLOSE')}
+          onPressClose={() => setUndefinedVariablesModal(false)}
         />
+        {isAnEmailChannelAndNotInPrivateNote() && emailFields && (
+          <View style={styles.emailFields}>
+            <View style={styles.emailFieldsTextWrap}>
+              <Text medium sm color={colors.text} style={styles.emailFieldLabel}>
+                {'Cc'}
+              </Text>
+              <TextInput
+                style={styles.ccInputView}
+                value={ccEmails}
+                onChangeText={onCCMailChange}
+                placeholder="Emails separated by commas"
+                placeholderTextColor={colors.textLighter}
+              />
+            </View>
+            <View style={styles.emailFieldsTextWrap}>
+              <Text medium sm color={colors.text} style={styles.emailFieldLabel}>
+                {'Bcc'}
+              </Text>
+              <TextInput
+                style={styles.bccInputView}
+                value={bccEmails}
+                onChangeText={onBCCMailChange}
+                placeholder="Emails separated by commas"
+                placeholderTextColor={colors.textLighter}
+              />
+            </View>
+          </View>
+        )}
 
-        <View style={styles.buttonViews}>
-          <View style={styles.attachIconView}>
-            <Attachment conversationId={conversationId} onSelectAttachment={onSelectAttachment} />
-            <Pressable style={styles.privateNoteView} onPress={togglePrivateMode}>
+        <View style={[isPrivate ? styles.privateView : styles.replyView, inputBorderColor()]}>
+          {isAnEmailChannelAndNotInPrivateNote() && !emailFields && (
+            <Text
+              medium
+              sm
+              color={colors.primaryColorDark}
+              style={styles.emailFieldToggleButton}
+              onPress={toggleCcBccInputs}>
+              {'Cc/Bcc'}
+            </Text>
+          )}
+          <MentionInput
+            style={[styles.inputView, inputFieldColor()]}
+            value={message}
+            onChange={onNewMessageChange}
+            partTypes={[
+              {
+                allowedSpacesCount: 0,
+                isInsertSpaceAfterMention: true,
+                trigger: '@',
+                renderSuggestions,
+                textStyle: { fontWeight: 'bold', color: 'white', backgroundColor: '#8c9eb6' },
+              },
+              {
+                pattern: /\[([^\]]+)\]\(([^\)]+)\)/g,
+                textStyle: { color: colors.primaryColor },
+              },
+            ]}
+            multiline={true}
+            placeholderTextColor={colors.textLighter}
+            placeholder={
+              isPrivate
+                ? `${i18n.t('CONVERSATION.PRIVATE_MSG_INPUT')}`
+                : `${i18n.t('CONVERSATION.TYPE_MESSAGE')}`
+            }
+            onBlur={onBlur}
+            onFocus={onFocus}
+          />
+
+          <View style={styles.buttonViews}>
+            <View style={styles.attachIconView}>
+              <Attachment conversationId={conversationId} onSelectAttachment={onSelectAttachment} />
+              <Pressable style={styles.privateNoteView} onPress={togglePrivateMode}>
+                <Icon
+                  icon="lock-closed-outline"
+                  color={isPrivate ? colors.primaryColor : colors.textLight}
+                  size={24}
+                />
+              </Pressable>
+            </View>
+            <Pressable
+              style={[styles.sendButtonView, sendMessageButtonWrapStyles()]}
+              disabled={!enableReplyBox}
+              onPress={onNewMessageAdd}>
               <Icon
-                icon="lock-closed-outline"
-                color={isPrivate ? colors.primaryColor : colors.textLight}
+                icon="send-outline"
+                style={styles.sendButton}
+                color={enableReplyBox ? colors.primaryColor : colors.background}
                 size={24}
               />
             </Pressable>
           </View>
-          <Pressable
-            style={[styles.sendButtonView, sendMessageButtonWrapStyles()]}
-            disabled={!enableReplyBox}
-            onPress={onNewMessageAdd}>
-            <Icon
-              icon="send-outline"
-              style={styles.sendButton}
-              color={enableReplyBox ? colors.primaryColor : colors.background}
-              size={24}
-            />
-          </Pressable>
         </View>
       </View>
     </React.Fragment>
@@ -338,6 +342,9 @@ const ReplyBox = ({ conversationId, inboxId, conversationDetails, enableReplyBut
 const createStyles = theme => {
   const { spacing, borderRadius, fontSize, colors } = theme;
   return StyleSheet.create({
+    replyBoxContainer: {
+      position: 'relative',
+    },
     replyView: {
       paddingVertical: spacing.smaller,
       paddingHorizontal: spacing.small,
@@ -353,12 +360,12 @@ const createStyles = theme => {
     },
     inputView: {
       fontSize: fontSize.sm,
-      color: colors.text,
+      color: colors.textDarker,
+      lineHeight: 18,
       borderRadius: borderRadius.small,
-      paddingTop: 10,
+      paddingTop: !isAndroid ? spacing.half : spacing.smaller,
+      paddingBottom: !isAndroid ? spacing.half : spacing.smaller,
       paddingHorizontal: 10,
-      paddingVertical: spacing.half,
-      textAlignVertical: 'top',
       textAlign: 'left',
       maxHeight: 160,
     },

--- a/src/screens/Conversation/components/ConversationItem/ConversationAttachment.js
+++ b/src/screens/Conversation/components/ConversationItem/ConversationAttachment.js
@@ -23,7 +23,7 @@ const ConversationAttachmentItem = ({ attachment }) => {
           <View style={styles.icon}>
             <Icon icon="image-outline" color={colors.text} size={14} />
           </View>
-          <Text sm medium color={colors.text}>
+          <Text sm color={colors.text}>
             {i18n.t('CONVERSATION.PICTURE_CONTENT')}
           </Text>
         </View>
@@ -32,7 +32,7 @@ const ConversationAttachmentItem = ({ attachment }) => {
           <View style={styles.icon}>
             <Icon icon="document-outline" color={colors.text} size={14} />
           </View>
-          <Text sm medium color={colors.text}>
+          <Text sm color={colors.text}>
             {i18n.t('CONVERSATION.ATTACHMENT_CONTENT')}
           </Text>
         </View>

--- a/src/screens/Conversation/components/ConversationItem/ConversationItem.js
+++ b/src/screens/Conversation/components/ConversationItem/ConversationItem.js
@@ -1,5 +1,5 @@
 import React, { useMemo, useRef } from 'react';
-import { View, Pressable, StyleSheet, Animated } from 'react-native';
+import { View, Pressable, StyleSheet, Animated, Platform } from 'react-native';
 import PropTypes from 'prop-types';
 import { useTheme } from '@react-navigation/native';
 import { useSelector, useDispatch } from 'react-redux';
@@ -19,6 +19,8 @@ import { CONVERSATION_EVENTS } from 'constants/analyticsEvents';
 
 import ConversationLabel from './ConversationLabels';
 import ConversationPriority from './ConversationPriority';
+
+const isAndroid = Platform.OS === 'android';
 
 const propTypes = {
   item: PropTypes.shape({
@@ -284,7 +286,7 @@ const createStyles = theme => {
     },
     avatarView: {
       alignSelf: 'flex-start',
-      marginTop: 30,
+      marginTop: !isAndroid ? 30 : 34,
       marginRight: spacing.smaller,
     },
     contentView: {


### PR DESCRIPTION
# Pull Request Template

## Description 

- Improved canned response list rendering, like a pop view instead of scrolling up the chat screen.
- Minor chatlist [spacing](https://linear.app/chatwoot/issue/CW-1885/alignment-issues-with-the-thumbnail) and font weight fixes 

Fixes https://linear.app/chatwoot/issue/CW-1889/improve-the-canned-response-list-design , https://linear.app/chatwoot/issue/CW-1885/alignment-issues-with-the-thumbnail

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

![image](https://github.com/chatwoot/chatwoot-mobile-app/assets/64252451/eaa33c09-ee2e-47d0-8d6a-e319c98b9bb6)




## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested in both Android and iOS platform
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
