### PR TITLE
fix: Support all types conversation links in deep linking

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -140,8 +140,8 @@ android {
         applicationId "com.chatwoot.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion 
-        versionCode 5168
-        versionName "1.9.26"
+        versionCode 5169
+        versionName "1.9.27"
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
 
         multiDexEnabled true 

--- a/ios/Chatwoot.xcodeproj/project.pbxproj
+++ b/ios/Chatwoot.xcodeproj/project.pbxproj
@@ -567,7 +567,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Chatwoot/Chatwoot.entitlements;
-				CURRENT_PROJECT_VERSION = 301;
+				CURRENT_PROJECT_VERSION = 302;
 				DEVELOPMENT_TEAM = L7YLMN4634;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Chatwoot/Info.plist;
@@ -580,7 +580,7 @@
 					"$(SDKROOT)/usr/lib/swift",
 					"$(inherited)",
 				);
-				MARKETING_VERSION = 1.9.26;
+				MARKETING_VERSION = 1.9.27;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -605,7 +605,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Chatwoot/Chatwoot.entitlements;
-				CURRENT_PROJECT_VERSION = 301;
+				CURRENT_PROJECT_VERSION = 302;
 				DEVELOPMENT_TEAM = L7YLMN4634;
 				INFOPLIST_FILE = Chatwoot/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Chatwoot;
@@ -617,7 +617,7 @@
 					"$(SDKROOT)/usr/lib/swift",
 					"$(inherited)",
 				);
-				MARKETING_VERSION = 1.9.26;
+				MARKETING_VERSION = 1.9.27;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/mobile-app",
-  "version": "1.9.26",
+  "version": "1.9.27",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/src/router.js
+++ b/src/router.js
@@ -64,6 +64,23 @@ const App = () => {
         },
       },
     },
+    getStateFromPath: (path, config) => {
+      const conversationIdMatch = path.match(/\/conversations\/(\d+)/);
+      const conversationId = conversationIdMatch ? parseInt(conversationIdMatch[1]) : null;
+      if (!conversationId) {
+        return;
+      }
+      return {
+        routes: [
+          {
+            name: 'ChatScreen',
+            params: {
+              conversationId: conversationId,
+            },
+          },
+        ],
+      };
+    },
     async getInitialURL() {
       // Check if app was opened from a deep link
       const url = await Linking.getInitialURL();


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2168/mobile-support-all-the-conversations-links-in-deeplinking