### PR TITLE
chore: Contact/User availability store update improvements

### DIFF
--- a/src/store/auth/authSlice.ts
+++ b/src/store/auth/authSlice.ts
@@ -33,19 +33,43 @@ export const authSlice = createSlice({
       state.user = null;
       state.accessToken = null;
       state.headers = null;
-      state.error = null;
     },
     setCurrentUserAvailability(state, action) {
       const { users } = action.payload;
       const userId = state.user?.id;
-      if (userId && users[userId] && state.user?.accounts) {
-        const availability = users[userId];
-        state.user.accounts = state.user.accounts.map(account => {
-          if (account.id === state.user?.account_id) {
-            return { ...account, availability, availability_status: availability };
+
+      // Only proceed if we have a valid user and matching availability data
+      if (!userId || !users[userId] || !state.user?.accounts) {
+        return;
+      }
+
+      const newAvailability = users[userId];
+      let needsUpdate = false;
+
+      // Update the accounts array with the new availability
+      const updatedAccounts = state.user.accounts.map(account => {
+        if (account.id === state.user?.account_id) {
+          // Since this event triggers frequently, we should verify if a state update is necessary to prevent unnecessary component re-renders.
+          const shouldUpdateAccount =
+            !account.availability || // availability doesn't exist
+            account.availability !== newAvailability || // availability doesn't match
+            account.availability_status !== newAvailability; // availability_status doesn't match
+          if (shouldUpdateAccount) {
+            needsUpdate = true;
+            return {
+              ...account,
+              availability: newAvailability,
+              availability_status: newAvailability,
+            };
           }
-          return account;
-        });
+        }
+        return account;
+      });
+      if (needsUpdate) {
+        state.user = {
+          ...state.user,
+          accounts: updatedAccounts,
+        };
       }
     },
     setAccount: (state, action) => {

--- a/src/store/auth/authSlice.ts
+++ b/src/store/auth/authSlice.ts
@@ -33,6 +33,7 @@ export const authSlice = createSlice({
       state.user = null;
       state.accessToken = null;
       state.headers = null;
+      state.error = null;
     },
     setCurrentUserAvailability(state, action) {
       const { users } = action.payload;

--- a/src/store/auth/specs/authMockData.ts
+++ b/src/store/auth/specs/authMockData.ts
@@ -3,6 +3,7 @@ export const mockUser = {
   email: 'test@example.com',
   name: 'Test User',
   account_id: 123,
+  type: 'user',
 };
 
 export const mockHeaders = {

--- a/src/store/auth/specs/authSlice.spec.ts
+++ b/src/store/auth/specs/authSlice.spec.ts
@@ -240,6 +240,62 @@ describe('Auth Slice', () => {
         const nextState = authReducer(state, action);
         expect(nextState).toEqual(state);
       });
+
+      it('should not update when the update is not needed', () => {
+        const state = {
+          ...initialState,
+          user: {
+            ...mockUser,
+            id: 1,
+            account_id: 123,
+            accounts: [
+              {
+                id: 123,
+                active_at: '',
+                auto_offline: false,
+                availability: 'online',
+                availability_status: 'online' as AvailabilityStatus,
+                custom_role: '',
+                custom_role_id: '',
+                name: 'Account 1',
+                permissions: [],
+                role: 'agent' as UserRole,
+                status: 'active',
+              },
+              {
+                id: 456,
+                active_at: '',
+                auto_offline: false,
+                availability: 'online',
+                availability_status: 'online' as AvailabilityStatus,
+                custom_role: '',
+                custom_role_id: '',
+                name: 'Account 2',
+                permissions: [],
+                role: 'agent' as UserRole,
+                status: 'active',
+              },
+            ],
+            pubsub_token: '',
+            avatar_url: '',
+            available_name: '',
+            role: 'agent' as UserRole,
+            availability: 'online',
+            availability_status: 'online' as AvailabilityStatus,
+            identifier_hash: '',
+            thumbnail: '',
+            type: 'user',
+          },
+        };
+
+        const action = {
+          type: 'auth/setCurrentUserAvailability',
+          payload: { users: { '123': 'busy' } },
+        };
+
+        const nextState = authReducer(state, action);
+        expect(nextState).toEqual(state);
+      });
     });
   });
 

--- a/src/store/auth/specs/authSlice.spec.ts
+++ b/src/store/auth/specs/authSlice.spec.ts
@@ -1,7 +1,6 @@
 import authReducer, { logout, resetAuth, setAccount } from '@/store/auth/authSlice';
 import { mockUser } from './authMockData';
 import { AuthState } from '@/store/auth/authSlice';
-
 import { authActions } from '@/store/auth/authActions';
 import { AvailabilityStatus, UserRole } from '@/types';
 
@@ -37,58 +36,80 @@ describe('Auth Slice', () => {
     headers: null,
     error: null,
   };
+
+  const loggedInState = {
+    ...initialState,
+    user: {
+      ...mockUser,
+      accounts: [],
+      pubsub_token: 'token',
+      avatar_url: 'url',
+      available_name: 'name',
+      role: 'agent' as UserRole,
+      identifier_hash: 'hash',
+      availability: 'online',
+      thumbnail: 'thumbnail',
+      availability_status: 'online' as AvailabilityStatus,
+      type: 'user',
+    },
+    accessToken: 'token',
+    headers: { 'access-token': 'token', uid: 'uid', client: 'client' },
+  };
+
+  const userWithAccounts = {
+    ...mockUser,
+    id: 1,
+    account_id: 123,
+    accounts: [
+      {
+        id: 123,
+        active_at: '',
+        auto_offline: false,
+        availability: 'online',
+        availability_status: 'online' as AvailabilityStatus,
+        custom_role: '',
+        custom_role_id: '',
+        name: 'Account 1',
+        permissions: [],
+        role: 'agent' as UserRole,
+        status: 'active',
+      },
+      {
+        id: 456,
+        active_at: '',
+        auto_offline: false,
+        availability: 'online',
+        availability_status: 'online' as AvailabilityStatus,
+        custom_role: '',
+        custom_role_id: '',
+        name: 'Account 2',
+        permissions: [],
+        role: 'agent' as UserRole,
+        status: 'active',
+      },
+    ],
+    pubsub_token: '',
+    avatar_url: '',
+    available_name: '',
+    role: 'agent' as UserRole,
+    availability: 'online',
+    availability_status: 'online' as AvailabilityStatus,
+    identifier_hash: '',
+    thumbnail: '',
+    type: 'user',
+  };
+
   it('should handle initial state', () => {
     expect(authReducer(undefined, { type: 'unknown' })).toEqual(initialState);
   });
 
-  describe('reducers', () => {
+  describe('basic reducers', () => {
     it('should handle logout', () => {
-      const state = {
-        ...initialState,
-        user: {
-          ...mockUser,
-          accounts: [],
-          pubsub_token: 'token',
-          avatar_url: 'url',
-          available_name: 'name',
-          role: 'agent' as UserRole,
-          identifier_hash: 'hash',
-          availability: 'online',
-          thumbnail: 'thumbnail',
-          availability_status: 'online' as AvailabilityStatus,
-          type: 'user',
-        },
-        accessToken: 'token',
-        headers: { 'access-token': 'token', uid: 'uid', client: 'client' },
-      };
-      expect(() => authReducer(state, logout())).not.toThrow();
+      expect(() => authReducer(loggedInState, logout())).not.toThrow();
     });
 
     it('should handle resetAuth', () => {
-      const state = {
-        ...initialState,
-        user: {
-          ...mockUser,
-          accounts: [],
-          pubsub_token: 'token',
-          avatar_url: 'url',
-          available_name: 'name',
-          role: 'agent' as UserRole,
-          identifier_hash: 'hash',
-          availability: 'online',
-          thumbnail: 'thumbnail',
-          availability_status: 'online' as AvailabilityStatus,
-          type: 'user',
-        },
-        accessToken: 'token',
-        headers: { 'access-token': 'token', uid: 'uid', client: 'client' },
-        uiFlags: {
-          isLoggingIn: false,
-          isResettingPassword: false,
-        },
-        error: null,
-      };
-      expect(authReducer(state, resetAuth())).toEqual(initialState);
+      expect(authReducer(loggedInState, resetAuth())).toEqual(initialState);
     });
 
     it('should handle setAccount', () => {
@@ -97,236 +118,102 @@ describe('Auth Slice', () => {
         user: {
           ...mockUser,
           accounts: [],
-          pubsub_token: '',
-          avatar_url: '',
-          available_name: '',
           role: 'agent' as UserRole,
+          availability_status: 'online' as AvailabilityStatus,
+          pubsub_token: 'token',
+          avatar_url: 'url',
+          available_name: 'name',
           identifier_hash: 'hash',
           availability: 'online',
           thumbnail: 'thumbnail',
-          availability_status: 'online' as AvailabilityStatus,
           type: 'user',
         },
       };
       expect(authReducer(state, setAccount(123))).toEqual(state);
     });
+  });
 
-    describe('setCurrentUserAvailability', () => {
-      it('should update user availability when user exists and has matching account', () => {
-        const state = {
-          ...initialState,
-          user: {
-            ...mockUser,
-            id: 1,
-            account_id: 123,
-            accounts: [
-              {
-                id: 123,
-                active_at: '',
-                auto_offline: false,
-                availability: 'online',
-                availability_status: 'online' as AvailabilityStatus,
-                custom_role: '',
-                custom_role_id: '',
-                name: 'Account 1',
-                permissions: [],
-                role: 'agent' as UserRole,
-                status: 'active',
-              },
-              {
-                id: 456,
-                active_at: '',
-                auto_offline: false,
-                availability: 'online',
-                availability_status: 'online' as AvailabilityStatus,
-                custom_role: '',
-                custom_role_id: '',
-                name: 'Account 2',
-                permissions: [],
-                role: 'agent' as UserRole,
-                status: 'active',
-              },
-            ],
-            pubsub_token: '',
-            avatar_url: '',
-            available_name: '',
-            role: 'agent' as UserRole,
-            availability: 'online',
-            availability_status: 'online' as AvailabilityStatus,
-            identifier_hash: '',
-            thumbnail: '',
-            type: 'user',
+  describe('setCurrentUserAvailability', () => {
+    it('should update availability for matching user and account', () => {
+      const state = {
+        ...initialState,
+        user: userWithAccounts,
+      };
+
+      const action = {
+        type: 'auth/setCurrentUserAvailability',
+        payload: {
+          users: {
+            '1': 'busy',
           },
-        };
+        },
+      };
 
-        const action = {
-          type: 'auth/setCurrentUserAvailability',
-          payload: {
-            users: {
-              '1': 'busy',
-            },
+      const nextState = authReducer(state, action);
+      expect(nextState.user?.accounts[0].availability).toBe('busy');
+      expect(nextState.user?.accounts[0].availability_status).toBe('busy');
+      expect(nextState.user?.accounts[1].availability).toBe('online');
+    });
+
+    it('should not update for non-matching user ID', () => {
+      const state = {
+        ...initialState,
+        user: { ...userWithAccounts, id: 2 },
+      };
+
+      const action = {
+        type: 'auth/setCurrentUserAvailability',
+        payload: {
+          users: {
+            '1': 'busy',
           },
-        };
+        },
+      };
 
-        const nextState = authReducer(state, action);
-        expect(nextState.user?.accounts[0].availability).toBe('busy');
-        expect(nextState.user?.accounts[0].availability_status).toBe('busy');
-        expect(nextState.user?.accounts[1].availability).toBe('online');
-        expect(nextState.user?.accounts[1].availability_status).toBe('online');
-      });
+      expect(authReducer(state, action)).toEqual(state);
+    });
 
-      it('should not update user availability when user id does not match', () => {
-        const state = {
-          ...initialState,
-          user: {
-            ...mockUser,
-            id: 2,
-            account_id: 123,
-            accounts: [
-              {
-                id: 123,
-                active_at: '',
-                auto_offline: false,
-                availability: 'online',
-                availability_status: 'online' as AvailabilityStatus,
-                custom_role: '',
-                custom_role_id: '',
-                name: 'Account 1',
-                permissions: [],
-                role: 'agent' as UserRole,
-                status: 'active',
-              },
-            ],
-            pubsub_token: '',
-            avatar_url: '',
-            available_name: '',
-            role: 'agent' as UserRole,
-            availability: 'online',
-            availability_status: 'online' as AvailabilityStatus,
-            identifier_hash: '',
-            thumbnail: '',
-            type: 'user',
-          },
-        };
+    it('should not update when user is null', () => {
+      const state = { ...initialState, user: null };
+      const action = {
+        type: 'auth/setCurrentUserAvailability',
+        payload: { users: { '1': 'busy' } },
+      };
 
-        const action = {
-          type: 'auth/setCurrentUserAvailability',
-          payload: {
-            users: {
-              '1': 'busy',
-            },
-          },
-        };
-
-        const nextState = authReducer(state, action);
-        expect(nextState).toEqual(state);
-      });
-
-      it('should not update when user is null', () => {
-        const state = {
-          ...initialState,
-          user: null,
-        };
-
-        const action = {
-          type: 'auth/setCurrentUserAvailability',
-          payload: {
-            users: {
-              '1': 'busy',
-            },
-          },
-        };
-
-        const nextState = authReducer(state, action);
-        expect(nextState).toEqual(state);
-      });
-
-      it('should not update when the update is not needed', () => {
-        const state = {
-          ...initialState,
-          user: {
-            ...mockUser,
-            id: 1,
-            account_id: 123,
-            accounts: [
-              {
-                id: 123,
-                active_at: '',
-                auto_offline: false,
-                availability: 'online',
-                availability_status: 'online' as AvailabilityStatus,
-                custom_role: '',
-                custom_role_id: '',
-                name: 'Account 1',
-                permissions: [],
-                role: 'agent' as UserRole,
-                status: 'active',
-              },
-              {
-                id: 456,
-                active_at: '',
-                auto_offline: false,
-                availability: 'online',
-                availability_status: 'online' as AvailabilityStatus,
-                custom_role: '',
-                custom_role_id: '',
-                name: 'Account 2',
-                permissions: [],
-                role: 'agent' as UserRole,
-                status: 'active',
-              },
-            ],
-            pubsub_token: '',
-            avatar_url: '',
-            available_name: '',
-            role: 'agent' as UserRole,
-            availability: 'online',
-            availability_status: 'online' as AvailabilityStatus,
-            identifier_hash: '',
-            thumbnail: '',
-            type: 'user',
-          },
-        };
-
-        const action = {
-          type: 'auth/setCurrentUserAvailability',
-          payload: { users: { '123': 'busy' } },
-        };
-
-        const nextState = authReducer(state, action);
-        expect(nextState).toEqual(state);
-      });
+      expect(authReducer(state, action)).toEqual(state);
     });
   });
 
-  describe('auth extra reducers', () => {
-    it('should set isLoggingIn to true when login is pending', () => {
+  describe('auth async actions', () => {
+    it('should set isLoggingIn flag when login is pending', () => {
       const action = { type: authActions.login.pending.type };
       const state = authReducer(initialState, action);
       expect(state.uiFlags.isLoggingIn).toBe(true);
       expect(state.error).toBeNull();
     });
 
-    it('should handle login.fulfilled', () => {
+    it('should handle successful login', () => {
       const payload = {
         user: mockUser,
         headers: { 'access-token': 'token', uid: 'uid', client: 'client' },
       };
       const action = { type: authActions.login.fulfilled.type, payload };
       const state = authReducer(initialState, action);
+
       expect(state.user).toEqual(mockUser);
       expect(state.headers).toEqual(payload.headers);
       expect(state.uiFlags.isLoggingIn).toBe(false);
       expect(state.error).toBeNull();
     });
 
-    it('should handle login.rejected', () => {
+    it('should handle login failure', () => {
       const error = 'Invalid credentials';
       const action = {
         type: authActions.login.rejected.type,
         payload: { errors: [error] },
       };
       const state = authReducer(initialState, action);
+
       expect(state.uiFlags.isLoggingIn).toBe(false);
       expect(state.error).toBe(error);
     });

--- a/src/store/contact/contactSlice.ts
+++ b/src/store/contact/contactSlice.ts
@@ -34,16 +34,11 @@ const contactSlice = createSlice({
     },
     updateContactsPresence: (state, action) => {
       const { contacts } = action.payload;
-      const { selectById } = contactAdapter.getSelectors();
-      // Check each incoming contact and update their availability status in the store. Only update the status if the contact already exists in the store.
-      Object.keys(contacts).forEach(contactId => {
-        const numericId = Number(contactId);
-        const entity = selectById(state, numericId);
-        if (entity) {
-          contactAdapter.updateOne(state, {
-            id: numericId,
-            changes: { availabilityStatus: contacts[contactId] || 'offline' },
-          });
+      Object.values(state.entities as Record<string, Contact>).forEach(entity => {
+        const contactId = entity.id;
+        const newAvailability = contacts[contactId] || 'offline';
+        if (entity.availabilityStatus !== newAvailability) {
+          entity.availabilityStatus = newAvailability;
         }
       });
     },

--- a/src/store/contact/specs/contactMockData.ts
+++ b/src/store/contact/specs/contactMockData.ts
@@ -12,6 +12,7 @@ export const contact: Contact = {
   additionalAttributes: {},
   lastActivityAt: 1732159896,
   createdAt: 1728033836,
+  type: 'user',
 };
 
 export const conversation = {

--- a/src/store/contact/specs/contactSlice.spec.ts
+++ b/src/store/contact/specs/contactSlice.spec.ts
@@ -1,3 +1,4 @@
+import { AvailabilityStatus } from '@/types/common';
 import reducer, {
   addContacts,
   addContact,
@@ -48,12 +49,17 @@ describe('contact reducer', () => {
     expect(state.entities[contact.id]?.availabilityStatus).toEqual('offline');
   });
 
-  it('should not update the contacts presence if the contact is not found', () => {
+  it('should not update the contacts presence if the contact availability status is the same', () => {
     const initialState = {
       ids: [1],
-      entities: { 1: contact },
+      entities: {
+        1: {
+          ...contact,
+          availabilityStatus: 'online' as AvailabilityStatus,
+        },
+      },
     };
-    const action = updateContactsPresence({ contacts: { 2: 'offline' } });
+    const action = updateContactsPresence({ contacts: { 1: 'online' } });
     const state = reducer(initialState, action);
     expect(state.entities[contact.id]?.availabilityStatus).toEqual('online');
   });

--- a/src/store/contact/specs/contactSlice.spec.ts
+++ b/src/store/contact/specs/contactSlice.spec.ts
@@ -8,7 +8,7 @@ import { contact } from './contactMockData';
 
 describe('contact reducer', () => {
   it('should return the initial state', () => {
-    expect(reducer(undefined, { type: undefined })).toEqual({
+    expect(reducer(undefined, { type: 'unknown' })).toEqual({
       ids: [],
       entities: {},
     });
@@ -46,5 +46,15 @@ describe('contact reducer', () => {
     const action = updateContactsPresence({ contacts: { 1: 'offline' } });
     const state = reducer(initialState, action);
     expect(state.entities[contact.id]?.availabilityStatus).toEqual('offline');
+  });
+
+  it('should not update the contacts presence if the contact is not found', () => {
+    const initialState = {
+      ids: [1],
+      entities: { 1: contact },
+    };
+    const action = updateContactsPresence({ contacts: { 2: 'offline' } });
+    const state = reducer(initialState, action);
+    expect(state.entities[contact.id]?.availabilityStatus).toEqual('online');
   });
 });


### PR DESCRIPTION
Contact and agent presence updates occur frequently in the app, which can trigger unnecessary re-rendering of multiple components. This PR implements optimizations to minimize these re-renders by updating state only when necessary.

**Set Current User Availability**

Previously, the user account status was updated regardless of availability changes. Now, the account updates only when there is an actual change in status.

**Contact User Availability Status**

Similarly, contact availability updates now occur only when there is an actual status change. Comprehensive test specs have been added to cover all scenarios.