### PR TITLE
fix(android): remove READ_MEDIA_IMAGES permission to comply with Play Console review

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -37,13 +37,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     android: {
       adaptiveIcon: { foregroundImage: './assets/adaptive-icon.png', backgroundColor: '#ffffff' },
       package: 'com.chatwoot.app',
-      permissions: [
-        'android.permission.CAMERA',
-        'android.permission.READ_EXTERNAL_STORAGE',
-        'android.permission.WRITE_EXTERNAL_STORAGE',
-        'android.permission.RECORD_AUDIO',
-        'android.permission.READ_MEDIA_IMAGES',
-      ],
+      permissions: ['android.permission.CAMERA', 'android.permission.RECORD_AUDIO'],
       // Please use the relative path to the google-services.json file
       googleServicesFile: process.env.EXPO_PUBLIC_ANDROID_GOOGLE_SERVICES_FILE,
       intentFilters: [

--- a/src/screens/chat-screen/components/message-components/CommandOptionsMenu.tsx
+++ b/src/screens/chat-screen/components/message-components/CommandOptionsMenu.tsx
@@ -16,95 +16,39 @@ import { MAXIMUM_FILE_UPLOAD_SIZE } from '@/constants';
 import i18n from '@/i18n';
 import { showToast } from '@/utils/toastUtils';
 import { findFileSize } from '@/utils/fileUtils';
-import { getApiLevel } from 'react-native-device-info';
 
 export const handleOpenPhotosLibrary = async dispatch => {
-  if (Platform.OS === 'ios') {
-    request(
-      Platform.OS === 'ios'
-        ? PERMISSIONS.IOS.PHOTO_LIBRARY
-        : PERMISSIONS.ANDROID.READ_EXTERNAL_STORAGE,
-    ).then(async result => {
-      if (RESULTS.BLOCKED === result) {
-        Alert.alert(
-          'Permission Denied',
-          'The permission to access the photo library has been denied and cannot be requested again. Please enable it in your device settings if you wish to access photos from your library.',
-          [
-            {
-              text: 'Cancel',
-              style: 'cancel',
-            },
-            {
-              text: 'Open Settings',
-              onPress: () => {
-                // Open app settings
-                Linking.openSettings();
-              },
-            },
-          ],
-          { cancelable: false },
-        );
-      }
-      if (result === RESULTS.GRANTED || result === RESULTS.LIMITED) {
-        const pickedAssets = await launchImageLibrary({
-          quality: 1,
-          selectionLimit: 4,
-          mediaType: 'mixed',
-          presentationStyle: 'formSheet',
-        });
-        if (pickedAssets.didCancel) {
-        } else if (pickedAssets.errorCode) {
-        } else {
-          if (pickedAssets.assets && pickedAssets.assets?.length > 0) {
-            validateFileAndSetAttachments(dispatch, pickedAssets.assets[0]);
-          }
-        }
-      }
-    });
+  const pickedAssets = await launchImageLibrary({
+    quality: 1,
+    selectionLimit: 4,
+    mediaType: 'mixed',
+    presentationStyle: 'formSheet',
+  });
+  if (pickedAssets.didCancel) {
+  } else if (pickedAssets.errorCode) {
+    Alert.alert(
+      'Permission Denied',
+      pickedAssets.errorMessage ||
+        'The permission to access the photo library has been denied and cannot be requested again. Please enable it in your device settings if you wish to access photos from your library.',
+      [
+        {
+          text: 'Cancel',
+          style: 'cancel',
+        },
+        {
+          text: 'Open Settings',
+          onPress: () => {
+            // Open app settings
+            Linking.openSettings();
+          },
+        },
+      ],
+      { cancelable: false },
+    );
   } else {
-    const apiLevel = await getApiLevel();
-    const permission =
-      apiLevel >= 33
-        ? PERMISSIONS.ANDROID.READ_MEDIA_IMAGES
-        : PERMISSIONS.ANDROID.READ_EXTERNAL_STORAGE;
-
-    request(permission).then(async result => {
-      if (RESULTS.BLOCKED === result) {
-        Alert.alert(
-          'Permission Denied',
-          'The permission to access the photo library has been denied and cannot be requested again. Please enable it in your device settings if you wish to access photos from your library.',
-          [
-            {
-              text: 'Cancel',
-              style: 'cancel',
-            },
-            {
-              text: 'Open Settings',
-              onPress: () => {
-                // Open app settings
-                Linking.openSettings();
-              },
-            },
-          ],
-          { cancelable: false },
-        );
-      }
-      if (result === RESULTS.GRANTED) {
-        const pickedAssets = await launchImageLibrary({
-          quality: 1,
-          selectionLimit: 4,
-          mediaType: 'mixed',
-          presentationStyle: 'formSheet',
-        });
-        if (pickedAssets.didCancel) {
-        } else if (pickedAssets.errorCode) {
-        } else {
-          if (pickedAssets.assets && pickedAssets.assets?.length > 0) {
-            validateFileAndSetAttachments(dispatch, pickedAssets.assets[0]);
-          }
-        }
-      }
-    });
+    if (pickedAssets.assets && pickedAssets.assets?.length > 0) {
+      validateFileAndSetAttachments(dispatch, pickedAssets.assets[0]);
+    }
   }
 };
 


### PR DESCRIPTION
## Description 

Removed the android.permission.READ_MEDIA_IMAGES permission from app.config.ts as it was causing rejection during Play Console review. According to the latest [react-native-image-picker](https://github.com/react-native-image-picker/react-native-image-picker) documentation, Android does not require this explicit permission, so it has been safely removed.

Fixes: Play Console rejection regarding unnecessary permission usage. 
https://support.google.com/googleplay/android-developer/answer/14115180?hl=en

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Verified that image picker still works correctly on Android and IOS without requesting the READ_MEDIA_IMAGES/PHOTO_LIBRARY permission respectively.
Refer more details [react-native-image-picker](https://github.com/react-native-image-picker/react-native-image-picker)
- Tested functionality on both Android and iOS devices.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested in both Android and iOS platform
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
