### PR TITLE
fix: Resolve file attachment caching conflicts for identical filenames

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -4,7 +4,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
   return {
     name: 'Chatwoot',
     slug: process.env.EXPO_PUBLIC_APP_SLUG || 'chatwoot-mobile',
-    version: '4.3.0',
+    version: '4.3.10',
     orientation: 'portrait',
     icon: './assets/icon.png',
     userInterfaceStyle: 'light',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/mobile-app",
-  "version": "4.3.0",
+  "version": "4.3.10",
   "scripts": {
     "start": "expo start --dev-client",
     "start:production": "expo start --no-dev --minify",

--- a/src/screens/chat-screen/components/message-components/FileBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/FileBubble.tsx
@@ -9,6 +9,22 @@ import { tailwind } from '@/theme';
 import { Icon } from '@/components-next/common';
 import { Spinner } from '@/components-next/spinner';
 import { MESSAGE_VARIANTS } from '@/constants';
+
+const generateUniqueFileName = (url: string, originalFileName: string) => {
+  const hash = url.split('').reduce((acc, char) => {
+    const charCode = char.charCodeAt(0);
+    return ((acc << 5) - acc + charCode) | 0;
+  }, 0);
+  const uniqueHash = Math.abs(hash).toString(36);
+  const fileExtension = originalFileName.includes('.')
+    ? originalFileName.substring(originalFileName.lastIndexOf('.'))
+    : '';
+  const baseFileName = originalFileName.includes('.')
+    ? originalFileName.substring(0, originalFileName.lastIndexOf('.'))
+    : originalFileName;
+  return `${baseFileName}_${uniqueHash}${fileExtension}`;
+};
+
 type FilePreviewProps = Pick<FileBubbleProps, 'fileSrc'> & {
   isComposed?: boolean;
   variant: string;
@@ -20,7 +36,8 @@ export const FileBubblePreview = (props: FilePreviewProps) => {
 
   const [fileDownload, setFileDownload] = useState(false);
   const fileName = fileSrc.split('/')[fileSrc.split('/').length - 1];
-  const localFilePath = dirs.DocumentDir + `/${fileName}`;
+  const uniqueFileName = generateUniqueFileName(fileSrc, fileName);
+  const localFilePath = dirs.DocumentDir + `/${uniqueFileName}`;
 
   const previewFile = () => {
     try {


### PR DESCRIPTION
This PR fixes the file caching issue where attachments with identical filenames would display the same content