### PR TITLE
chore: Adjust card labels to fit container width

### DIFF
--- a/src/screens/conversations/components/conversation-item/LabelIndicator.tsx
+++ b/src/screens/conversations/components/conversation-item/LabelIndicator.tsx
@@ -1,55 +1,80 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Text } from 'react-native';
-
 import { tailwind } from '@/theme';
 import { AnimatedNativeView, NativeView } from '@/components-next/native-components';
 import { Label } from '@/types';
 
-type LabelTextProps = {
-  labelText: string;
-  labelColor: string;
-};
+interface LabelState {
+  result: Label[]; // List of labels that fit within the available width
+  totalWidth: number; // Total width of the labels added so far
+}
 
-const LabelText = (props: LabelTextProps) => {
-  const { labelText, labelColor } = props;
+interface LayoutChangeEvent {
+  nativeEvent: {
+    layout: {
+      width: number; // Width of the component
+      height: number; // Height of the component
+    };
+  };
+}
+
+const LabelText = ({ labelText, labelColor }: { labelText: string; labelColor: string }) => (
+  <NativeView style={tailwind.style('flex-row items-center py-[3px]')}>
+    <NativeView style={tailwind.style('h-[5px] w-[5px] rounded-full', `bg-[${labelColor}]`)} />
+    <Text
+      style={tailwind.style(
+        'pl-1 text-sm font-inter-420-20 leading-[16px] tracking-[0.32px] text-gray-700',
+      )}>
+      {labelText}
+    </Text>
+  </NativeView>
+);
+
+export const LabelIndicator = ({ labels, allLabels }: { labels: string[]; allLabels: Label[] }) => {
+  // Store the container width
+  const [containerWidth, setContainerWidth] = useState<number | null>(null);
+
+  const activeLabels = React.useMemo(() => {
+    if (!allLabels || !labels || containerWidth === null) return [];
+
+    const availableWidth = containerWidth;
+
+    const { result } = allLabels.reduce<LabelState>(
+      (state, label) => {
+        if (!labels.includes(label.title)) return state; // Skip labels not in `labels`
+
+        const labelWidth = label.title.length * 8 + 12; // Approximate width of the label
+
+        if (state.totalWidth + labelWidth <= availableWidth) {
+          // Add the label to the result and update the total width
+          return {
+            result: [...state.result, label],
+            totalWidth: state.totalWidth + labelWidth,
+          };
+        }
+        // Stop adding labels if the total width exceeds the available space
+        return state;
+      },
+      { result: [], totalWidth: 0 }, // Start with an empty list and zero width
+    );
+
+    return result; // Return the list of active labels
+  }, [allLabels, labels, containerWidth]);
+
   return (
-    <NativeView style={tailwind.style('flex flex-row items-center py-[3px]')}>
-      <NativeView style={tailwind.style('h-[5px] w-[5px] rounded-full', `bg-[${labelColor}]`)} />
-      <NativeView style={tailwind.style('pl-1')}>
-        <Text
-          style={tailwind.style(
-            'text-sm font-inter-420-20 leading-[16px] tracking-[0.32px] text-gray-700',
-          )}>
-          {labelText}
-        </Text>
-      </NativeView>
-    </NativeView>
-  );
-};
-type LabelIndicatorProps = {
-  labels: string[];
-  allLabels: Label[];
-};
-export const LabelIndicator = (props: LabelIndicatorProps) => {
-  const { labels, allLabels } = props;
-
-  const activeLabels =
-    allLabels && labels
-      ? allLabels.filter(label => {
-          return labels?.find(l => l === label.title);
-        })
-      : [];
-
-  return (
-    <AnimatedNativeView style={tailwind.style('flex-1')}>
-      <NativeView style={tailwind.style('flex flex-row items-center overflow-hidden')}>
-        {activeLabels.map((label, i) => {
-          return (
-            <NativeView key={i} style={tailwind.style(i !== 0 ? 'pl-1.5' : '')}>
-              <LabelText labelText={label.title} labelColor={label.color} />
-            </NativeView>
-          );
-        })}
+    <AnimatedNativeView
+      style={tailwind.style('flex-1')}
+      onLayout={(event: LayoutChangeEvent) => {
+        // Measure the container width when it is rendered
+        const { width } = event.nativeEvent.layout;
+        setContainerWidth(width);
+      }}>
+      <NativeView style={tailwind.style('flex-row items-center overflow-hidden')}>
+        {activeLabels.map((label, index) => (
+          <NativeView key={index} style={tailwind.style(index !== 0 ? 'pl-1.5' : '')}>
+            <LabelText labelText={label.title} labelColor={label.color} />
+          </NativeView>
+        ))}
       </NativeView>
     </AnimatedNativeView>
   );


### PR DESCRIPTION
# Pull Request Template

## Description 

This PR dynamically adjusts conversation card labels based on the container’s width. It uses the `onLayout` event to measure the container’s width and calculate how many labels fit. Labels exceeding the container width are excluded to prevent overflow.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Screenshots**

**Before**
<img width="422" alt="image" src="https://github.com/user-attachments/assets/7b60721f-c44e-4976-a133-5d987ecc49fd" />


**After**
<img width="422" alt="image" src="https://github.com/user-attachments/assets/ee98e6ca-aa06-4acf-aad5-78bf097ff0f2" />
<img width="422" alt="image" src="https://github.com/user-attachments/assets/7903e0fb-66fd-4368-bb4f-53e6c274c7b5" />




## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested in both Android and iOS platform
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
