### PR TITLE
chore: Upgrade zeego packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@react-native-community/netinfo": "^11.3.2",
     "@react-native-firebase/app": "^21.0.0",
     "@react-native-firebase/messaging": "^21.0.0",
+    "@react-native-menu/menu": "^1.2.0",
     "@react-navigation/bottom-tabs": "^6.6.1",
     "@react-navigation/native": "^6.1.18",
     "@react-navigation/native-stack": "^6.10.1",
@@ -80,6 +81,8 @@
     "react-native-file-viewer": "^2.1.5",
     "react-native-gesture-handler": "^2.17.1",
     "react-native-image-picker": "^7.1.2",
+    "react-native-ios-context-menu": "^3.1.0",
+    "react-native-ios-utilities": "^5.1.0",
     "react-native-keyboard-controller": "^1.13.4",
     "react-native-markdown-display": "^7.0.0-alpha.2",
     "react-native-pager-view": "^6.2.1",
@@ -100,7 +103,7 @@
     "tailwindcss": "^3.4.12",
     "twrnc": "^4.5.1",
     "use-deep-compare-effect": "^1.8.1",
-    "zeego": "^1.10.0"
+    "zeego": "^2.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@react-native-firebase/messaging':
         specifier: ^21.0.0
         version: 21.0.0(@react-native-firebase/app@21.0.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0)))(expo@51.0.37(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7)))(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(expo@51.0.37(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7)))
