### PR TITLE
fix: Audio recorder error handling

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -4,7 +4,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
   return {
     name: 'Chatwoot',
     slug: process.env.EXPO_PUBLIC_APP_SLUG || 'chatwoot-mobile',
-    version: '4.0.20',
+    version: '4.1.2',
     orientation: 'portrait',
     icon: './assets/icon.png',
     userInterfaceStyle: 'light',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/mobile-app",
-  "version": "4.0.20",
+  "version": "4.1.2",
   "scripts": {
     "start": "expo start --dev-client",
     "start:production": "expo start --no-dev --minify",

--- a/src/screens/chat-screen/components/audio-recorder/AudioRecorder.tsx
+++ b/src/screens/chat-screen/components/audio-recorder/AudioRecorder.tsx
@@ -120,7 +120,6 @@ export const AudioRecorder = ({
           }
         })
         .catch(error => {
-          .catch(error => {
           Alert.alert(
             'Error preparing audio file',
             error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
Removed a redundant '.catch' statement in AudioRecorder.tsx to clean up error handling.
