### PR TITLE
feat: Add copy button for email and number

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -169,7 +169,8 @@
     "OPERATING_SYSTEM": "Operating System",
     "INITIATED_AT": "Initiated at",
     "INITIATED_FROM": "Initiated from",
-    "IP_ADDRESS": "IP Address"
+    "IP_ADDRESS": "IP Address",
+    "CLIPBOARD_SUCCESS": "Copied to clipboard"
   },
   "CONVERSATION_PARTICIPANTS": {
     "TITLE": "Conversation participants",

--- a/src/screens/ConversationDetails/components/ContactDetails.js
+++ b/src/screens/ConversationDetails/components/ContactDetails.js
@@ -1,10 +1,13 @@
 import React, { useMemo } from 'react';
-import { StyleSheet } from 'react-native';
+import i18n from 'i18n';
+import { StyleSheet, View } from 'react-native';
 import { useTheme } from '@react-navigation/native';
 import PropTypes from 'prop-types';
 import { Icon, Text, Pressable } from 'components';
+import Clipboard from '@react-native-clipboard/clipboard';
 
 import { openNumber } from 'src/helpers/UrlHelper';
+import { showToast } from 'helpers/ToastHelper';
 
 const createStyles = theme => {
   const { spacing } = theme;
@@ -15,8 +18,9 @@ const createStyles = theme => {
       alignItems: 'center',
       marginTop: spacing.smaller,
       marginBottom: spacing.micro,
+      gap: spacing.micro,
     },
-    detailText: {
+    copyButton: {
       marginLeft: spacing.micro,
     },
   });
@@ -33,6 +37,11 @@ const ContactDetails = ({ type, value, iconName }) => {
   const { colors } = theme;
   const styles = useMemo(() => createStyles(theme), [theme]);
 
+  // Avoid rendering if the value is empty or whitespace (Case: identifier)
+  if (!value || value === ' ') {
+    return null;
+  }
+
   const onClickOpen = () => {
     if (type === 'phoneNumber') {
       openNumber({ phoneNumber: value });
@@ -40,13 +49,27 @@ const ContactDetails = ({ type, value, iconName }) => {
       return;
     }
   };
+
+  const showCopyButton = type === 'phoneNumber' || type === 'email';
+
+  const onClickCopy = () => {
+    Clipboard.setString(value);
+    showToast({ message: i18n.t('CONVERSATION_DETAILS.CLIPBOARD_SUCCESS') });
+  };
   return (
-    <Pressable style={styles.detailsContainer} onPress={() => onClickOpen()}>
+    <View style={styles.detailsContainer}>
       <Icon icon={iconName} color={colors.primaryColor} size={14} />
-      <Text sm color={colors.textDark} style={styles.detailText}>
-        {value}
-      </Text>
-    </Pressable>
+      <Pressable onPress={() => onClickOpen()}>
+        <Text sm color={colors.textDark}>
+          {value}
+        </Text>
+      </Pressable>
+      {showCopyButton && (
+        <Pressable style={styles.copyButton} onPress={() => onClickCopy()}>
+          <Icon icon="copy-outline" color={colors.text} size={14} />
+        </Pressable>
+      )}
+    </View>
   );
 };
 


### PR DESCRIPTION
# Pull Request Template

## Description 

This PR adds the ability to copy the email and phone number from the conversation details.

Fixes https://linear.app/chatwoot/issue/CW-3333/add-copy-button

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

**Screenrecording**

https://github.com/chatwoot/chatwoot-mobile-app/assets/64252451/b943c9ba-b808-4d3d-9b52-4372dd7add45




## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested in both Android and iOS platform
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
