### PR TITLE
fix: Notifications do not move to the top when added via action cable events

### DIFF
--- a/src/screens/inbox/InboxScreen.tsx
+++ b/src/screens/inbox/InboxScreen.tsx
@@ -3,6 +3,7 @@ import { ActivityIndicator, RefreshControl, StatusBar } from 'react-native';
 import Animated, {
   LinearTransition,
   runOnJS,
+  SharedValue,
   useAnimatedScrollHandler,
 } from 'react-native-reanimated';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -15,9 +16,9 @@ import { tailwind } from '@/theme';
 import { useAppDispatch, useAppSelector } from '@/hooks';
 import { notificationActions } from '@/store/notification/notificationAction';
 import {
-  selectAllNotifications,
   selectIsAllNotificationsFetched,
   selectIsLoadingNotifications,
+  getFilteredNotifications,
 } from '@/store/notification/notificationSelectors';
 import { InboxHeader, InboxItemContainer } from './components';
 import { useInboxListStateContext } from '@/context';
@@ -36,8 +37,6 @@ type FlashListRenderItemType = {
 };
 
 const InboxList = () => {
-  const notifications = useAppSelector(selectAllNotifications);
-
   const [pageNumber, setPageNumber] = useState(1);
 
   const [isFlashListReady, setFlashListReady] = useState(false);
@@ -46,6 +45,8 @@ const InboxList = () => {
   const isNotificationsLoading = useAppSelector(selectIsLoadingNotifications);
   const isAllNotificationsFetched = useAppSelector(selectIsAllNotificationsFetched);
   const sortOrder = useAppSelector(selectSortOrder);
+
+  const notifications = useAppSelector(state => getFilteredNotifications(state, sortOrder));
 
   const previousSortOrder = useRef(sortOrder);
 
@@ -59,7 +60,8 @@ const InboxList = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sortOrder]);
 
-  const ListFooterComponent = () => {
+  // eslint-disable-next-line react/display-name
+  const ListFooterComponent = React.memo(() => {
     if (isAllNotificationsFetched) return null;
     return (
       <Animated.View
@@ -70,7 +72,7 @@ const InboxList = () => {
         {isAllNotificationsFetched ? null : <ActivityIndicator size="small" />}
       </Animated.View>
     );
-  };
+  });
 
   useEffect(() => {
     clearAndFetchNotifications(sortOrder);
@@ -118,7 +120,13 @@ const InboxList = () => {
   const { openedRowIndex } = useInboxListStateContext();
 
   const handleRender = useCallback(({ item, index }: FlashListRenderItemType) => {
-    return <InboxItemContainer item={item} index={index} openedRowIndex={openedRowIndex} />;
+    return (
+      <InboxItemContainer
+        item={item}
+        index={index}
+        openedRowIndex={openedRowIndex as SharedValue<number | null>}
+      />
+    );
   }, []);
 
   const scrollHandler = useAnimatedScrollHandler({
@@ -169,12 +177,14 @@ const InboxList = () => {
 
 const InboxScreen = () => {
   const dispatch = useAppDispatch();
-  const markAllAsRead = async () => {
+
+  // Memoize the markAllAsRead callback
+  const markAllAsRead = useCallback(async () => {
     await dispatch(notificationActions.markAllAsRead());
     showToast({
       message: i18n.t('NOTIFICATION.ALERTS.MARK_ALL_READ'),
     });
-  };
+  }, [dispatch]);
 
   return (
     <SafeAreaView edges={['top']} style={tailwind.style('flex-1 bg-white')}>

--- a/src/store/notification/notificationSelectors.ts
+++ b/src/store/notification/notificationSelectors.ts
@@ -1,7 +1,8 @@
-import { createSelector } from '@reduxjs/toolkit';
+import { createDraftSafeSelector, createSelector } from '@reduxjs/toolkit';
 import type { RootState } from '@/store';
 import { notificationsAdapter } from './notificationSlice';
-
+import { SortTypes } from './notificationFilterSlice';
+import { Notification } from '@/types/Notification';
 export const selectNotificationsState = (state: RootState) => state.notifications;
 
 export const {
@@ -40,4 +41,19 @@ export const selectNotificationsCurrentPage = createSelector(
 export const selectIsAllNotificationsFetched = createSelector(
   selectNotificationsState,
   state => state.uiFlags.isAllNotificationsFetched,
+);
+
+export const getFilteredNotifications = createDraftSafeSelector(
+  [selectAllNotifications, (_, sortOrder: SortTypes) => sortOrder],
+  (notifications, sortOrder) => {
+    type SortComparator = {
+      asc: (a: Notification, b: Notification) => number;
+      desc: (a: Notification, b: Notification) => number;
+    };
+    const comparator: SortComparator = {
+      asc: (a, b) => a.createdAt - b.createdAt,
+      desc: (a, b) => b.createdAt - a.createdAt,
+    };
+    return notifications.sort(comparator[sortOrder]);
+  },
 );

--- a/src/store/notification/notificationSlice.ts
+++ b/src/store/notification/notificationSlice.ts
@@ -80,7 +80,7 @@ const notificationsSlice = createSlice({
           } else {
             notificationsAdapter.upsertMany(state, payload);
           }
-          state.uiFlags.isAllNotificationsFetched = payload.length < 15;
+          state.uiFlags.isAllNotificationsFetched = payload.length <= 15;
         },
       )
       .addCase(notificationActions.fetchNotifications.rejected, (state, action) => {


### PR DESCRIPTION
This PR fixes an issue where notifications weren't moving to the top when added through action cable events. The solution implements frontend sorting to address this problem.