### PR TITLE
fix: Dashboard app data injection

### DIFF
--- a/src/screens/dashboard/DashboardScreen.tsx
+++ b/src/screens/dashboard/DashboardScreen.tsx
@@ -13,7 +13,7 @@ import { User } from '@/types/User';
 const DashboardScreen = () => {
   const route = useRoute();
   const navigation = useNavigation();
-  const webviewRef = useRef(null);
+  const webviewRef = useRef<WebView>(null);
 
   const { conversation, currentUser, title, url } = route.params as {
     conversation: Conversation;
@@ -71,10 +71,12 @@ const DashboardScreen = () => {
         originWhitelist={['*']}
         source={{ uri: url }}
         startInLoadingState={true}
-        injectedJavaScript={INJECTED_JAVASCRIPT}
+        javaScriptEnabled={true}
+        onLoadEnd={() => {
+          webviewRef.current?.injectJavaScript(INJECTED_JAVASCRIPT);
+        }}
         onMessage={event => {
           if (event?.nativeEvent?.data === 'chatwoot-dashboard-app:fetch-info') {
-            // @ts-expect-error
             webviewRef.current?.injectJavaScript(INJECTED_JAVASCRIPT);
           }
         }}


### PR DESCRIPTION
# Fixes Dashboard App data injection

## Description 
Fixes Dashboard App data injection by enabling javascript in WebView and send the data after the webpage loading ends.

Fixes #906 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

You can host index.html from https://github.com/JaideepGuntupalli/chatwoot-sample-dashboard-app/tree/main locally and proxy using ngrok and add as dashboard app to any one of the account. You can open the same account on chatwoot mobile app and try to load this dashboard app. There is no json being sent earlier, but after this change we actually get the json


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have tested in both Android and iOS platform
- [x] My changes generate no new warnings
