### PR TITLE
fix: Typing indicator triggered when input is focused

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@chatwoot/react-native-widget": "^0.0.18",
-    "@chatwoot/utils": "^0.0.16",
+    "@chatwoot/utils": "^0.0.21",
     "@gorhom/bottom-sheet": "^4.4.7",
     "@kesha-antonov/react-native-action-cable": "^1.1.4",
     "@react-native-async-storage/async-storage": "^1.19.2",

--- a/src/screens/ChatScreen/components/ReplyBox.js
+++ b/src/screens/ChatScreen/components/ReplyBox.js
@@ -138,6 +138,7 @@ const ReplyBox = ({ conversationId, inboxId, conversationDetails, enableReplyBut
   const messageVariables = () => {
     const variables = getMessageVariables({
       conversation: conversationDetails,
+      contact: conversationDetails?.meta?.sender,
     });
     return variables;
   };

--- a/src/screens/ChatScreen/components/ReplyBox.js
+++ b/src/screens/ChatScreen/components/ReplyBox.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { useTheme } from '@react-navigation/native';
 import {
   View,
@@ -31,6 +31,7 @@ import {
   getMessageVariables,
   getUndefinedVariablesInMessage,
   replaceVariablesInMessage,
+  createTypingIndicator,
 } from '@chatwoot/utils';
 
 const propTypes = {
@@ -41,6 +42,7 @@ const propTypes = {
 };
 
 const isAndroid = Platform.OS === 'android';
+const TYPING_INDICATOR_IDLE_TIME = 4000;
 
 // eslint-disable-next-line react/prop-types
 const DismissKeyboard = ({ children }) => (
@@ -70,8 +72,30 @@ const ReplyBox = ({ conversationId, inboxId, conversationDetails, enableReplyBut
     }
   }, [dispatch, inboxId]);
 
+  const dispatchTypingStatus = useCallback(
+    status => {
+      dispatch(conversationActions.toggleTypingStatus({ conversationId, typingStatus: status }));
+    },
+    [dispatch, conversationId],
+  );
+
+  const typingIndicator = useMemo(
+    () =>
+      createTypingIndicator(
+        () => dispatchTypingStatus('on'),
+        () => dispatchTypingStatus('off'),
+        TYPING_INDICATOR_IDLE_TIME,
+      ),
+    [dispatchTypingStatus],
+  );
+
+  const startTyping = useCallback(() => {
+    typingIndicator.start();
+  }, [typingIndicator]);
+
   const onNewMessageChange = text => {
     setMessage(text);
+    startTyping();
     if (text.charAt(0) === '/') {
       const query = text.substring(1) ? text.substring(1).toLowerCase() : ' ';
       setCannedResponseSearchKey(query);
@@ -79,6 +103,15 @@ const ReplyBox = ({ conversationId, inboxId, conversationDetails, enableReplyBut
       setCannedResponseSearchKey('');
     }
   };
+
+  const onBlur = useCallback(() => {
+    typingIndicator.stop();
+  }, [typingIndicator]);
+
+  useEffect(() => {
+    return () => typingIndicator.stop();
+  }, [typingIndicator]);
+
   const onCCMailChange = mail => {
     setCCEmails(mail);
   };
@@ -100,13 +133,6 @@ const ReplyBox = ({ conversationId, inboxId, conversationDetails, enableReplyBut
 
   const inputBorderColor = () => {
     isAnEmailChannelAndNotInPrivateNote() ? { borderTopWidth: 0 } : { borderTopWidth: 1 };
-  };
-
-  const onBlur = () => {
-    dispatch(conversationActions.toggleTypingStatus({ conversationId, typingStatus: 'off' }));
-  };
-  const onFocus = () => {
-    dispatch(conversationActions.toggleTypingStatus({ conversationId, typingStatus: 'on' }));
   };
 
   const messageVariables = () => {
@@ -320,7 +346,6 @@ const ReplyBox = ({ conversationId, inboxId, conversationDetails, enableReplyBut
                   : `${i18n.t('CONVERSATION.TYPE_MESSAGE')}`
               }
               onBlur={onBlur}
-              onFocus={onFocus}
               returnKeyType="done"
             />
           </DismissKeyboard>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1233,10 +1233,10 @@
   dependencies:
     react-native-modal "^13.0.1"
 
-"@chatwoot/utils@^0.0.16":
-  version "0.0.16"
-  resolved "https://registry.yarnpkg.com/@chatwoot/utils/-/utils-0.0.16.tgz#84a0ade7f0377a3c7a95b2e5fa3c3b3d7d045339"
-  integrity sha512-PcWEJ+LeJlDkjOOCHyi7wLaaBsPpedDh1jBblkqOYnt8PvKHSttq/Fusi6u6EcxPhIw1umgq5A/k8sWozmZ4iQ==
+"@chatwoot/utils@^0.0.21":
+  version "0.0.21"
+  resolved "https://registry.yarnpkg.com/@chatwoot/utils/-/utils-0.0.21.tgz#f9116daac0514a8a8fa6ce594efff10062222be0"
+  integrity sha512-eUDJ1K5x1rFlBywRctU3hXXiJ1U0EZiklowNl/YJOh1/BWDns4It3DWrQmAcjvsNbEUNWMfY+ShJmjdeei71Cw==
   dependencies:
     date-fns "^2.29.1"
 


### PR DESCRIPTION
# Pull Request Template

## Description 

This PR utilizes the typing status functionality from the utils. The `typing on` status is triggered only when typing begins, and the `typing off` status is activated after 4 seconds of inactivity or when the user stops typing and the input field loses focus (on input blur or going back).

Fixes https://linear.app/chatwoot/issue/CW-2904/typing-indicator-ui-issue-for-mobile-app

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Loom video**
https://www.loom.com/share/d6b153f7935142d5a8fb8ae06535f376?sid=02f0c9e9-abb1-49e2-8ea3-940c36a9fa9e


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested in both Android and iOS platform
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
