### PR TITLE
feat(messages): Add translate message functionality

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -242,6 +242,7 @@
       "TRANSLATE": "Translate"
     },
     "TRANSLATE_MESSAGE_SUCCESS": "Message translated",
+    "TRANSLATE_MESSAGE_ERROR": "Failed to translate message",
     "VIEW_ORIGINAL": "View original",
     "VIEW_TRANSLATED": "View translated",
     "EMAIL_HEADER": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -238,8 +238,12 @@
     "LONG_PRESS_ACTIONS": {
       "COPY": "Copy",
       "REPLY": "Reply",
-      "DELETE_MESSAGE": "Delete message"
+      "DELETE_MESSAGE": "Delete message",
+      "TRANSLATE": "Translate"
     },
+    "TRANSLATE_MESSAGE_SUCCESS": "Message translated",
+    "VIEW_ORIGINAL": "View original",
+    "VIEW_TRANSLATED": "View translated",
     "EMAIL_HEADER": {
       "FROM": "From",
       "TO": "To",

--- a/src/screens/chat-screen/components/message-components/TextBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/TextBubble.tsx
@@ -22,9 +22,14 @@ export const TextBubble = (props: TextBubbleProps) => {
 
   const translations = contentAttributes?.translations;
   const hasTranslations = translations && Object.keys(translations).length > 0;
-  const translationContent = hasTranslations ? translations[Object.keys(translations)[0]] : null;
+  const translationContent = hasTranslations
+    ? Object.values(translations)[0]
+    : null;
 
-  const displayContent = hasTranslations && !showOriginal ? translationContent : content;
+  const displayContent =
+    hasTranslations && !showOriginal && translationContent
+      ? translationContent
+      : content;
 
   const renderTranslationToggle = () => {
     if (!hasTranslations) return null;

--- a/src/screens/chat-screen/components/message-components/TextBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/TextBubble.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Pressable } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { tailwind } from '@/theme';
 import { Message } from '@/types';
 import { MarkdownBubble } from './MarkdownBubble';
 import { EmailMeta } from './EmailMeta';
+import i18n from '@/i18n';
 
 export type TextBubbleProps = {
   item: Message;
@@ -16,6 +18,31 @@ export const TextBubble = (props: TextBubbleProps) => {
 
   const { private: isPrivate, content, contentAttributes, sender } = messageItem;
 
+  const [showOriginal, setShowOriginal] = useState(false);
+
+  const translations = contentAttributes?.translations;
+  const hasTranslations = translations && Object.keys(translations).length > 0;
+  const translationContent = hasTranslations ? translations[Object.keys(translations)[0]] : null;
+
+  const displayContent = hasTranslations && !showOriginal ? translationContent : content;
+
+  const renderTranslationToggle = () => {
+    if (!hasTranslations) return null;
+
+    return (
+      <Pressable onPress={() => setShowOriginal(!showOriginal)}>
+        <Animated.Text
+          style={tailwind.style(
+            'text-xs text-gray-500 mt-1 font-inter-420-20 tracking-[0.32px]',
+          )}>
+          {showOriginal
+            ? i18n.t('CONVERSATION.VIEW_TRANSLATED')
+            : i18n.t('CONVERSATION.VIEW_ORIGINAL')}
+        </Animated.Text>
+      </Pressable>
+    );
+  };
+
   return (
     <React.Fragment>
       {contentAttributes && <EmailMeta {...{ contentAttributes, sender }} />}
@@ -23,11 +50,15 @@ export const TextBubble = (props: TextBubbleProps) => {
         <Animated.View style={tailwind.style('flex flex-row')}>
           <Animated.View style={tailwind.style('w-[3px] bg-amber-700 h-auto rounded-[4px]')} />
           <Animated.View style={tailwind.style('pl-2.5')}>
-            <MarkdownBubble messageContent={content} variant={variant} />
+            <MarkdownBubble messageContent={displayContent} variant={variant} />
+            {renderTranslationToggle()}
           </Animated.View>
         </Animated.View>
       ) : (
-        <MarkdownBubble messageContent={content} variant={variant} />
+        <>
+          <MarkdownBubble messageContent={displayContent} variant={variant} />
+          {renderTranslationToggle()}
+        </>
       )}
     </React.Fragment>
   );

--- a/src/screens/chat-screen/components/message-item/MessageItemContainer.tsx
+++ b/src/screens/chat-screen/components/message-item/MessageItemContainer.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Message } from '@/types';
 import { useAppDispatch, useAppSelector } from '@/hooks';
 import { selectConversationById } from '@/store/conversation/conversationSelectors';
+import { selectLocale } from '@/store/settings/settingsSelectors';
 import { useChatWindowContext } from '@/context';
 // import { setQuoteMessage } from '@/store/conversation/sendMessageSlice';
 import { conversationActions } from '@/store/conversation/conversationActions';
@@ -12,7 +13,7 @@ import { showToast } from '@/utils/toastUtils';
 import i18n from '@/i18n';
 import Clipboard from '@react-native-clipboard/clipboard';
 import { MESSAGE_TYPES } from '@/constants';
-import { CopyIcon, Trash } from '@/svg-icons';
+import { CopyIcon, Trash, TranslateIcon } from '@/svg-icons';
 import { MenuOption } from '../message-menu';
 import { MessageItem } from './MessageItem';
 
@@ -27,6 +28,7 @@ export const MessageItemContainer = (props: MessageItemContainerProps) => {
 
   const hapticSelection = useHaptic();
   const conversation = useAppSelector(state => selectConversationById(state, conversationId));
+  const locale = useAppSelector(selectLocale);
 
   // const handleQuoteReplyAttachment = () => {
   //   dispatch(setQuoteMessage(props.item as Message));
@@ -43,6 +45,18 @@ export const MessageItemContainer = (props: MessageItemContainerProps) => {
   const handleDeleteMessage = async (messageId: number) => {
     await dispatch(conversationActions.deleteMessage({ conversationId, messageId }));
     showToast({ message: i18n.t('CONVERSATION.DELETE_MESSAGE_SUCCESS') });
+  };
+
+  const handleTranslateMessage = async (messageId: number) => {
+    hapticSelection?.();
+    await dispatch(
+      conversationActions.translateMessage({
+        conversationId,
+        messageId,
+        targetLanguage: locale || 'en',
+      }),
+    );
+    showToast({ message: i18n.t('CONVERSATION.TRANSLATE_MESSAGE_SUCCESS') });
   };
 
   // const inboxSupportsReplyTo = (channel: string) => {
@@ -73,6 +87,12 @@ export const MessageItemContainer = (props: MessageItemContainerProps) => {
         title: i18n.t('CONVERSATION.LONG_PRESS_ACTIONS.COPY'),
         icon: <CopyIcon />,
         handleOnPressMenuOption: () => handleCopyMessage(content),
+        destructive: false,
+      });
+      menuOptions.push({
+        title: i18n.t('CONVERSATION.LONG_PRESS_ACTIONS.TRANSLATE'),
+        icon: <TranslateIcon />,
+        handleOnPressMenuOption: () => handleTranslateMessage(message.id),
         destructive: false,
       });
     }

--- a/src/screens/chat-screen/components/message-item/MessageItemContainer.tsx
+++ b/src/screens/chat-screen/components/message-item/MessageItemContainer.tsx
@@ -1,14 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Message } from '@/types';
 import { useAppDispatch, useAppSelector } from '@/hooks';
 import { selectConversationById } from '@/store/conversation/conversationSelectors';
 import { selectLocale } from '@/store/settings/settingsSelectors';
 import { useChatWindowContext } from '@/context';
-// import { setQuoteMessage } from '@/store/conversation/sendMessageSlice';
 import { conversationActions } from '@/store/conversation/conversationActions';
 import { useHaptic } from '@/utils';
-// import { inboxHasFeature, is360DialogWhatsAppChannel, useHaptic } from '@/utils';
-// import { INBOX_FEATURES } from '@/constants';
 import { showToast } from '@/utils/toastUtils';
 import i18n from '@/i18n';
 import Clipboard from '@react-native-clipboard/clipboard';
@@ -29,10 +26,7 @@ export const MessageItemContainer = (props: MessageItemContainerProps) => {
   const hapticSelection = useHaptic();
   const conversation = useAppSelector(state => selectConversationById(state, conversationId));
   const locale = useAppSelector(selectLocale);
-
-  // const handleQuoteReplyAttachment = () => {
-  //   dispatch(setQuoteMessage(props.item as Message));
-  // };
+  const [translatingMessageId, setTranslatingMessageId] = useState<number | null>(null);
 
   const handleCopyMessage = (content: string) => {
     hapticSelection?.();
@@ -49,38 +43,38 @@ export const MessageItemContainer = (props: MessageItemContainerProps) => {
 
   const handleTranslateMessage = async (messageId: number) => {
     hapticSelection?.();
-    await dispatch(
-      conversationActions.translateMessage({
-        conversationId,
-        messageId,
-        targetLanguage: locale || 'en',
-      }),
-    );
-    showToast({ message: i18n.t('CONVERSATION.TRANSLATE_MESSAGE_SUCCESS') });
+    setTranslatingMessageId(messageId);
+    try {
+      await dispatch(
+        conversationActions.translateMessage({
+          conversationId,
+          messageId,
+          targetLanguage: locale || 'en',
+        }),
+      ).unwrap();
+      showToast({ message: i18n.t('CONVERSATION.TRANSLATE_MESSAGE_SUCCESS') });
+    } catch {
+      showToast({ message: i18n.t('CONVERSATION.TRANSLATE_MESSAGE_ERROR') });
+    } finally {
+      setTranslatingMessageId(null);
+    }
   };
-
-  // const inboxSupportsReplyTo = (channel: string) => {
-  //   const incoming = inboxHasFeature(INBOX_FEATURES.REPLY_TO, channel);
-  //   const outgoing =
-  //     inboxHasFeature(INBOX_FEATURES.REPLY_TO_OUTGOING, channel) &&
-  //     !is360DialogWhatsAppChannel(channel);
-
-  //   return { incoming, outgoing };
-  // };
 
   const getMenuOptions = (message: Message): MenuOption[] => {
     const { messageType, content, attachments } = message;
-    // const { private: isPrivate } = message;
     const hasText = !!content;
     const hasAttachments = !!(attachments && attachments.length > 0);
-    // const channel = conversation?.meta?.channel;
-
     const isDeleted = message.contentAttributes?.deleted;
 
     const menuOptions: MenuOption[] = [];
     if (messageType === MESSAGE_TYPES.ACTIVITY || isDeleted) {
       return [];
     }
+
+    const hasTranslations =
+      message.contentAttributes?.translations &&
+      Object.keys(message.contentAttributes.translations).length > 0;
+    const isTranslating = translatingMessageId === message.id;
 
     if (hasText) {
       menuOptions.push({
@@ -89,23 +83,15 @@ export const MessageItemContainer = (props: MessageItemContainerProps) => {
         handleOnPressMenuOption: () => handleCopyMessage(content),
         destructive: false,
       });
-      menuOptions.push({
-        title: i18n.t('CONVERSATION.LONG_PRESS_ACTIONS.TRANSLATE'),
-        icon: <TranslateIcon />,
-        handleOnPressMenuOption: () => handleTranslateMessage(message.id),
-        destructive: false,
-      });
+      if (!hasTranslations && !isTranslating) {
+        menuOptions.push({
+          title: i18n.t('CONVERSATION.LONG_PRESS_ACTIONS.TRANSLATE'),
+          icon: <TranslateIcon />,
+          handleOnPressMenuOption: () => handleTranslateMessage(message.id),
+          destructive: false,
+        });
+      }
     }
-
-    // TODO: Add reply to message when we have the feature
-    // if (!isPrivate && channel && inboxSupportsReplyTo(channel).outgoing) {
-    //   menuOptions.push({
-    //     title: i18n.t('CONVERSATION.LONG_PRESS_ACTIONS.REPLY'),
-    //     icon: null,
-    //     handleOnPressMenuOption: handleQuoteReplyAttachment,
-    //     destructive: false,
-    //   });
-    // }
 
     if (hasAttachments || hasText) {
       menuOptions.push({

--- a/src/store/conversation/conversationActions.ts
+++ b/src/store/conversation/conversationActions.ts
@@ -25,6 +25,7 @@ import type {
   SendMessageAPIResponse,
   SendMessagePayload,
   TogglePriorityPayload,
+  TranslateMessagePayload,
 } from './conversationTypes';
 import { AxiosError } from 'axios';
 import { MESSAGE_STATUS } from '@/constants';
@@ -252,6 +253,20 @@ export const conversationActions = {
     'conversations/togglePriority',
     async (payload, { rejectWithValue }) => {
       return await ConversationService.togglePriority(payload);
+    },
+  ),
+  translateMessage: createAsyncThunk<void, TranslateMessagePayload>(
+    'conversations/translateMessage',
+    async (payload, { rejectWithValue }) => {
+      try {
+        await ConversationService.translateMessage(payload);
+      } catch (error) {
+        const { response } = error as AxiosError<ApiErrorResponse>;
+        if (!response) {
+          throw error;
+        }
+        return rejectWithValue(response.data);
+      }
     },
   ),
 };

--- a/src/store/conversation/conversationService.ts
+++ b/src/store/conversation/conversationService.ts
@@ -29,6 +29,7 @@ import type {
   MarkMessageReadOrUnreadResponse,
   ToggleConversationStatusAPIResponse,
   TogglePriorityPayload,
+  TranslateMessagePayload,
 } from './conversationTypes';
 
 import {
@@ -211,5 +212,12 @@ export class ConversationService {
   static async togglePriority(payload: TogglePriorityPayload): Promise<void> {
     const { conversationId, priority } = payload;
     await apiService.post(`conversations/${conversationId}/toggle_priority`, { priority });
+  }
+
+  static async translateMessage(payload: TranslateMessagePayload): Promise<void> {
+    const { conversationId, messageId, targetLanguage } = payload;
+    await apiService.post(`conversations/${conversationId}/messages/${messageId}/translate`, {
+      target_language: targetLanguage,
+    });
   }
 }

--- a/src/store/conversation/conversationTypes.ts
+++ b/src/store/conversation/conversationTypes.ts
@@ -238,3 +238,9 @@ export interface TogglePriorityPayload {
   conversationId: number;
   priority: ConversationPriority;
 }
+
+export interface TranslateMessagePayload {
+  conversationId: number;
+  messageId: number;
+  targetLanguage: string;
+}

--- a/src/types/Message.ts
+++ b/src/types/Message.ts
@@ -63,6 +63,7 @@ export type MessageContentAttributes = {
   imageType: string;
   contentType: ContentType;
   isUnsupported: boolean;
+  translations?: Record<string, string>;
 };
 
 export interface Message {


### PR DESCRIPTION
## Description

This message translation PR has been superseded by #1044, which was merged into `develop` on March 30, 2026.

#1044 includes the translate menu option, translation API service/action, inline translation toggle, locale-specific translation cache check, and the store update that resolves the automated review concern on this PR.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Verified #1044 is merged into current `develop`.
- Verified current `develop` contains the translation store update in `conversationSlice` and locale-specific translation display/checks.

## Checklist:

- [x] I have performed a self-review of my own code
