### PR TITLE
feat(mobile): Add inline remove button for conversation participants

### DIFF
--- a/src/screens/chat-screen/conversation-actions/ConversationActions.tsx
+++ b/src/screens/chat-screen/conversation-actions/ConversationActions.tsx
@@ -147,6 +147,7 @@ export const ConversationActions = () => {
           <AddParticipantList
             conversationParticipants={conversationParticipants}
             onAddParticipant={onAddParticipant}
+            conversationId={conversationId}
           />
         </Animated.View>
         <Animated.View style={tailwind.style('pt-10')}>

--- a/src/screens/chat-screen/conversation-actions/components/AddParticipantList.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/AddParticipantList.tsx
@@ -2,19 +2,25 @@ import React from 'react';
 import { Platform, Pressable, StyleSheet } from 'react-native';
 import Animated from 'react-native-reanimated';
 
-import { AddParticipant, Overflow } from '@/svg-icons';
+import { AddParticipant, CloseIcon, Overflow } from '@/svg-icons';
 import { tailwind } from '@/theme';
 import { Avatar, Icon } from '@/components-next';
 import { Agent } from '@/types';
 import i18n from '@/i18n';
+import { useAppDispatch } from '@/hooks';
+import { conversationParticipantActions } from '@/store/conversation-participant/conversationParticipantActions';
+import { showToast } from '@/utils/toastUtils';
+import AnalyticsHelper from '@/utils/analyticsUtils';
+import { CONVERSATION_EVENTS } from '@/constants/analyticsEvents';
 
 type ListItemProps = {
   listItem: Agent;
   index: number;
+  onRemove: (agent: Agent) => void;
 };
 
 const ListItem = (props: ListItemProps) => {
-  const { listItem, index } = props;
+  const { listItem, index, onRemove } = props;
   return (
     <Pressable
       key={index}
@@ -26,13 +32,16 @@ const ListItem = (props: ListItemProps) => {
           <Avatar src={{ uri: listItem.thumbnail || undefined }} size="lg" />
         </Animated.View>
         <Animated.View
-          style={tailwind.style('flex-1 py-[11px] ml-2 border-b-[1px] border-b-blackA-A3')}>
+          style={tailwind.style('flex-1 py-[11px] ml-2 border-b-[1px] border-b-blackA-A3 flex-row justify-between items-center pr-3')}>
           <Animated.Text
             style={tailwind.style(
               'text-base font-inter-420-20 leading-[22px] tracking-[0.16px] text-gray-950',
             )}>
             {listItem.name}
           </Animated.Text>
+          <Pressable hitSlop={16} onPress={() => onRemove(listItem)}>
+            <Icon icon={<CloseIcon />} size={20} />
+          </Pressable>
         </Animated.View>
       </Animated.View>
     </Pressable>
@@ -63,10 +72,20 @@ const ParticipantOverflowCell = ({ count }: { count: number }) => {
 type AddParticipantListProps = {
   conversationParticipants: Agent[];
   onAddParticipant: () => void;
+  conversationId: number;
 };
 
 export const AddParticipantList = (props: AddParticipantListProps) => {
-  const { conversationParticipants, onAddParticipant } = props;
+  const { conversationParticipants, onAddParticipant, conversationId } = props;
+  const dispatch = useAppDispatch();
+
+  const handleRemoveParticipant = async (agent: Agent) => {
+    const remainingParticipants = conversationParticipants.filter(p => p.id !== agent.id);
+    const userIds = remainingParticipants.map(p => p.id);
+    await dispatch(conversationParticipantActions.update({ conversationId, userIds }));
+    AnalyticsHelper.track(CONVERSATION_EVENTS.PARTICIPANT_CHANGED);
+    showToast({ message: i18n.t('CONVERSATION.PARTICIPANT_CHANGE') });
+  };
 
   const overflowCount = conversationParticipants?.length;
   return (
@@ -82,7 +101,7 @@ export const AddParticipantList = (props: AddParticipantListProps) => {
       <Animated.View style={[tailwind.style('rounded-[13px] mx-4 bg-white'), styles.listShadow]}>
         {conversationParticipants &&
           conversationParticipants.slice(0, 4).map((listItem, index) => {
-            return <ListItem key={index} {...{ listItem, index }} />;
+            return <ListItem key={index} {...{ listItem, index, onRemove: handleRemoveParticipant }} />;
           })}
         {overflowCount > 4 && <ParticipantOverflowCell count={overflowCount - 4} />}
         <Pressable

--- a/src/screens/chat-screen/conversation-actions/components/AddParticipantList.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/AddParticipantList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import { Platform, Pressable, StyleSheet } from 'react-native';
 import Animated from 'react-native-reanimated';
 
@@ -17,10 +17,11 @@ type ListItemProps = {
   listItem: Agent;
   index: number;
   onRemove: (agent: Agent) => void;
+  removeDisabled: boolean;
 };
 
 const ListItem = (props: ListItemProps) => {
-  const { listItem, index, onRemove } = props;
+  const { listItem, index, onRemove, removeDisabled } = props;
   return (
     <Pressable
       key={index}
@@ -32,14 +33,20 @@ const ListItem = (props: ListItemProps) => {
           <Avatar src={{ uri: listItem.thumbnail || undefined }} size="lg" />
         </Animated.View>
         <Animated.View
-          style={tailwind.style('flex-1 py-[11px] ml-2 border-b-[1px] border-b-blackA-A3 flex-row justify-between items-center pr-3')}>
+          style={tailwind.style(
+            'flex-1 py-[11px] ml-2 border-b-[1px] border-b-blackA-A3 flex-row justify-between items-center pr-3',
+          )}>
           <Animated.Text
             style={tailwind.style(
               'text-base font-inter-420-20 leading-[22px] tracking-[0.16px] text-gray-950',
             )}>
             {listItem.name}
           </Animated.Text>
-          <Pressable hitSlop={16} onPress={() => onRemove(listItem)}>
+          <Pressable
+            hitSlop={16}
+            disabled={removeDisabled}
+            onPress={() => onRemove(listItem)}
+            style={removeDisabled ? tailwind.style('opacity-50') : undefined}>
             <Icon icon={<CloseIcon />} size={20} />
           </Pressable>
         </Animated.View>
@@ -78,13 +85,29 @@ type AddParticipantListProps = {
 export const AddParticipantList = (props: AddParticipantListProps) => {
   const { conversationParticipants, onAddParticipant, conversationId } = props;
   const dispatch = useAppDispatch();
+  const isRemovingParticipantRef = useRef(false);
+  const [isRemovingParticipant, setIsRemovingParticipant] = useState(false);
 
   const handleRemoveParticipant = async (agent: Agent) => {
+    if (isRemovingParticipantRef.current) {
+      return;
+    }
+
+    isRemovingParticipantRef.current = true;
+    setIsRemovingParticipant(true);
+
     const remainingParticipants = conversationParticipants.filter(p => p.id !== agent.id);
     const userIds = remainingParticipants.map(p => p.id);
-    await dispatch(conversationParticipantActions.update({ conversationId, userIds }));
-    AnalyticsHelper.track(CONVERSATION_EVENTS.PARTICIPANT_CHANGED);
-    showToast({ message: i18n.t('CONVERSATION.PARTICIPANT_CHANGE') });
+    try {
+      await dispatch(conversationParticipantActions.update({ conversationId, userIds })).unwrap();
+      AnalyticsHelper.track(CONVERSATION_EVENTS.PARTICIPANT_CHANGED);
+      showToast({ message: i18n.t('CONVERSATION.PARTICIPANT_CHANGE') });
+    } catch {
+      showToast({ message: i18n.t('ERRORS.COMMON_ERROR') });
+    } finally {
+      isRemovingParticipantRef.current = false;
+      setIsRemovingParticipant(false);
+    }
   };
 
   const overflowCount = conversationParticipants?.length;
@@ -101,13 +124,28 @@ export const AddParticipantList = (props: AddParticipantListProps) => {
       <Animated.View style={[tailwind.style('rounded-[13px] mx-4 bg-white'), styles.listShadow]}>
         {conversationParticipants &&
           conversationParticipants.slice(0, 4).map((listItem, index) => {
-            return <ListItem key={index} {...{ listItem, index, onRemove: handleRemoveParticipant }} />;
+            return (
+              <ListItem
+                key={index}
+                {...{
+                  listItem,
+                  index,
+                  onRemove: handleRemoveParticipant,
+                  removeDisabled: isRemovingParticipant,
+                }}
+              />
+            );
           })}
         {overflowCount > 4 && <ParticipantOverflowCell count={overflowCount - 4} />}
         <Pressable
+          disabled={isRemovingParticipant}
           onPress={onAddParticipant}
           style={({ pressed }) => [
-            tailwind.style('rounded-b-[13px]', pressed ? 'bg-blue-100' : ''),
+            tailwind.style(
+              'rounded-b-[13px]',
+              pressed ? 'bg-blue-100' : '',
+              isRemovingParticipant ? 'opacity-50' : '',
+            ),
           ]}>
           <Animated.View style={tailwind.style('flex flex-row items-center ml-3')}>
             <Animated.View style={tailwind.style('p-0.5')}>

--- a/src/screens/chat-screen/conversation-actions/components/UpdateParticipant.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/UpdateParticipant.tsx
@@ -81,16 +81,20 @@ const ParticipantStack = ({
     }
     const userIds = updateAgentList.map(agent => agent.id);
     if (selectedConversation) {
-      await dispatch(
-        conversationParticipantActions.update({
-          conversationId: selectedConversation?.id,
-          userIds,
-        }),
-      );
-      AnalyticsHelper.track(CONVERSATION_EVENTS.PARTICIPANT_CHANGED);
-      showToast({
-        message: i18n.t('CONVERSATION.PARTICIPANT_CHANGE'),
-      });
+      try {
+        await dispatch(
+          conversationParticipantActions.update({
+            conversationId: selectedConversation?.id,
+            userIds,
+          }),
+        ).unwrap();
+        AnalyticsHelper.track(CONVERSATION_EVENTS.PARTICIPANT_CHANGED);
+        showToast({
+          message: i18n.t('CONVERSATION.PARTICIPANT_CHANGE'),
+        });
+      } catch {
+        showToast({ message: i18n.t('ERRORS.COMMON_ERROR') });
+      }
     }
   };
 


### PR DESCRIPTION
## Description

Adds an inline remove button for conversation participants in the conversation actions panel.

This also fixes participant update feedback so success toast and analytics are only emitted after the participant update request succeeds. The same fulfilled-action gating is applied to the existing participant sheet path for consistent behavior. Inline remove buttons and the Add Participant row are disabled while a participant update is in flight, preventing stale participant lists from re-adding a previously removed participant when users tap multiple controls quickly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Rebased on current `develop` (`v4.7.0`).
- Ran focused ESLint on the touched participant components.
- Ran `git diff --check`.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