+      '@react-native-menu/menu':
+        specifier: ^1.2.0
+        version: 1.2.0(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
       '@react-navigation/bottom-tabs':
         specifier: ^6.6.1
         version: 6.6.1(@react-navigation/native@6.1.18(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.11.0(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native-screens@3.34.0(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
@@ -164,6 +167,12 @@ importers:
       react-native-image-picker:
         specifier: ^7.1.2
         version: 7.1.2(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
+      react-native-ios-context-menu:
+        specifier: ^3.1.0
+        version: 3.1.0(react-native-ios-utilities@5.1.0(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
+      react-native-ios-utilities:
+        specifier: ^5.1.0
+        version: 5.1.0(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
       react-native-keyboard-controller:
         specifier: ^1.13.4
         version: 1.14.3(react-native-reanimated@3.15.4(@babel/core@7.25.7)(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
@@ -225,8 +234,8 @@ importers:
         specifier: ^1.8.1
         version: 1.8.1(react@18.2.0)
       zeego:
-        specifier: ^1.10.0
-        version: 1.10.0(@react-native-menu/menu@1.1.6(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react-native-ios-context-menu@2.5.2(expo@51.0.37(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7)))(react-native-ios-utilities@4.5.1(expo@51.0.37(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7)))(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
+        specifier: ^2.0.3
+        version: 2.0.4(@react-native-menu/menu@1.2.0(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react-native-ios-context-menu@3.1.0(react-native-ios-utilities@5.1.0(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@babel/core':
         specifier: ^7.20.0
@@ -2150,8 +2159,8 @@ packages:
       expo:
         optional: true
 
-  '@react-native-menu/menu@1.1.6':
-    resolution: {integrity: sha512-KRPBqa9jmYDFoacUxw8z1ucpbvmdlPuRO8tsFt2jM8JMC2s+YQwTtISG73PeqH9KD7BV+8igD/nizPfcipOmhQ==}
+  '@react-native-menu/menu@1.2.0':
+    resolution: {integrity: sha512-trRWIrVpDQPnTTxdOLnx2lF0sfnO0ofZaXiGWepzPCr2T2NswQLB1zmpTy4eO9w9wABESAOdF3In6oMo6mJrIg==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -5830,18 +5839,16 @@ packages:
       react: '*'
       react-native: '*'
 
-  react-native-ios-context-menu@2.5.2:
-    resolution: {integrity: sha512-DlG/4uTaNqq2Gnz2bN2seLPyvZTptQ6UhftImvcVdsQyNqG9R9Bnmh4cD/JZVAyK732cyFgtFIE/EUXo0AstoQ==}
+  react-native-ios-context-menu@3.1.0:
+    resolution: {integrity: sha512-qdPSXMKUp5lDgmZeUPdv5sgBFhkFrIqma+zsnqJQYOvekb6Qs17yJy1Rqhrj0bJrwuduHzZX0aYbaA8whxqpDw==}
     peerDependencies:
-      expo: '*'
       react: '*'
       react-native: '*'
-      react-native-ios-utilities: '>= 4.4.x <=4.5.x'
+      react-native-ios-utilities: '*'
 
-  react-native-ios-utilities@4.5.1:
-    resolution: {integrity: sha512-A8PMME94PXv1Ui5WrTBcz69zVPAshvvIuYxJUkE09Nl1Ca6/ds6wCxys/A+KkNPtgeVCN7diBR/M5BTVnJbKDQ==}
+  react-native-ios-utilities@5.1.0:
+    resolution: {integrity: sha512-25QqdENHyMdlT48Xkr5hEke1yfGbbGk6Wy+hM5jFPlfXDmGgF/QicGN4SiQXIbSLWuMqFHVVoiJ2vkQ8ARP5mg==}
     peerDependencies:
-      expo: '*'
       react: '*'
       react-native: '*'
 
@@ -7139,13 +7146,13 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zeego@1.10.0:
-    resolution: {integrity: sha512-HrPv7DfyAubkp/NOy+Uwcb1rcS3DtkZEtNQFiSDduBoZt2EDf89+1N+aweACj1UnmGOOu+kk56WYiV9sliMpng==}
+  zeego@2.0.4:
+    resolution: {integrity: sha512-mkKfUJmgcSGCTqWXW7ccqap8d8z6guQoLF5/mWlH17Jckd0BaFLVZ74y/uWvfBGaC9OawYVt/1MchPnQ8ieSxg==}
     peerDependencies:
       '@react-native-menu/menu': '*'
       react: '*'
       react-native: '*'
-      react-native-ios-context-menu: ^2.3.2
+      react-native-ios-context-menu: ~2.5.1
 
   zod-validation-error@2.1.0:
     resolution: {integrity: sha512-VJh93e2wb4c3tWtGgTa0OF/dTt/zoPCPzXq4V11ZjxmEAFaPi/Zss1xIZdEB5RD8GD00U0/iVXgqkF77RV7pdQ==}
@@ -9669,7 +9676,7 @@ snapshots:
     optionalDependencies:
       expo: 51.0.37(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))
 
-  '@react-native-menu/menu@1.1.6(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)':
+  '@react-native-menu/menu@1.2.0(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)':
     dependencies:
       react: 18.2.0
       react-native: 0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0)
@@ -14213,17 +14220,15 @@ snapshots:
       react: 18.2.0
       react-native: 0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0)
 
-  react-native-ios-context-menu@2.5.2(expo@51.0.37(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7)))(react-native-ios-utilities@4.5.1(expo@51.0.37(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7)))(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0):
+  react-native-ios-context-menu@3.1.0(react-native-ios-utilities@5.1.0(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0):
     dependencies:
       '@dominicstop/ts-event-emitter': 1.1.0
-      expo: 51.0.37(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))
       react: 18.2.0
       react-native: 0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0)
-      react-native-ios-utilities: 4.5.1(expo@51.0.37(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7)))(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
+      react-native-ios-utilities: 5.1.0(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
 
-  react-native-ios-utilities@4.5.1(expo@51.0.37(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7)))(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0):
+  react-native-ios-utilities@5.1.0(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0):
     dependencies:
-      expo: 51.0.37(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))
       react: 18.2.0
       react-native: 0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0)
 
@@ -15631,14 +15636,14 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zeego@1.10.0(@react-native-menu/menu@1.1.6(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react-native-ios-context-menu@2.5.2(expo@51.0.37(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7)))(react-native-ios-utilities@4.5.1(expo@51.0.37(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7)))(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0):
+  zeego@2.0.4(@react-native-menu/menu@1.2.0(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react-native-ios-context-menu@3.1.0(react-native-ios-utilities@5.1.0(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0):
     dependencies:
       '@radix-ui/react-context-menu': 2.2.2(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-dropdown-menu': 2.1.2(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@react-native-menu/menu': 1.1.6(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
+      '@react-native-menu/menu': 1.2.0(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-native: 0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0)
-      react-native-ios-context-menu: 2.5.2(expo@51.0.37(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7)))(react-native-ios-utilities@4.5.1(expo@51.0.37(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7)))(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
+      react-native-ios-context-menu: 3.1.0(react-native-ios-utilities@5.1.0(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
       sf-symbols-typescript: 2.0.0
     transitivePeerDependencies:
       - '@types/react'

--- a/src/screens/chat-screen/components/chat-header/ChatHeader.tsx
+++ b/src/screens/chat-screen/components/chat-header/ChatHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ImageSourcePropType, Keyboard, Pressable } from 'react-native';
+import { ImageSourcePropType, Keyboard, Platform, Pressable } from 'react-native';
 import { BottomSheetModal, useBottomSheetSpringConfigs } from '@gorhom/bottom-sheet';
 import Animated from 'react-native-reanimated';
 
@@ -80,7 +80,10 @@ export const ChatHeader = ({
           </Pressable>
         </Animated.View>
 
-        <Animated.View style={tailwind.style('flex flex-row flex-1 justify-end')}>
+        <Animated.View
+          style={tailwind.style(
+            `flex flex-row flex-1 justify-end ${Platform.OS === 'ios' ? 'gap-4' : ''}`,
+          )}>
           <Animated.View style={tailwind.style('flex flex-row items-center gap-4')}>
             {hasSla && (
               <Pressable hitSlop={8} onPress={toggleSlaEventsSheet}>

--- a/src/screens/chat-screen/components/chat-header/DropdownMenu.tsx
+++ b/src/screens/chat-screen/components/chat-header/DropdownMenu.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, PropsWithChildren, useCallback, useRef } from 'react';
-import { Platform, Pressable } from 'react-native';
+import { Platform, Pressable, View } from 'react-native';
 import Animated, { interpolate, useAnimatedStyle } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
@@ -17,6 +17,35 @@ export type DashboardList = {
   url?: string;
   onSelect: (url: string | undefined, title: string | undefined) => void;
 };
+
+// Create custom trigger component to maintain consistent behavior
+const DropdownMenuTrigger = DropdownMenu.create<React.ComponentProps<typeof DropdownMenu.Trigger>>(
+  props => (
+    <DropdownMenu.Trigger {...props} asChild>
+      <View aria-role="button" style={tailwind.style('ml-4')}>
+        {props.children}
+      </View>
+    </DropdownMenu.Trigger>
+  ),
+  'Trigger',
+);
+
+// Create custom item component to maintain View wrapper and styles
+const DropdownMenuItem = DropdownMenu.create<React.ComponentProps<typeof DropdownMenu.Item>>(
+  props => (
+    <DropdownMenu.Item {...props}>
+      <View style={tailwind.style('flex flex-row items-center')}>
+        <DropdownMenu.ItemTitle
+          style={tailwind.style(
+            'text-base text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px] capitalize',
+          )}>
+          {props.children}
+        </DropdownMenu.ItemTitle>
+      </View>
+    </DropdownMenu.Item>
+  ),
+  'Item',
+);
 
 // eslint-disable-next-line react/display-name
 const DropdownMenuBottomSheetBackdrop = forwardRef<
@@ -136,21 +165,19 @@ export const ChatDropdownMenu = (props: PropsWithChildren<ChatDropdownMenuProps>
       </React.Fragment>
     );
   }
+
   return (
     <DropdownMenu.Root>
-      <DropdownMenu.Trigger style={tailwind.style('ml-4')}>
-        {/* @ts-ignore */}
-        {children}
-      </DropdownMenu.Trigger>
+      <DropdownMenuTrigger>{children}</DropdownMenuTrigger>
       <DropdownMenu.Content>
         {dropdownMenuList.map(menuOption => {
           const handleOnOptionSelect = () => {
             menuOption.onSelect(menuOption.url, menuOption.title);
           };
           return (
-            <DropdownMenu.Item onSelect={handleOnOptionSelect} key={menuOption.title}>
-              <DropdownMenu.ItemTitle>{menuOption.title}</DropdownMenu.ItemTitle>
-            </DropdownMenu.Item>
+            <DropdownMenuItem onSelect={handleOnOptionSelect} key={menuOption.title}>
+              {menuOption.title}
+            </DropdownMenuItem>
           );
         })}
       </DropdownMenu.Content>

--- a/src/screens/chat-screen/components/chat-header/DropdownMenu.tsx
+++ b/src/screens/chat-screen/components/chat-header/DropdownMenu.tsx
@@ -18,7 +18,6 @@ export type DashboardList = {
   onSelect: (url: string | undefined, title: string | undefined) => void;
 };
 
-// Create custom trigger component to maintain consistent behavior
 const DropdownMenuTrigger = DropdownMenu.create<React.ComponentProps<typeof DropdownMenu.Trigger>>(
   props => (
     <DropdownMenu.Trigger {...props} asChild>
@@ -30,7 +29,6 @@ const DropdownMenuTrigger = DropdownMenu.create<React.ComponentProps<typeof Drop
   'Trigger',
 );
 
-// Create custom item component to maintain View wrapper and styles
 const DropdownMenuItem = DropdownMenu.create<React.ComponentProps<typeof DropdownMenu.Item>>(
   props => (
     <DropdownMenu.Item {...props}>

--- a/src/screens/chat-screen/components/message-menu/MessageMenu.tsx
+++ b/src/screens/chat-screen/components/message-menu/MessageMenu.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, PropsWithChildren, useCallback, useRef } from 'react';
-import { Platform, Pressable } from 'react-native';
+import { Platform, Pressable, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { interpolate, runOnJS, useAnimatedStyle } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -23,6 +23,28 @@ export type MenuOption = {
 type MessageMenuProps = {
   menuOptions: MenuOption[];
 };
+
+// Create custom trigger component
+const ContextMenuTrigger = ContextMenu.create<React.ComponentProps<typeof ContextMenu.Trigger>>(
+  props => (
+    <ContextMenu.Trigger {...props} asChild>
+      <View aria-role="button">{props.children}</View>
+    </ContextMenu.Trigger>
+  ),
+  'Trigger',
+);
+
+// Create custom item component
+const ContextMenuItem = ContextMenu.create<React.ComponentProps<typeof ContextMenu.Item>>(
+  props => (
+    <ContextMenu.Item {...props}>
+      <View style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
+        {props.children}
+      </View>
+    </ContextMenu.Item>
+  ),
+  'Item',
+);
 
 // eslint-disable-next-line react/display-name
 const ContextMenuBottomSheetBackdrop = forwardRef<
@@ -131,27 +153,20 @@ export const MessageMenu = (props: PropsWithChildren<MessageMenuProps>) => {
       </React.Fragment>
     );
   }
+
   return menuOptions?.length > 0 ? (
     <ContextMenu.Root>
-      {/*
-          The below children is a React Element but is not as per the types
-          of the library so ignoring the issue
-      */}
-      <ContextMenu.Trigger action="longPress">
-        {/* @ts-ignore */}
-        {children}
-      </ContextMenu.Trigger>
-
+      <ContextMenuTrigger>{children}</ContextMenuTrigger>
       <ContextMenu.Content>
         {menuOptions?.map(option => {
           return (
-            <ContextMenu.Item
-              onSelect={option.handleOnPressMenuOption}
+            <ContextMenuItem
               key={option.title}
+              onSelect={option.handleOnPressMenuOption}
               destructive={option.destructive}>
-              <ContextMenu.ItemTitle>{option.title}</ContextMenu.ItemTitle>
               {option.icon}
-            </ContextMenu.Item>
+              <ContextMenu.ItemTitle>{option.title}</ContextMenu.ItemTitle>
+            </ContextMenuItem>
           );
         })}
       </ContextMenu.Content>

--- a/src/screens/chat-screen/components/message-menu/MessageMenu.tsx
+++ b/src/screens/chat-screen/components/message-menu/MessageMenu.tsx
@@ -24,7 +24,6 @@ type MessageMenuProps = {
   menuOptions: MenuOption[];
 };
 
-// Create custom trigger component
 const ContextMenuTrigger = ContextMenu.create<React.ComponentProps<typeof ContextMenu.Trigger>>(
   props => (
     <ContextMenu.Trigger {...props} asChild>
@@ -34,7 +33,6 @@ const ContextMenuTrigger = ContextMenu.create<React.ComponentProps<typeof Contex
   'Trigger',
 );
 
-// Create custom item component
 const ContextMenuItem = ContextMenu.create<React.ComponentProps<typeof ContextMenu.Item>>(
   props => (
     <ContextMenu.Item {...props}>


### PR DESCRIPTION
We encountered errors while uploading a new version to the App Store, even though we hadn't made any changes to the code. The issue has been reported [here](https://github.com/expo/expo/issues/33994), but it kept recurring. I first tried updating the `react-native-ios-utilities` through peer dependencies, which didn't resolve the problem. However, upgrading the [`Zeego`](https://github.com/nandorojo/zeego) package to its latest major version fixed the issue. This upgrade required adding some new dependencies.