### PR TITLE
feat: Add comprehensive dark mode support with system theme detection

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -4,10 +4,10 @@ export default ({ config }: ConfigContext): ExpoConfig => {
   return {
     name: 'Chatwoot',
     slug: process.env.EXPO_PUBLIC_APP_SLUG || 'chatwoot-mobile',
-    version: '4.3.10',
+    version: '4.3.12',
     orientation: 'portrait',
     icon: './assets/icon.png',
-    userInterfaceStyle: 'light',
+    userInterfaceStyle: 'automatic',
     newArchEnabled: false,
     scheme: 'chatwootapp',
     splash: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/mobile-app",
-  "version": "4.3.10",
+  "version": "4.3.12",
   "scripts": {
     "start": "expo start --dev-client",
     "start:production": "expo start --no-dev --minify",
@@ -55,7 +55,7 @@
     "@sentry/react-native": "^6.10.0",
     "@shopify/flash-list": "^1.7.3",
     "@types/lodash": "^4.17.9",
-    "axios": "^1.6.4",
+    "axios": "^1.12.0",
     "camelcase": "^8.0.0",
     "camelcase-keys": "^7.0.2",
     "cross-env": "^7.0.3",
@@ -179,6 +179,14 @@
   "pnpm": {
     "patchedDependencies": {
       "ffmpeg-kit-react-native@6.0.2": "patches/ffmpeg-kit-react-native.patch"
+    },
+    "overrides": {
+      "form-data": "^4.0.4",
+      "node-forge": "^1.3.2",
+      "glob": "^10.5.0",
+      "markdown-it": "^12.3.2",
+      "brace-expansion": "^2.0.2",
+      "js-yaml": "^4.1.1"
     }
   }
 }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,6 +4,7 @@ import { Alert, BackHandler } from 'react-native';
 import { PersistGate } from 'redux-persist/integration/react';
 import { store, persistor } from './store';
 import { AppNavigator } from '@/navigation';
+import { ThemeProvider } from '@/context';
 
 import i18n from '@/i18n';
 
@@ -34,7 +35,9 @@ const Chatwoot = () => {
   return (
     <Provider store={store}>
       <PersistGate loading={null} persistor={persistor}>
-        <AppNavigator />
+        <ThemeProvider>
+          <AppNavigator />
+        </ThemeProvider>
       </PersistGate>
     </Provider>
   );

--- a/src/components-next/action-tabs/ActionTabs.tsx
+++ b/src/components-next/action-tabs/ActionTabs.tsx
@@ -183,7 +183,7 @@ export const ActionTabs = () => {
         ],
         android: [
           tailwind.style(
-            'flex flex-row rounded-[30px] items-center absolute justify-between w-[220px] px-6 py-[15px] bg-white',
+            'flex flex-row rounded-[30px] items-center absolute justify-between w-[220px] px-6 py-[15px] bg-white dark:bg-grayDark-50',
             `h-[${ACTION_TAB_HEIGHT}px] bottom-[${bottom + 8}px] left-[${
               (SCREEN_WIDTH - 220) / 2
             }px]`,
@@ -209,7 +209,6 @@ const styles = StyleSheet.create({
       },
       android: {
         elevation: 4,
-        backgroundColor: 'white',
       },
     }) || {}, // Add fallback empty object
 });

--- a/src/components-next/button/AuthButton.tsx
+++ b/src/components-next/button/AuthButton.tsx
@@ -24,7 +24,7 @@ export const AuthButton = ({
 }: AuthButtonProps) => {
   const getButtonStyles = () => {
     const baseStyles = 'py-[11px] flex-row items-center justify-center rounded-[13px]';
-    const variantStyles = variant === 'filled' ? 'bg-blue-800' : 'bg-gray-50';
+    const variantStyles = variant === 'filled' ? 'bg-blue-800' : 'bg-gray-50 dark:bg-grayDark-100';
     const disabledStyles = disabled ? 'opacity-50' : '';
 
     return tailwind.style(baseStyles, variantStyles, disabledStyles);
@@ -32,7 +32,7 @@ export const AuthButton = ({
 
   const getTextStyles = () => {
     const baseStyles = 'ml-2 text-base font-medium';
-    const colorStyles = variant === 'filled' ? 'text-white' : 'text-gray-950';
+    const colorStyles = variant === 'filled' ? 'text-white' : 'text-gray-950 dark:text-grayDark-950';
 
     return tailwind.style(baseStyles, colorStyles);
   };

--- a/src/components-next/button/AuthButton.tsx
+++ b/src/components-next/button/AuthButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Pressable } from 'react-native';
 import Animated from 'react-native-reanimated';
+import type { StyleProp, ViewStyle } from 'react-native';
 
 import { tailwind } from '@/theme';
 import { Icon } from '../common/icon/Icon';
@@ -11,7 +12,7 @@ type AuthButtonProps = {
   handlePress?: () => void;
   disabled?: boolean;
   variant?: 'outline' | 'filled';
-  style?: any;
+  style?: StyleProp<ViewStyle>;
 };
 
 export const AuthButton = ({
@@ -24,7 +25,7 @@ export const AuthButton = ({
 }: AuthButtonProps) => {
   const getButtonStyles = () => {
     const baseStyles = 'py-[11px] flex-row items-center justify-center rounded-[13px]';
-    const variantStyles = variant === 'filled' ? 'bg-blue-800' : 'bg-gray-50';
+    const variantStyles = variant === 'filled' ? 'bg-blue-800' : 'bg-gray-50 dark:bg-grayDark-100';
     const disabledStyles = disabled ? 'opacity-50' : '';
 
     return tailwind.style(baseStyles, variantStyles, disabledStyles);
@@ -32,7 +33,8 @@ export const AuthButton = ({
 
   const getTextStyles = () => {
     const baseStyles = 'ml-2 text-base font-medium';
-    const colorStyles = variant === 'filled' ? 'text-white' : 'text-gray-950';
+    const colorStyles =
+      variant === 'filled' ? 'text-white' : 'text-gray-950 dark:text-grayDark-950';
 
     return tailwind.style(baseStyles, colorStyles);
   };

--- a/src/components-next/button/Button.tsx
+++ b/src/components-next/button/Button.tsx
@@ -15,8 +15,8 @@ type ButtonProps = {
 
 const getButtonStyles = (isPrimary: boolean, pressed: boolean) => {
   const baseStyles = 'py-[11px] flex items-center justify-center rounded-[13px]';
-  const variantStyles = isPrimary ? 'bg-blue-800' : 'bg-gray-50';
-  const pressedStyles = isPrimary ? 'opacity-95' : pressed ? 'bg-gray-100' : '';
+  const variantStyles = isPrimary ? 'bg-blue-800' : 'bg-gray-50 dark:bg-grayDark-100';
+  const pressedStyles = isPrimary ? 'opacity-95' : pressed ? 'bg-gray-100 dark:bg-grayDark-200' : '';
 
   return tailwind.style(baseStyles, variantStyles, pressedStyles);
 };
@@ -29,7 +29,7 @@ const getTextStyles = (isPrimary: boolean, isDestructive: boolean) => {
       : 'text-white'
     : isDestructive
       ? 'text-ruby-800'
-      : 'text-gray-950';
+      : 'text-gray-950 dark:text-grayDark-950';
 
   return tailwind.style(baseStyles, colorStyles);
 };

--- a/src/components-next/button/Button.tsx
+++ b/src/components-next/button/Button.tsx
@@ -15,8 +15,12 @@ type ButtonProps = {
 
 const getButtonStyles = (isPrimary: boolean, pressed: boolean) => {
   const baseStyles = 'py-[11px] flex items-center justify-center rounded-[13px]';
-  const variantStyles = isPrimary ? 'bg-blue-800' : 'bg-gray-50';
-  const pressedStyles = isPrimary ? 'opacity-95' : pressed ? 'bg-gray-100' : '';
+  const variantStyles = isPrimary ? 'bg-blue-800' : 'bg-gray-50 dark:bg-grayDark-100';
+  const pressedStyles = isPrimary
+    ? 'opacity-95'
+    : pressed
+      ? 'bg-gray-100 dark:bg-grayDark-200'
+      : '';
 
   return tailwind.style(baseStyles, variantStyles, pressedStyles);
 };
@@ -29,7 +33,7 @@ const getTextStyles = (isPrimary: boolean, isDestructive: boolean) => {
       : 'text-white'
     : isDestructive
       ? 'text-ruby-800'
-      : 'text-gray-950';
+      : 'text-gray-950 dark:text-grayDark-950';
 
   return tailwind.style(baseStyles, colorStyles);
 };

--- a/src/components-next/button/IconButton.tsx
+++ b/src/components-next/button/IconButton.tsx
@@ -17,8 +17,8 @@ type ButtonProps = {
 
 const getButtonStyles = (isPrimary: boolean, pressed: boolean) => {
   const baseStyles = 'py-[11px] flex-row items-center justify-center rounded-[13px] gap-4';
-  const variantStyles = isPrimary ? 'bg-blue-800' : 'bg-gray-50';
-  const pressedStyles = isPrimary ? 'opacity-95' : pressed ? 'bg-gray-100' : '';
+  const variantStyles = isPrimary ? 'bg-blue-800' : 'bg-gray-50 dark:bg-grayDark-100';
+  const pressedStyles = isPrimary ? 'opacity-95' : pressed ? 'bg-gray-100 dark:bg-grayDark-200' : '';
 
   return tailwind.style(baseStyles, variantStyles, pressedStyles);
 };

--- a/src/components-next/button/IconButton.tsx
+++ b/src/components-next/button/IconButton.tsx
@@ -17,8 +17,12 @@ type ButtonProps = {
 
 const getButtonStyles = (isPrimary: boolean, pressed: boolean) => {
   const baseStyles = 'py-[11px] flex-row items-center justify-center rounded-[13px] gap-4';
-  const variantStyles = isPrimary ? 'bg-blue-800' : 'bg-gray-50';
-  const pressedStyles = isPrimary ? 'opacity-95' : pressed ? 'bg-gray-100' : '';
+  const variantStyles = isPrimary ? 'bg-blue-800' : 'bg-gray-50 dark:bg-grayDark-100';
+  const pressedStyles = isPrimary
+    ? 'opacity-95'
+    : pressed
+      ? 'bg-gray-100 dark:bg-grayDark-200'
+      : '';
 
   return tailwind.style(baseStyles, variantStyles, pressedStyles);
 };

--- a/src/components-next/common/bottomsheet/BottomSheetBackdrop.tsx
+++ b/src/components-next/common/bottomsheet/BottomSheetBackdrop.tsx
@@ -15,6 +15,7 @@ export const BottomSheetBackdrop: React.FC<BottomSheetBackgroundProps> = props =
     actionsModalSheetRef,
     addLabelSheetRef,
     languagesModalSheetRef,
+    themeSheetRef,
     macrosListSheetRef,
     notificationPreferencesSheetRef,
     switchAccountSheetRef,
@@ -39,6 +40,7 @@ export const BottomSheetBackdrop: React.FC<BottomSheetBackgroundProps> = props =
     actionsModalSheetRef.current?.dismiss({ overshootClamping: true });
     addLabelSheetRef.current?.dismiss({ overshootClamping: true });
     languagesModalSheetRef.current?.dismiss({ overshootClamping: true });
+    themeSheetRef.current?.dismiss({ overshootClamping: true });
     macrosListSheetRef.current?.dismiss({ overshootClamping: true });
     notificationPreferencesSheetRef.current?.dismiss({ overshootClamping: true });
     switchAccountSheetRef.current?.dismiss({ overshootClamping: true });

--- a/src/components-next/common/bottomsheet/BottomSheetHeader.tsx
+++ b/src/components-next/common/bottomsheet/BottomSheetHeader.tsx
@@ -13,7 +13,7 @@ export const BottomSheetHeader = (props: BottomSheetHeaderProps) => {
     <Animated.View style={tailwind.style('flex-row justify-center items-center')}>
       <Animated.Text
         style={tailwind.style(
-          'text-gray-700 text-md font-inter-medium-24 leading-[17px] tracking-[0.32px]',
+          'text-gray-700 dark:text-grayDark-700 text-md font-inter-medium-24 leading-[17px] tracking-[0.32px]',
         )}>
         {headerText}
       </Animated.Text>

--- a/src/components-next/common/filters/FilterButton.tsx
+++ b/src/components-next/common/filters/FilterButton.tsx
@@ -31,12 +31,12 @@ export const FilterButton = (props: FilterButtonProps) => {
   return (
     <Animated.View style={animatedStyle}>
       <Pressable
-        style={tailwind.style('px-3 py-[7px] rounded-lg bg-gray-100 flex flex-row items-center')}
+        style={tailwind.style('px-3 py-[7px] rounded-lg bg-gray-100 dark:bg-grayDark-200 flex flex-row items-center')}
         onPress={onPress}
         {...handlers}>
         <Animated.Text
           style={tailwind.style(
-            'text-sm font-inter-medium-24 leading-[16px] tracking-[0.24px] pr-1 capitalize text-gray-950',
+            'text-sm font-inter-medium-24 leading-[16px] tracking-[0.24px] pr-1 capitalize text-gray-950 dark:text-grayDark-950',
           )}>
           {value}
         </Animated.Text>

--- a/src/components-next/common/filters/FilterButton.tsx
+++ b/src/components-next/common/filters/FilterButton.tsx
@@ -31,12 +31,14 @@ export const FilterButton = (props: FilterButtonProps) => {
   return (
     <Animated.View style={animatedStyle}>
       <Pressable
-        style={tailwind.style('px-3 py-[7px] rounded-lg bg-gray-100 flex flex-row items-center')}
+        style={tailwind.style(
+          'px-3 py-[7px] rounded-lg bg-gray-100 dark:bg-grayDark-200 flex flex-row items-center',
+        )}
         onPress={onPress}
         {...handlers}>
         <Animated.Text
           style={tailwind.style(
-            'text-sm font-inter-medium-24 leading-[16px] tracking-[0.24px] pr-1 capitalize text-gray-950',
+            'text-sm font-inter-medium-24 leading-[16px] tracking-[0.24px] pr-1 capitalize text-gray-950 dark:text-grayDark-950',
           )}>
           {value}
         </Animated.Text>

--- a/src/components-next/common/search/SearchBar.tsx
+++ b/src/components-next/common/search/SearchBar.tsx
@@ -51,7 +51,7 @@ export const SearchBar = (props: SearchBarProps) => {
             isLoading ? 'px-8.5' : 'pl-8.5 pr-4',
           ),
         ]}
-        placeholderTextColor={tailwind.color('text-gray-800')}
+        placeholderTextColor={tailwind.color('text-gray-800 dark:text-grayDark-800')}
         {...otherProps}
       />
       {isLoading ? (

--- a/src/components-next/common/search/SearchBar.tsx
+++ b/src/components-next/common/search/SearchBar.tsx
@@ -55,11 +55,11 @@ export const SearchBar = (props: SearchBarProps) => {
       <SearchTextInput
         style={[
           tailwind.style(
-            'h-9 px-8.5 py-[7px] bg-blackA-A3 text-black text-base font-inter-normal-20 leading-[19.5px] rounded-[11px]',
+            'h-9 px-8.5 py-[7px] bg-blackA-A3 dark:bg-grayDark-100 text-black dark:text-grayDark-950 text-base font-inter-normal-20 leading-[19.5px] rounded-[11px]',
             isLoading ? 'px-8.5' : value && onClear ? 'pl-8.5 pr-10' : 'pl-8.5 pr-4',
           ),
         ]}
-        placeholderTextColor={tailwind.color('text-gray-800')}
+        placeholderTextColor={tailwind.color('text-gray-800 dark:text-grayDark-800')}
         autoCapitalize="none"
         value={value}
         {...otherProps}

--- a/src/components-next/common/slider/Slider.tsx
+++ b/src/components-next/common/slider/Slider.tsx
@@ -124,7 +124,7 @@ export const Slider = (props: SliderProps) => {
         <Animated.View
           style={[
             tailwind.style(
-              'absolute justify-center items-center h-4 w-4 bg-white rounded-full -bottom-1.5',
+              'absolute justify-center items-center h-4 w-4 bg-white dark:bg-grayDark-50 rounded-full -bottom-1.5',
               knobStyle,
             ),
             styles.knobShadow,

--- a/src/components-next/common/swipeable/Swipeable.tsx
+++ b/src/components-next/common/swipeable/Swipeable.tsx
@@ -133,7 +133,7 @@ export const Swipeable = forwardRef((props: SwipeableProps, _ref) => {
   const isGestureActive = useSharedValue(false);
 
   const maxTranslation = WIDTH * 0.6;
-  const tappedBgStyle = tailwind.color('bg-gray-200') as string;
+  const tappedBgStyle = tailwind.color('bg-gray-200 dark:bg-grayDark-200') as string;
   const maxSnapPointLeft = -maxTranslation;
   const maxSnapPointRight = maxTranslation;
 

--- a/src/components-next/common/swipeable/Swipeable.tsx
+++ b/src/components-next/common/swipeable/Swipeable.tsx
@@ -134,7 +134,7 @@ export const Swipeable = forwardRef((props: SwipeableProps, _ref) => {
   const isGestureActive = useSharedValue(false);
 
   const maxTranslation = WIDTH * 0.6;
-  const tappedBgStyle = tailwind.color('bg-gray-200') as string;
+  const tappedBgStyle = tailwind.color('bg-gray-200 dark:bg-grayDark-200') as string;
   const maxSnapPointLeft = -maxTranslation;
   const maxSnapPointRight = maxTranslation;
 

--- a/src/components-next/label-section/LabelCell.tsx
+++ b/src/components-next/label-section/LabelCell.tsx
@@ -32,7 +32,7 @@ export const LabelCell = (props: LabelCellProps) => {
         <Animated.Text
           style={[
             tailwind.style(
-              'text-base text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
+              'text-base text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
             ),
           ]}>
           {value.title}

--- a/src/components-next/label-section/LabelItem.tsx
+++ b/src/components-next/label-section/LabelItem.tsx
@@ -16,12 +16,12 @@ export const LabelItem = (props: LabelItemProps) => {
     <Animated.View
       style={[
         styles.labelShadow,
-        tailwind.style('flex flex-row items-center bg-white px-3 py-[7px] rounded-lg mr-2 mt-3'),
+        tailwind.style('flex flex-row items-center bg-white dark:bg-grayDark-50 px-3 py-[7px] rounded-lg mr-2 mt-3'),
       ]}>
       <Animated.View style={tailwind.style('h-2 w-2 rounded-full', `bg-[${item.color}]`)} />
       <Animated.Text
         style={tailwind.style(
-          'text-md font-inter-normal-20 leading-[17px] tracking-[0.32px] pl-1.5 text-gray-950',
+          'text-md font-inter-normal-20 leading-[17px] tracking-[0.32px] pl-1.5 text-gray-950 dark:text-grayDark-950',
         )}>
         {item.title}
       </Animated.Text>

--- a/src/components-next/label-section/LabelItem.tsx
+++ b/src/components-next/label-section/LabelItem.tsx
@@ -43,7 +43,6 @@ const styles = StyleSheet.create({
       },
       android: {
         elevation: 4,
-        backgroundColor: 'white',
       },
     }) || {}, // Add fallback empty object
 });

--- a/src/components-next/label-section/LabelItem.tsx
+++ b/src/components-next/label-section/LabelItem.tsx
@@ -16,12 +16,14 @@ export const LabelItem = (props: LabelItemProps) => {
     <Animated.View
       style={[
         styles.labelShadow,
-        tailwind.style('flex flex-row items-center bg-white px-3 py-[7px] rounded-lg mr-2 mt-3'),
+        tailwind.style(
+          'flex flex-row items-center bg-white dark:bg-grayDark-50 px-3 py-[7px] rounded-lg mr-2 mt-3',
+        ),
       ]}>
       <Animated.View style={tailwind.style('h-2 w-2 rounded-full', `bg-[${item.color}]`)} />
       <Animated.Text
         style={tailwind.style(
-          'text-md font-inter-normal-20 leading-[17px] tracking-[0.32px] pl-1.5 text-gray-950',
+          'text-md font-inter-normal-20 leading-[17px] tracking-[0.32px] pl-1.5 text-gray-950 dark:text-grayDark-950',
         )}>
         {item.title}
       </Animated.Text>

--- a/src/components-next/label-section/label-actions/LabelActions.tsx
+++ b/src/components-next/label-section/label-actions/LabelActions.tsx
@@ -161,7 +161,6 @@ const styles = StyleSheet.create({
       },
       android: {
         elevation: 4,
-        backgroundColor: 'white',
       },
     }) || {}, // Add fallback empty object
 });

--- a/src/components-next/list-components/AttributeList.tsx
+++ b/src/components-next/list-components/AttributeList.tsx
@@ -50,7 +50,7 @@ const AttributeItem = (props: AttributeItemProps) => {
       key={index}
       style={({ pressed }) => [
         tailwind.style(
-          pressed ? 'bg-gray-100' : '',
+          pressed ? 'bg-gray-100 dark:bg-grayDark-100' : '',
           index === 0 ? 'rounded-t-[13px]' : '',
           isLastItem ? 'rounded-b-[13px]' : '',
         ),
@@ -70,7 +70,7 @@ const AttributeItem = (props: AttributeItemProps) => {
           <Animated.View>
             <Animated.Text
               style={tailwind.style(
-                'text-base font-inter-420-20 leading-[22px] tracking-[0.16px] text-gray-950',
+                'text-base font-inter-420-20 leading-[22px] tracking-[0.16px] text-gray-950 dark:text-grayDark-950',
               )}>
               {listItem.title}
             </Animated.Text>
@@ -81,7 +81,7 @@ const AttributeItem = (props: AttributeItemProps) => {
               ellipsizeMode="tail"
               style={tailwind.style(
                 'text-base font-inter-normal-20 leading-[22px] tracking-[0.16px] overflow-hidden',
-                listItem.subtitleType === 'light' ? 'text-gray-900' : 'text-gray-950',
+                listItem.subtitleType === 'light' ? 'text-gray-900 dark:text-grayDark-900' : 'text-gray-950 dark:text-grayDark-950',
                 listItem.type === 'link' ? 'text-blue-800 underline' : '',
               )}>
               {formattedValue}
@@ -107,13 +107,13 @@ export const AttributeList = (props: AttributeListProps) => {
         <Animated.View style={tailwind.style('pl-4 pb-3')}>
           <Animated.Text
             style={tailwind.style(
-              'text-sm font-inter-medium-24 leading-[16px] tracking-[0.32px] text-gray-700',
+              'text-sm font-inter-medium-24 leading-[16px] tracking-[0.32px] text-gray-700 dark:text-grayDark-700',
             )}>
             {sectionTitle}
           </Animated.Text>
         </Animated.View>
       ) : null}
-      <Animated.View style={[tailwind.style('rounded-[13px] mx-4 bg-white'), styles.listShadow]}>
+      <Animated.View style={[tailwind.style('rounded-[13px] mx-4 bg-white dark:bg-grayDark-50'), styles.listShadow]}>
         {list.map(
           (listItem, index) =>
             !listItem.disabled &&

--- a/src/components-next/list-components/AttributeList.tsx
+++ b/src/components-next/list-components/AttributeList.tsx
@@ -149,7 +149,6 @@ const styles = StyleSheet.create({
       },
       android: {
         elevation: 4,
-        backgroundColor: 'white',
       },
     }) || {}, // Add fallback empty object
 });

--- a/src/components-next/list-components/AttributeList.tsx
+++ b/src/components-next/list-components/AttributeList.tsx
@@ -50,7 +50,7 @@ const AttributeItem = (props: AttributeItemProps) => {
       key={index}
       style={({ pressed }) => [
         tailwind.style(
-          pressed ? 'bg-gray-100' : '',
+          pressed ? 'bg-gray-100 dark:bg-grayDark-100' : '',
           index === 0 ? 'rounded-t-[13px]' : '',
           isLastItem ? 'rounded-b-[13px]' : '',
         ),
@@ -70,7 +70,7 @@ const AttributeItem = (props: AttributeItemProps) => {
           <Animated.View>
             <Animated.Text
               style={tailwind.style(
-                'text-base font-inter-420-20 leading-[22px] tracking-[0.16px] text-gray-950',
+                'text-base font-inter-420-20 leading-[22px] tracking-[0.16px] text-gray-950 dark:text-grayDark-950',
               )}>
               {listItem.title}
             </Animated.Text>
@@ -81,7 +81,9 @@ const AttributeItem = (props: AttributeItemProps) => {
               ellipsizeMode="tail"
               style={tailwind.style(
                 'text-base font-inter-normal-20 leading-[22px] tracking-[0.16px] overflow-hidden',
-                listItem.subtitleType === 'light' ? 'text-gray-900' : 'text-gray-950',
+                listItem.subtitleType === 'light'
+                  ? 'text-gray-900 dark:text-grayDark-900'
+                  : 'text-gray-950 dark:text-grayDark-950',
                 listItem.type === 'link' ? 'text-blue-800 underline' : '',
               )}>
               {formattedValue}
@@ -107,13 +109,17 @@ export const AttributeList = (props: AttributeListProps) => {
         <Animated.View style={tailwind.style('pl-4 pb-3')}>
           <Animated.Text
             style={tailwind.style(
-              'text-sm font-inter-medium-24 leading-[16px] tracking-[0.32px] text-gray-700',
+              'text-sm font-inter-medium-24 leading-[16px] tracking-[0.32px] text-gray-700 dark:text-grayDark-700',
             )}>
             {sectionTitle}
           </Animated.Text>
         </Animated.View>
       ) : null}
-      <Animated.View style={[tailwind.style('rounded-[13px] mx-4 bg-white'), styles.listShadow]}>
+      <Animated.View
+        style={[
+          tailwind.style('rounded-[13px] mx-4 bg-white dark:bg-grayDark-50'),
+          styles.listShadow,
+        ]}>
         {list.map(
           (listItem, index) =>
             !listItem.disabled &&

--- a/src/components-next/list-components/LanguageList.tsx
+++ b/src/components-next/list-components/LanguageList.tsx
@@ -48,7 +48,7 @@ const LanguageCell = (props: LanguageCellProps) => {
           )}>
           <Animated.Text
             style={tailwind.style(
-              'text-base capitalize text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
+              'text-base capitalize text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
             )}>
             {item.title}
           </Animated.Text>

--- a/src/components-next/list-components/SettingsList.tsx
+++ b/src/components-next/list-components/SettingsList.tsx
@@ -27,7 +27,7 @@ const ListItem = (props: ListItemProps) => {
       key={index}
       style={({ pressed }) => [
         tailwind.style(
-          pressed ? 'bg-gray-100' : '',
+          pressed ? 'bg-gray-100 dark:bg-grayDark-100' : '',
           index === 0 ? 'rounded-t-[13px]' : '',
           isLastItem ? 'rounded-b-[13px]' : '',
         ),
@@ -47,7 +47,7 @@ const ListItem = (props: ListItemProps) => {
           <Animated.View>
             <Animated.Text
               style={tailwind.style(
-                'text-base font-inter-420-20 leading-[22px] tracking-[0.16px] text-gray-950',
+                'text-base font-inter-420-20 leading-[22px] tracking-[0.16px] text-gray-950 dark:text-grayDark-950',
               )}>
               {listItem.title}
             </Animated.Text>
@@ -56,7 +56,7 @@ const ListItem = (props: ListItemProps) => {
             <Animated.Text
               style={tailwind.style(
                 'text-base font-inter-normal-20 leading-[22px] tracking-[0.16px]',
-                listItem.subtitleType === 'light' ? 'text-gray-900' : 'text-gray-950',
+                listItem.subtitleType === 'light' ? 'text-gray-900 dark:text-grayDark-900' : 'text-gray-950 dark:text-grayDark-950',
               )}>
               {listItem.subtitle}
             </Animated.Text>
@@ -77,13 +77,13 @@ export const SettingsList = (props: GenericListProps) => {
         <Animated.View style={tailwind.style('pl-4 pb-3')}>
           <Animated.Text
             style={tailwind.style(
-              'text-sm font-inter-medium-24 leading-[16px] tracking-[0.32px] text-gray-700',
+              'text-sm font-inter-medium-24 leading-[16px] tracking-[0.32px] text-gray-700 dark:text-grayDark-700',
             )}>
             {sectionTitle}
           </Animated.Text>
         </Animated.View>
       ) : null}
-      <Animated.View style={[tailwind.style('rounded-[13px] mx-4 bg-white'), styles.listShadow]}>
+      <Animated.View style={[tailwind.style('rounded-[13px] mx-4 bg-white dark:bg-grayDark-50'), styles.listShadow]}>
         {list.map(
           (listItem, index) =>
             !listItem.disabled && (

--- a/src/components-next/list-components/SettingsList.tsx
+++ b/src/components-next/list-components/SettingsList.tsx
@@ -27,7 +27,7 @@ const ListItem = (props: ListItemProps) => {
       key={index}
       style={({ pressed }) => [
         tailwind.style(
-          pressed ? 'bg-gray-100' : '',
+          pressed ? 'bg-gray-100 dark:bg-grayDark-100' : '',
           index === 0 ? 'rounded-t-[13px]' : '',
           isLastItem ? 'rounded-b-[13px]' : '',
         ),
@@ -47,7 +47,7 @@ const ListItem = (props: ListItemProps) => {
           <Animated.View>
             <Animated.Text
               style={tailwind.style(
-                'text-base font-inter-420-20 leading-[22px] tracking-[0.16px] text-gray-950',
+                'text-base font-inter-420-20 leading-[22px] tracking-[0.16px] text-gray-950 dark:text-grayDark-950',
               )}>
               {listItem.title}
             </Animated.Text>
@@ -56,7 +56,9 @@ const ListItem = (props: ListItemProps) => {
             <Animated.Text
               style={tailwind.style(
                 'text-base font-inter-normal-20 leading-[22px] tracking-[0.16px]',
-                listItem.subtitleType === 'light' ? 'text-gray-900' : 'text-gray-950',
+                listItem.subtitleType === 'light'
+                  ? 'text-gray-900 dark:text-grayDark-900'
+                  : 'text-gray-950 dark:text-grayDark-950',
               )}>
               {listItem.subtitle}
             </Animated.Text>
@@ -77,13 +79,17 @@ export const SettingsList = (props: GenericListProps) => {
         <Animated.View style={tailwind.style('pl-4 pb-3')}>
           <Animated.Text
             style={tailwind.style(
-              'text-sm font-inter-medium-24 leading-[16px] tracking-[0.32px] text-gray-700',
+              'text-sm font-inter-medium-24 leading-[16px] tracking-[0.32px] text-gray-700 dark:text-grayDark-700',
             )}>
             {sectionTitle}
           </Animated.Text>
         </Animated.View>
       ) : null}
-      <Animated.View style={[tailwind.style('rounded-[13px] mx-4 bg-white'), styles.listShadow]}>
+      <Animated.View
+        style={[
+          tailwind.style('rounded-[13px] mx-4 bg-white dark:bg-grayDark-50'),
+          styles.listShadow,
+        ]}>
         {list.map(
           (listItem, index) =>
             !listItem.disabled && (

--- a/src/components-next/list-components/SettingsList.tsx
+++ b/src/components-next/list-components/SettingsList.tsx
@@ -116,7 +116,6 @@ const styles = StyleSheet.create({
       },
       android: {
         elevation: 4,
-        backgroundColor: 'white',
       },
     }) || {}, // Add fallback empty object
 });

--- a/src/components-next/sheet-components/AvailabilityStatusList.tsx
+++ b/src/components-next/sheet-components/AvailabilityStatusList.tsx
@@ -42,7 +42,7 @@ const StatusCell = ({
           )}>
           <Text
             style={tailwind.style(
-              'text-base capitalize text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
+              'text-base capitalize text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
             )}>
             {item.status}
           </Text>

--- a/src/components-next/sheet-components/NotificationPreferences.tsx
+++ b/src/components-next/sheet-components/NotificationPreferences.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Switch, StyleSheet } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { useAppDispatch, useAppSelector } from '@/hooks';
+import { useTheme } from '@/context';
 
 import { tailwind } from '@/theme';
 import i18n from 'i18n';
@@ -28,6 +29,13 @@ export const NotificationPreferences = () => {
   } = useAppSelector(selectNotificationSettings);
 
   const dispatch = useAppDispatch();
+  const { isDark } = useTheme();
+
+  // Theme-aware switch colors
+  const trackColorFalse = isDark ? tailwind.color('gray-600') : '#C9D7E3';
+  const trackColorTrue = tailwind.color('blue-700') || '#1F93FF';
+  const thumbColor = isDark ? tailwind.color('gray-50') : '#FFFFFF';
+  const iosBackgroundColor = isDark ? tailwind.color('gray-600') : '#C9D7E3';
 
   const [selectedPushFlags, setPushFlags] = useState(selected_push_flags);
 
@@ -66,14 +74,14 @@ export const NotificationPreferences = () => {
           key={item}
           style={tailwind.style('flex flex-row items-center justify-between ml-2 mt-2')}>
           <Animated.Text
-            style={tailwind.style('flex-1 leading-[17px] tracking-[0.24px] text-gray-950')}>
+            style={tailwind.style('flex-1 leading-[17px] tracking-[0.24px] text-gray-950 dark:text-grayDark-950')}>
             {i18n.t(`NOTIFICATION_PREFERENCE.${NOTIFICATION_PREFERENCE_TYPES[item]}`)}
           </Animated.Text>
           <Switch
-            trackColor={{ false: '#C9D7E3', true: '#1F93FF' }}
-            thumbColor="#FFFFFF"
+            trackColor={{ false: trackColorFalse, true: trackColorTrue }}
+            thumbColor={thumbColor}
             style={styles.switch}
-            ios_backgroundColor="#C9D7E3"
+            ios_backgroundColor={iosBackgroundColor}
             onValueChange={() => onPushItemChange(item)}
             value={selectedPushFlags.includes(item)}
           />

--- a/src/components-next/sheet-components/NotificationPreferences.tsx
+++ b/src/components-next/sheet-components/NotificationPreferences.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Switch, StyleSheet } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { useAppDispatch, useAppSelector } from '@/hooks';
+import { useTheme } from '@/context';
 
 import { tailwind } from '@/theme';
 import i18n from 'i18n';
@@ -28,6 +29,13 @@ export const NotificationPreferences = () => {
   } = useAppSelector(selectNotificationSettings);
 
   const dispatch = useAppDispatch();
+  const { isDark } = useTheme();
+
+  // Theme-aware switch colors
+  const trackColorFalse = isDark ? tailwind.color('gray-600') : '#C9D7E3';
+  const trackColorTrue = tailwind.color('blue-700') || '#1F93FF';
+  const thumbColor = isDark ? tailwind.color('gray-50') : '#FFFFFF';
+  const iosBackgroundColor = isDark ? tailwind.color('gray-600') : '#C9D7E3';
 
   const [selectedPushFlags, setPushFlags] = useState(selected_push_flags);
 
@@ -66,14 +74,16 @@ export const NotificationPreferences = () => {
           key={item}
           style={tailwind.style('flex flex-row items-center justify-between ml-2 mt-2')}>
           <Animated.Text
-            style={tailwind.style('flex-1 leading-[17px] tracking-[0.24px] text-gray-950')}>
+            style={tailwind.style(
+              'flex-1 leading-[17px] tracking-[0.24px] text-gray-950 dark:text-grayDark-950',
+            )}>
             {i18n.t(`NOTIFICATION_PREFERENCE.${NOTIFICATION_PREFERENCE_TYPES[item]}`)}
           </Animated.Text>
           <Switch
-            trackColor={{ false: '#C9D7E3', true: '#1F93FF' }}
-            thumbColor="#FFFFFF"
+            trackColor={{ false: trackColorFalse, true: trackColorTrue }}
+            thumbColor={thumbColor}
             style={styles.switch}
-            ios_backgroundColor="#C9D7E3"
+            ios_backgroundColor={iosBackgroundColor}
             onValueChange={() => onPushItemChange(item)}
             value={selectedPushFlags.includes(item)}
           />

--- a/src/components-next/sheet-components/SwitchAccount.tsx
+++ b/src/components-next/sheet-components/SwitchAccount.tsx
@@ -42,13 +42,13 @@ const AccountCell = ({
           <View>
             <Text
               style={tailwind.style(
-                'text-base capitalize text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
+                'text-base capitalize text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
               )}>
               {item.name}
             </Text>
             <Text
               style={tailwind.style(
-                'text-sm text-gray-900 font-inter-420-20 leading-[18px] tracking-[0.16px] capitalize',
+                'text-sm text-gray-900 dark:text-grayDark-900 font-inter-420-20 leading-[18px] tracking-[0.16px] capitalize',
               )}>
               {item.role}
             </Text>

--- a/src/components-next/sheet-components/ThemeList.tsx
+++ b/src/components-next/sheet-components/ThemeList.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { Pressable, Text, Animated } from 'react-native';
+
+import { TickIcon } from '@/svg-icons';
+import { tailwind } from '@/theme';
+import { Theme } from '@/types/common/Theme';
+import { useHaptic } from '@/utils';
+import { Icon } from '@/components-next/common/icon';
+import i18n from '@/i18n';
+
+type ThemeListItemType = {
+  value: Theme;
+  label: string;
+  description: string;
+};
+
+const THEME_OPTIONS: ThemeListItemType[] = [
+  {
+    value: 'light',
+    label: i18n.t('SETTINGS.THEME.LIGHT'),
+    description: i18n.t('SETTINGS.THEME.LIGHT_DESCRIPTION'),
+  },
+  {
+    value: 'dark',
+    label: i18n.t('SETTINGS.THEME.DARK'),
+    description: i18n.t('SETTINGS.THEME.DARK_DESCRIPTION'),
+  },
+  {
+    value: 'system',
+    label: i18n.t('SETTINGS.THEME.SYSTEM'),
+    description: i18n.t('SETTINGS.THEME.SYSTEM_DESCRIPTION'),
+  },
+];
+
+type ThemeCellProps = {
+  item: ThemeListItemType;
+  index: number;
+  currentTheme: Theme;
+  changeTheme: (theme: Theme) => void;
+};
+
+const ThemeCell = ({ item, index, currentTheme, changeTheme }: ThemeCellProps) => {
+  const hapticSelection = useHaptic();
+
+  const handlePress = () => {
+    hapticSelection?.();
+    changeTheme(item.value);
+  };
+
+  const isLastItem = index === THEME_OPTIONS.length - 1;
+  const isSelected = currentTheme === item.value;
+
+  return (
+    <Pressable onPress={handlePress}>
+      <Animated.View
+        style={tailwind.style(
+          'flex flex-row items-center justify-between py-3 px-4',
+          !isLastItem && 'border-b-[1px] border-blackA-A3 dark:border-whiteA-A3',
+        )}>
+        <Animated.View style={tailwind.style('flex-1 flex-col')}>
+          <Text
+            style={tailwind.style(
+              'text-base text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
+            )}>
+            {item.label}
+          </Text>
+          <Text style={tailwind.style('text-sm text-gray-700 dark:text-grayDark-700 font-inter-normal-20 mt-0.5')}>
+            {item.description}
+          </Text>
+        </Animated.View>
+        {isSelected && (
+          <Animated.View style={tailwind.style('ml-3')}>
+            <Icon icon={<TickIcon />} size={20} />
+          </Animated.View>
+        )}
+      </Animated.View>
+    </Pressable>
+  );
+};
+
+export const ThemeList = ({
+  currentTheme,
+  changeTheme,
+}: {
+  currentTheme: Theme;
+  changeTheme: (theme: Theme) => void;
+}) => {
+  return (
+    <Animated.View style={tailwind.style('flex flex-col')}>
+      {THEME_OPTIONS.map((item, index) => (
+        <ThemeCell
+          key={item.value}
+          item={item}
+          index={index}
+          currentTheme={currentTheme}
+          changeTheme={changeTheme}
+        />
+      ))}
+    </Animated.View>
+  );
+};

--- a/src/components-next/sheet-components/ThemeList.tsx
+++ b/src/components-next/sheet-components/ThemeList.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { Pressable, Text, Animated } from 'react-native';
+
+import { TickIcon } from '@/svg-icons';
+import { tailwind } from '@/theme';
+import { Theme } from '@/types/common/Theme';
+import { useHaptic } from '@/utils';
+import { Icon } from '@/components-next/common/icon';
+import i18n from '@/i18n';
+
+type ThemeListItemType = {
+  value: Theme;
+  label: string;
+  description: string;
+};
+
+const THEME_OPTIONS: ThemeListItemType[] = [
+  {
+    value: 'light',
+    label: i18n.t('SETTINGS.THEME.LIGHT'),
+    description: i18n.t('SETTINGS.THEME.LIGHT_DESCRIPTION'),
+  },
+  {
+    value: 'dark',
+    label: i18n.t('SETTINGS.THEME.DARK'),
+    description: i18n.t('SETTINGS.THEME.DARK_DESCRIPTION'),
+  },
+  {
+    value: 'system',
+    label: i18n.t('SETTINGS.THEME.SYSTEM'),
+    description: i18n.t('SETTINGS.THEME.SYSTEM_DESCRIPTION'),
+  },
+];
+
+type ThemeCellProps = {
+  item: ThemeListItemType;
+  index: number;
+  currentTheme: Theme;
+  changeTheme: (theme: Theme) => void;
+};
+
+const ThemeCell = ({ item, index, currentTheme, changeTheme }: ThemeCellProps) => {
+  const hapticSelection = useHaptic();
+
+  const handlePress = () => {
+    hapticSelection?.();
+    changeTheme(item.value);
+  };
+
+  const isLastItem = index === THEME_OPTIONS.length - 1;
+  const isSelected = currentTheme === item.value;
+
+  return (
+    <Pressable onPress={handlePress}>
+      <Animated.View
+        style={tailwind.style(
+          'flex flex-row items-center justify-between py-3 px-4',
+          !isLastItem && 'border-b-[1px] border-blackA-A3 dark:border-whiteA-A3',
+        )}>
+        <Animated.View style={tailwind.style('flex-1 flex-col')}>
+          <Text
+            style={tailwind.style(
+              'text-base text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
+            )}>
+            {item.label}
+          </Text>
+          <Text
+            style={tailwind.style(
+              'text-sm text-gray-700 dark:text-grayDark-700 font-inter-normal-20 mt-0.5',
+            )}>
+            {item.description}
+          </Text>
+        </Animated.View>
+        {isSelected && (
+          <Animated.View style={tailwind.style('ml-3')}>
+            <Icon icon={<TickIcon />} size={20} />
+          </Animated.View>
+        )}
+      </Animated.View>
+    </Pressable>
+  );
+};
+
+export const ThemeList = ({
+  currentTheme,
+  changeTheme,
+}: {
+  currentTheme: Theme;
+  changeTheme: (theme: Theme) => void;
+}) => {
+  return (
+    <Animated.View style={tailwind.style('flex flex-col')}>
+      {THEME_OPTIONS.map((item, index) => (
+        <ThemeCell
+          key={item.value}
+          item={item}
+          index={index}
+          currentTheme={currentTheme}
+          changeTheme={changeTheme}
+        />
+      ))}
+    </Animated.View>
+  );
+};

--- a/src/components-next/sheet-components/ThemeList.tsx
+++ b/src/components-next/sheet-components/ThemeList.tsx
@@ -10,25 +10,25 @@ import i18n from '@/i18n';
 
 type ThemeListItemType = {
   value: Theme;
-  label: string;
-  description: string;
+  labelKey: string;
+  descriptionKey: string;
 };
 
 const THEME_OPTIONS: ThemeListItemType[] = [
   {
     value: 'light',
-    label: i18n.t('SETTINGS.THEME.LIGHT'),
-    description: i18n.t('SETTINGS.THEME.LIGHT_DESCRIPTION'),
+    labelKey: 'SETTINGS.THEME.LIGHT',
+    descriptionKey: 'SETTINGS.THEME.LIGHT_DESCRIPTION',
   },
   {
     value: 'dark',
-    label: i18n.t('SETTINGS.THEME.DARK'),
-    description: i18n.t('SETTINGS.THEME.DARK_DESCRIPTION'),
+    labelKey: 'SETTINGS.THEME.DARK',
+    descriptionKey: 'SETTINGS.THEME.DARK_DESCRIPTION',
   },
   {
     value: 'system',
-    label: i18n.t('SETTINGS.THEME.SYSTEM'),
-    description: i18n.t('SETTINGS.THEME.SYSTEM_DESCRIPTION'),
+    labelKey: 'SETTINGS.THEME.SYSTEM',
+    descriptionKey: 'SETTINGS.THEME.SYSTEM_DESCRIPTION',
   },
 ];
 
@@ -62,13 +62,13 @@ const ThemeCell = ({ item, index, currentTheme, changeTheme }: ThemeCellProps) =
             style={tailwind.style(
               'text-base text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
             )}>
-            {item.label}
+            {i18n.t(item.labelKey)}
           </Text>
           <Text
             style={tailwind.style(
               'text-sm text-gray-700 dark:text-grayDark-700 font-inter-normal-20 mt-0.5',
             )}>
-            {item.description}
+            {i18n.t(item.descriptionKey)}
           </Text>
         </Animated.View>
         {isSelected && (

--- a/src/components-next/sheet-components/index.ts
+++ b/src/components-next/sheet-components/index.ts
@@ -1,3 +1,4 @@
 export * from './AvailabilityStatusList';
 export * from './NotificationPreferences';
 export * from './SwitchAccount';
+export * from './ThemeList';

--- a/src/context/RefsContext.tsx
+++ b/src/context/RefsContext.tsx
@@ -9,6 +9,7 @@ interface RefsContextType {
   filtersModalSheetRef: React.RefObject<BottomSheetModal>;
   actionsModalSheetRef: React.RefObject<BottomSheetModal>;
   languagesModalSheetRef: React.RefObject<BottomSheetModal>;
+  themeSheetRef: React.RefObject<BottomSheetModal>;
   chatPagerView: React.RefObject<PagerView>;
   addLabelSheetRef: React.RefObject<BottomSheetModal>;
   macrosListSheetRef: React.RefObject<BottomSheetModal>;
@@ -41,6 +42,7 @@ const RefsProvider: React.FC<Partial<RefsContextType & { children: React.ReactNo
   const filtersModalSheetRef = useRef<BottomSheetModal>(null);
   const actionsModalSheetRef = useRef<BottomSheetModal>(null);
   const languagesModalSheetRef = useRef<BottomSheetModal>(null);
+  const themeSheetRef = useRef<BottomSheetModal>(null);
   const notificationPreferencesSheetRef = useRef<BottomSheetModal>(null);
   const addLabelSheetRef = useRef<BottomSheetModal>(null);
   const macrosListSheetRef = useRef<BottomSheetModal>(null);
@@ -61,6 +63,7 @@ const RefsProvider: React.FC<Partial<RefsContextType & { children: React.ReactNo
     filtersModalSheetRef,
     actionsModalSheetRef,
     languagesModalSheetRef,
+    themeSheetRef,
     notificationPreferencesSheetRef,
     chatPagerView,
     addLabelSheetRef,

--- a/src/context/RefsContext.tsx
+++ b/src/context/RefsContext.tsx
@@ -9,6 +9,7 @@ interface RefsContextType {
   filtersModalSheetRef: React.RefObject<BottomSheetModal>;
   actionsModalSheetRef: React.RefObject<BottomSheetModal>;
   languagesModalSheetRef: React.RefObject<BottomSheetModal>;
+  themeSheetRef: React.RefObject<BottomSheetModal>;
   chatPagerView: React.RefObject<PagerView>;
   addLabelSheetRef: React.RefObject<BottomSheetModal>;
   macrosListSheetRef: React.RefObject<BottomSheetModal>;
@@ -40,6 +41,7 @@ const RefsProvider: React.FC<Partial<RefsContextType & { children: React.ReactNo
   const filtersModalSheetRef = useRef<BottomSheetModal>(null);
   const actionsModalSheetRef = useRef<BottomSheetModal>(null);
   const languagesModalSheetRef = useRef<BottomSheetModal>(null);
+  const themeSheetRef = useRef<BottomSheetModal>(null);
   const notificationPreferencesSheetRef = useRef<BottomSheetModal>(null);
   const addLabelSheetRef = useRef<BottomSheetModal>(null);
   const macrosListSheetRef = useRef<BottomSheetModal>(null);
@@ -59,6 +61,7 @@ const RefsProvider: React.FC<Partial<RefsContextType & { children: React.ReactNo
     filtersModalSheetRef,
     actionsModalSheetRef,
     languagesModalSheetRef,
+    themeSheetRef,
     notificationPreferencesSheetRef,
     chatPagerView,
     addLabelSheetRef,

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,67 @@
+import React, { createContext, useContext, useEffect, useLayoutEffect, useState, ReactNode } from 'react';
+import { Appearance, ColorSchemeName } from 'react-native';
+import { useAppDispatch, useAppSelector } from '@/hooks';
+import { setTheme } from '@/store/settings/settingsSlice';
+import { selectTheme } from '@/store/settings/settingsSelectors';
+import { tailwind } from '@/theme';
+import { Theme } from '@/types/common/Theme';
+
+type ThemeContextType = {
+  theme: Theme;
+  colorScheme: ColorSchemeName;
+  isDark: boolean;
+  changeTheme: (newTheme: Theme) => void;
+};
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+type ThemeProviderProps = {
+  children: ReactNode;
+};
+
+const getColorScheme = (theme: Theme, systemScheme: ColorSchemeName): ColorSchemeName => {
+  if (theme === 'system') return systemScheme || 'light';
+  return theme === 'dark' ? 'dark' : 'light';
+};
+
+export const ThemeProvider = ({ children }: ThemeProviderProps) => {
+  const dispatch = useAppDispatch();
+  const theme = useAppSelector(selectTheme) || 'system';
+  const [systemColorScheme, setSystemColorScheme] = useState<ColorSchemeName>(
+    Appearance.getColorScheme()
+  );
+
+  const colorScheme = getColorScheme(theme, systemColorScheme);
+  const isDark = colorScheme === 'dark';
+
+  // Listen for system theme changes
+  useEffect(() => {
+    const subscription = Appearance.addChangeListener(({ colorScheme: newColorScheme }) => {
+      setSystemColorScheme(newColorScheme);
+    });
+    return () => subscription.remove();
+  }, []);
+
+  // Apply theme immediately on mount and when it changes
+  useLayoutEffect(() => {
+    tailwind.setColorScheme(colorScheme);
+  }, [colorScheme]);
+
+  const changeTheme = (newTheme: Theme) => {
+    dispatch(setTheme(newTheme));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, colorScheme, isDark, changeTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,68 @@
+import React, { createContext, useContext, useEffect, useRef, useState, ReactNode } from 'react';
+import { Appearance, ColorSchemeName } from 'react-native';
+import { useAppDispatch, useAppSelector } from '@/hooks';
+import { setTheme } from '@/store/settings/settingsSlice';
+import { selectTheme } from '@/store/settings/settingsSelectors';
+import { tailwind } from '@/theme';
+import { Theme } from '@/types/common/Theme';
+
+type ThemeContextType = {
+  theme: Theme;
+  colorScheme: ColorSchemeName;
+  isDark: boolean;
+  changeTheme: (newTheme: Theme) => void;
+};
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+type ThemeProviderProps = {
+  children: ReactNode;
+};
+
+const getColorScheme = (theme: Theme, systemScheme: ColorSchemeName): ColorSchemeName => {
+  if (theme === 'system') return systemScheme || 'light';
+  return theme === 'dark' ? 'dark' : 'light';
+};
+
+export const ThemeProvider = ({ children }: ThemeProviderProps) => {
+  const dispatch = useAppDispatch();
+  const theme = useAppSelector(selectTheme) || 'system';
+  const [systemColorScheme, setSystemColorScheme] = useState<ColorSchemeName>(
+    Appearance.getColorScheme(),
+  );
+  const appliedColorScheme = useRef<ColorSchemeName>(null);
+
+  const colorScheme = getColorScheme(theme, systemColorScheme);
+  const isDark = colorScheme === 'dark';
+
+  if (appliedColorScheme.current !== colorScheme) {
+    tailwind.setColorScheme(colorScheme);
+    appliedColorScheme.current = colorScheme;
+  }
+
+  // Listen for system theme changes
+  useEffect(() => {
+    const subscription = Appearance.addChangeListener(({ colorScheme: newColorScheme }) => {
+      setSystemColorScheme(newColorScheme);
+    });
+    return () => subscription.remove();
+  }, []);
+
+  const changeTheme = (newTheme: Theme) => {
+    dispatch(setTheme(newTheme));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, colorScheme, isDark, changeTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -2,3 +2,4 @@ export * from './RefsContext';
 export * from './ConversationListContext';
 export * from './InboxListContext';
 export * from './useChatWindowContext';
+export * from './ThemeContext';

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -290,6 +290,7 @@
     "SUPPORT": "Support",
     "SWITCH_ACCOUNT": "Switch Account",
     "CHANGE_LANGUAGE": "Change Language",
+    "CHANGE_THEME": "Appearance",
     "NOTIFICATIONS": "Notifications",
     "NOTIFICATION_PREFERENCES": "Notification Preferences",
     "READ_DOCS": "Read Docs",
@@ -297,7 +298,16 @@
     "LOGOUT": "Logout",
     "SUBMIT": "Submit",
     "SET_LANGUAGE": "Set Language",
-    "DEBUG_ACTIONS": "Debug Actions"
+    "SET_THEME": "Set Appearance",
+    "DEBUG_ACTIONS": "Debug Actions",
+    "THEME": {
+      "LIGHT": "Light",
+      "LIGHT_DESCRIPTION": "Always use light mode",
+      "DARK": "Dark",
+      "DARK_DESCRIPTION": "Always use dark mode",
+      "SYSTEM": "System",
+      "SYSTEM_DESCRIPTION": "Follow system settings"
+    }
   },
   "NOTIFICATION": {
     "HEADER_TITLE": "Notifications",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -295,6 +295,7 @@
     "SUPPORT": "Support",
     "SWITCH_ACCOUNT": "Switch Account",
     "CHANGE_LANGUAGE": "Change Language",
+    "CHANGE_THEME": "Appearance",
     "NOTIFICATIONS": "Notifications",
     "NOTIFICATION_PREFERENCES": "Notification Preferences",
     "READ_DOCS": "Read Docs",
@@ -302,7 +303,16 @@
     "LOGOUT": "Logout",
     "SUBMIT": "Submit",
     "SET_LANGUAGE": "Set Language",
-    "DEBUG_ACTIONS": "Debug Actions"
+    "SET_THEME": "Set Appearance",
+    "DEBUG_ACTIONS": "Debug Actions",
+    "THEME": {
+      "LIGHT": "Light",
+      "LIGHT_DESCRIPTION": "Always use light mode",
+      "DARK": "Dark",
+      "DARK_DESCRIPTION": "Always use dark mode",
+      "SYSTEM": "System",
+      "SYSTEM_DESCRIPTION": "Follow system settings"
+    }
   },
   "NOTIFICATION": {
     "HEADER_TITLE": "Notifications",

--- a/src/navigation/tabs/BottomTabBar.tsx
+++ b/src/navigation/tabs/BottomTabBar.tsx
@@ -161,7 +161,7 @@ export const BottomTabBar = ({ state, descriptors, navigation }: BottomTabBarPro
         ],
         android: [
           tailwind.style(
-            'flex flex-row absolute w-full bottom-0 pl-[72px] pr-[71px] py-[11px] bg-white',
+            'flex flex-row absolute w-full bottom-0 pl-[72px] pr-[71px] py-[11px] bg-white dark:bg-grayDark-50',
             `h-[${tabBarHeight}px]`,
           ),
         ],

--- a/src/navigation/tabs/BottomTabBar.tsx
+++ b/src/navigation/tabs/BottomTabBar.tsx
@@ -24,6 +24,7 @@ import { useHaptic, useScaleAnimation, useTabBarHeight } from '@/utils';
 
 import { TabParamList } from './AppTabs';
 import { useAppSelector } from '@/hooks';
+import { useTheme } from '@/context';
 
 const AnimatedBlurView = Animated.createAnimatedComponent(BlurView);
 
@@ -115,6 +116,26 @@ const TabItem = (props: any) => {
 export const BottomTabBar = ({ state, descriptors, navigation }: BottomTabBarProps) => {
   const hapticSelection = useHaptic();
   const tabBarHeight = useTabBarHeight();
+  const { isDark } = useTheme();
+
+  const tabBarStyle = React.useMemo(
+    () =>
+      Platform.select({
+        ios: [
+          tailwind.style(
+            'flex flex-row absolute w-full bottom-0 pl-[72px] pr-[71px] pt-[11px] pb-8 bg-[#00000009]',
+            `h-[${tabBarHeight}px]`,
+          ),
+        ],
+        android: [
+          tailwind.style(
+            `flex flex-row absolute w-full bottom-0 pl-[72px] pr-[71px] py-[11px] ${isDark ? 'bg-grayDark-50' : 'bg-white'}`,
+            `h-[${tabBarHeight}px]`,
+          ),
+        ],
+      }),
+    [isDark, tabBarHeight],
+  );
 
   // Memoize press handlers using useCallback
   const createPressHandler = React.useCallback(
@@ -149,23 +170,7 @@ export const BottomTabBar = ({ state, descriptors, navigation }: BottomTabBarPro
   );
 
   return (
-    <TabBarBackground
-      blurAmount={25}
-      blurType="light"
-      style={Platform.select({
-        ios: [
-          tailwind.style(
-            'flex flex-row absolute w-full bottom-0 pl-[72px] pr-[71px] pt-[11px] pb-8 bg-[#00000009]',
-            `h-[${tabBarHeight}px]`,
-          ),
-        ],
-        android: [
-          tailwind.style(
-            'flex flex-row absolute w-full bottom-0 pl-[72px] pr-[71px] py-[11px] bg-white dark:bg-grayDark-50',
-            `h-[${tabBarHeight}px]`,
-          ),
-        ],
-      })}>
+    <TabBarBackground blurAmount={25} blurType="light" style={tabBarStyle}>
       <Animated.View style={tailwind.style('absolute inset-0 h-[1px] bg-blackA-A3')} />
       {state.routes.map((route, index) => {
         const { options } = descriptors[route.key];

--- a/src/screens/auth/ConfigURLScreen.tsx
+++ b/src/screens/auth/ConfigURLScreen.tsx
@@ -9,6 +9,7 @@ import { LinkIcon } from '@/svg-icons';
 import { tailwind } from '@/theme';
 import i18n from '@/i18n';
 import { useAppSelector, useAppDispatch } from '@/hooks';
+import { useTheme } from '@/context';
 import { selectBaseUrl } from '@/store/settings/settingsSelectors';
 import { resetSettings } from '@/store/settings/settingsSlice';
 import { settingsActions } from '@/store/settings/settingsActions';
@@ -21,6 +22,7 @@ const appName = Application.applicationName;
 
 const ConfigURLScreen = () => {
   const baseUrl = useAppSelector(selectBaseUrl);
+  const { isDark } = useTheme();
 
   const dispatch = useAppDispatch();
 
@@ -46,24 +48,24 @@ const ConfigURLScreen = () => {
   };
 
   return (
-    <SafeAreaView style={tailwind.style('flex-1 bg-white')}>
+    <SafeAreaView style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
       <StatusBar
         translucent
-        backgroundColor={tailwind.color('bg-white')}
-        barStyle={'dark-content'}
+        backgroundColor={tailwind.color('bg-white dark:bg-grayDark-50')}
+        barStyle={isDark ? 'light-content' : 'dark-content'}
       />
-      <View style={tailwind.style('flex-1 bg-white')}>
+      <View style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
         <Animated.ScrollView
           showsVerticalScrollIndicator={false}
           contentContainerStyle={tailwind.style('px-6 pt-16')}>
           <Icon icon={<LinkIcon />} size={40} />
           <View style={tailwind.style('pt-6 gap-4')}>
-            <Animated.Text style={tailwind.style('text-2xl text-gray-950 font-inter-semibold-20')}>
+            <Animated.Text style={tailwind.style('text-2xl text-gray-950 dark:text-grayDark-950 font-inter-semibold-20')}>
               {i18n.t('CONFIGURE_URL.ENTER_URL')}
             </Animated.Text>
             <Animated.Text
               style={tailwind.style(
-                'font-inter-normal-20 leading-[18px] tracking-[0.32px] text-gray-900',
+                'font-inter-normal-20 leading-[18px] tracking-[0.32px] text-gray-900 dark:text-grayDark-900',
               )}>
               {i18n.t('CONFIGURE_URL.DESCRIPTION')}
             </Animated.Text>
@@ -84,14 +86,14 @@ const ConfigURLScreen = () => {
                   style={[
                     tailwind.style(
                       'text-base font-inter-normal-20 tracking-[0.24px] leading-[20px] android:leading-[18px]',
-                      'py-2 px-3 rounded-xl text-gray-950 bg-blackA-A4',
+                      'py-2 px-3 rounded-xl text-gray-950 dark:text-grayDark-950 bg-blackA-A4',
                       'h-10',
                     ),
                   ]}
                   onBlur={onBlur}
                   onChangeText={onChange}
                   value={value}
-                  placeholderTextColor={tailwind.color('text-gray-900')}
+                  placeholderTextColor={tailwind.color('text-gray-900 dark:text-grayDark-900')}
                   keyboardType="email-address"
                   autoCapitalize="none"
                 />

--- a/src/screens/auth/ConfigURLScreen.tsx
+++ b/src/screens/auth/ConfigURLScreen.tsx
@@ -9,6 +9,7 @@ import { LinkIcon } from '@/svg-icons';
 import { tailwind } from '@/theme';
 import i18n from '@/i18n';
 import { useAppSelector, useAppDispatch } from '@/hooks';
+import { useTheme } from '@/context';
 import { selectBaseUrl } from '@/store/settings/settingsSelectors';
 import { resetSettings } from '@/store/settings/settingsSlice';
 import { settingsActions } from '@/store/settings/settingsActions';
@@ -21,6 +22,7 @@ const appName = Application.applicationName;
 
 const ConfigURLScreen = () => {
   const baseUrl = useAppSelector(selectBaseUrl);
+  const { isDark } = useTheme();
 
   const dispatch = useAppDispatch();
 
@@ -46,24 +48,27 @@ const ConfigURLScreen = () => {
   };
 
   return (
-    <SafeAreaView style={tailwind.style('flex-1 bg-white')}>
+    <SafeAreaView style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
       <StatusBar
         translucent
-        backgroundColor={tailwind.color('bg-white')}
-        barStyle={'dark-content'}
+        backgroundColor={tailwind.color('bg-white dark:bg-grayDark-50')}
+        barStyle={isDark ? 'light-content' : 'dark-content'}
       />
-      <View style={tailwind.style('flex-1 bg-white')}>
+      <View style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
         <Animated.ScrollView
           showsVerticalScrollIndicator={false}
           contentContainerStyle={tailwind.style('px-6 pt-16')}>
           <Icon icon={<LinkIcon />} size={40} />
           <View style={tailwind.style('pt-6 gap-4')}>
-            <Animated.Text style={tailwind.style('text-2xl text-gray-950 font-inter-semibold-20')}>
+            <Animated.Text
+              style={tailwind.style(
+                'text-2xl text-gray-950 dark:text-grayDark-950 font-inter-semibold-20',
+              )}>
               {i18n.t('CONFIGURE_URL.ENTER_URL')}
             </Animated.Text>
             <Animated.Text
               style={tailwind.style(
-                'font-inter-normal-20 leading-[18px] tracking-[0.32px] text-gray-900',
+                'font-inter-normal-20 leading-[18px] tracking-[0.32px] text-gray-900 dark:text-grayDark-900',
               )}>
               {i18n.t('CONFIGURE_URL.DESCRIPTION')}
             </Animated.Text>
@@ -84,14 +89,14 @@ const ConfigURLScreen = () => {
                   style={[
                     tailwind.style(
                       'text-base font-inter-normal-20 tracking-[0.24px] leading-[20px] android:leading-[18px]',
-                      'py-2 px-3 rounded-xl text-gray-950 bg-blackA-A4',
+                      'py-2 px-3 rounded-xl text-gray-950 dark:text-grayDark-950 bg-blackA-A4',
                       'h-10',
                     ),
                   ]}
                   onBlur={onBlur}
                   onChangeText={onChange}
                   value={value}
-                  placeholderTextColor={tailwind.color('text-gray-900')}
+                  placeholderTextColor={tailwind.color('text-gray-900 dark:text-grayDark-900')}
                   keyboardType="email-address"
                   autoCapitalize="none"
                 />

--- a/src/screens/auth/ForgotPassword.tsx
+++ b/src/screens/auth/ForgotPassword.tsx
@@ -9,6 +9,7 @@ import { KeyRoundIcon } from '@/svg-icons';
 import { tailwind } from '@/theme';
 import { authActions } from '@/store/auth/authActions';
 import { useAppDispatch } from '@/hooks';
+import { useTheme } from '@/context';
 import { resetAuth } from '@/store/auth/authSlice';
 import AnalyticsHelper from '@/utils/analyticsUtils';
 import { ACCOUNT_EVENTS } from '@/constants/analyticsEvents';
@@ -21,6 +22,7 @@ type FormData = {
 
 const ForgotPassword = () => {
   const dispatch = useAppDispatch();
+  const { isDark } = useTheme();
 
   useEffect(() => {
     dispatch(resetAuth());
@@ -39,24 +41,24 @@ const ForgotPassword = () => {
   };
 
   return (
-    <SafeAreaView style={tailwind.style('flex-1 bg-white')}>
+    <SafeAreaView style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
       <StatusBar
         translucent
-        backgroundColor={tailwind.color('bg-white')}
-        barStyle={'dark-content'}
+        backgroundColor={tailwind.color('bg-white dark:bg-grayDark-50')}
+        barStyle={isDark ? 'light-content' : 'dark-content'}
       />
-      <View style={tailwind.style('flex-1 bg-white')}>
+      <View style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
         <Animated.ScrollView
           showsVerticalScrollIndicator={false}
           contentContainerStyle={tailwind.style('px-6 pt-16')}>
           <Icon icon={<KeyRoundIcon />} size={40} />
           <View style={tailwind.style('pt-6 gap-4')}>
-            <Animated.Text style={tailwind.style('text-2xl text-gray-950 font-inter-semibold-20')}>
+            <Animated.Text style={tailwind.style('text-2xl text-gray-950 dark:text-grayDark-950 font-inter-semibold-20')}>
               {i18n.t('FORGOT_PASSWORD.TITLE')}
             </Animated.Text>
             <Animated.Text
               style={tailwind.style(
-                'font-inter-normal-20 leading-[18px] tracking-[0.32px] text-gray-900',
+                'font-inter-normal-20 leading-[18px] tracking-[0.32px] text-gray-900 dark:text-grayDark-900',
               )}>
               {i18n.t('FORGOT_PASSWORD.SUB_TITLE')}
             </Animated.Text>
@@ -73,21 +75,21 @@ const ForgotPassword = () => {
             }}
             render={({ field: { onChange, onBlur, value } }) => (
               <View style={tailwind.style('pt-8 mb-8 gap-2')}>
-                <Animated.Text style={tailwind.style('font-inter-420-20 text-gray-950')}>
+                <Animated.Text style={tailwind.style('font-inter-420-20 text-gray-950 dark:text-grayDark-950')}>
                   {i18n.t('LOGIN.EMAIL')}
                 </Animated.Text>
                 <TextInput
                   style={[
                     tailwind.style(
                       'text-base font-inter-normal-20 tracking-[0.24px] leading-[20px] android:leading-[18px]',
-                      'py-2 px-3 rounded-xl text-gray-950 bg-blackA-A4',
+                      'py-2 px-3 rounded-xl text-gray-950 dark:text-grayDark-950 bg-blackA-A4',
                       'h-10',
                     ),
                   ]}
                   onBlur={onBlur}
                   onChangeText={onChange}
                   value={value}
-                  placeholderTextColor={tailwind.color('text-gray-900')}
+                  placeholderTextColor={tailwind.color('text-gray-900 dark:text-grayDark-900')}
                   keyboardType="email-address"
                   autoCapitalize="none"
                 />

--- a/src/screens/auth/ForgotPassword.tsx
+++ b/src/screens/auth/ForgotPassword.tsx
@@ -9,6 +9,7 @@ import { KeyRoundIcon } from '@/svg-icons';
 import { tailwind } from '@/theme';
 import { authActions } from '@/store/auth/authActions';
 import { useAppDispatch } from '@/hooks';
+import { useTheme } from '@/context';
 import { resetAuth } from '@/store/auth/authSlice';
 import AnalyticsHelper from '@/utils/analyticsUtils';
 import { ACCOUNT_EVENTS } from '@/constants/analyticsEvents';
@@ -21,6 +22,7 @@ type FormData = {
 
 const ForgotPassword = () => {
   const dispatch = useAppDispatch();
+  const { isDark } = useTheme();
 
   useEffect(() => {
     dispatch(resetAuth());
@@ -39,24 +41,27 @@ const ForgotPassword = () => {
   };
 
   return (
-    <SafeAreaView style={tailwind.style('flex-1 bg-white')}>
+    <SafeAreaView style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
       <StatusBar
         translucent
-        backgroundColor={tailwind.color('bg-white')}
-        barStyle={'dark-content'}
+        backgroundColor={tailwind.color('bg-white dark:bg-grayDark-50')}
+        barStyle={isDark ? 'light-content' : 'dark-content'}
       />
-      <View style={tailwind.style('flex-1 bg-white')}>
+      <View style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
         <Animated.ScrollView
           showsVerticalScrollIndicator={false}
           contentContainerStyle={tailwind.style('px-6 pt-16')}>
           <Icon icon={<KeyRoundIcon />} size={40} />
           <View style={tailwind.style('pt-6 gap-4')}>
-            <Animated.Text style={tailwind.style('text-2xl text-gray-950 font-inter-semibold-20')}>
+            <Animated.Text
+              style={tailwind.style(
+                'text-2xl text-gray-950 dark:text-grayDark-950 font-inter-semibold-20',
+              )}>
               {i18n.t('FORGOT_PASSWORD.TITLE')}
             </Animated.Text>
             <Animated.Text
               style={tailwind.style(
-                'font-inter-normal-20 leading-[18px] tracking-[0.32px] text-gray-900',
+                'font-inter-normal-20 leading-[18px] tracking-[0.32px] text-gray-900 dark:text-grayDark-900',
               )}>
               {i18n.t('FORGOT_PASSWORD.SUB_TITLE')}
             </Animated.Text>
@@ -73,21 +78,22 @@ const ForgotPassword = () => {
             }}
             render={({ field: { onChange, onBlur, value } }) => (
               <View style={tailwind.style('pt-8 mb-8 gap-2')}>
-                <Animated.Text style={tailwind.style('font-inter-420-20 text-gray-950')}>
+                <Animated.Text
+                  style={tailwind.style('font-inter-420-20 text-gray-950 dark:text-grayDark-950')}>
                   {i18n.t('LOGIN.EMAIL')}
                 </Animated.Text>
                 <TextInput
                   style={[
                     tailwind.style(
                       'text-base font-inter-normal-20 tracking-[0.24px] leading-[20px] android:leading-[18px]',
-                      'py-2 px-3 rounded-xl text-gray-950 bg-blackA-A4',
+                      'py-2 px-3 rounded-xl text-gray-950 dark:text-grayDark-950 bg-blackA-A4',
                       'h-10',
                     ),
                   ]}
                   onBlur={onBlur}
                   onChangeText={onChange}
                   value={value}
-                  placeholderTextColor={tailwind.color('text-gray-900')}
+                  placeholderTextColor={tailwind.color('text-gray-900 dark:text-grayDark-900')}
                   keyboardType="email-address"
                   autoCapitalize="none"
                 />

--- a/src/screens/auth/LoginScreen.tsx
+++ b/src/screens/auth/LoginScreen.tsx
@@ -33,6 +33,7 @@ import {
 import { selectIsLoggingIn } from '@/store/auth/authSelectors';
 import { setLocale } from '@/store/settings/settingsSlice';
 import { useRefsContext } from '@/context/RefsContext';
+import { useTheme } from '@/context';
 import { SsoUtils } from '@/utils/ssoUtils';
 
 type FormData = {
@@ -42,6 +43,7 @@ type FormData = {
 
 const LoginScreen = () => {
   const navigation = useNavigation();
+  const { isDark } = useTheme();
   const [showPassword, setShowPassword] = useState(false);
   const {
     control,
@@ -138,13 +140,13 @@ const LoginScreen = () => {
   };
 
   return (
-    <SafeAreaView edges={['top']} style={tailwind.style('flex-1 bg-white')}>
+    <SafeAreaView edges={['top']} style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
       <StatusBar
         translucent
-        backgroundColor={tailwind.color('bg-white')}
-        barStyle={'dark-content'}
+        backgroundColor={tailwind.color('bg-white dark:bg-grayDark-50')}
+        barStyle={isDark ? 'light-content' : 'dark-content'}
       />
-      <View style={tailwind.style('flex-1 bg-white')}>
+      <View style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
         <Animated.ScrollView
           showsVerticalScrollIndicator={false}
           contentContainerStyle={tailwind.style('px-6 pt-24')}>
@@ -155,12 +157,12 @@ const LoginScreen = () => {
             resizeMode="contain"
           />
           <View style={tailwind.style('pt-6 gap-4')}>
-            <Animated.Text style={tailwind.style('text-2xl text-gray-950 font-inter-semibold-20')}>
+            <Animated.Text style={tailwind.style('text-2xl text-gray-950 dark:text-grayDark-950 font-inter-semibold-20')}>
               {i18n.t('LOGIN.TITLE')}
             </Animated.Text>
             <Animated.Text
               style={tailwind.style(
-                'font-inter-normal-20 leading-[18px] tracking-[0.32px] text-gray-900',
+                'font-inter-normal-20 leading-[18px] tracking-[0.32px] text-gray-900 dark:text-grayDark-900',
               )}>
               {i18n.t('LOGIN.DESCRIPTION', { baseUrl })}
             </Animated.Text>
@@ -178,11 +180,11 @@ const LoginScreen = () => {
               />
 
               <View style={tailwind.style('flex-row items-center my-6')}>
-                <View style={tailwind.style('flex-1 h-px bg-gray-300')} />
-                <Animated.Text style={tailwind.style('px-4 text-sm text-gray-600')}>
+                <View style={tailwind.style('flex-1 h-px bg-gray-300 dark:bg-grayDark-300')} />
+                <Animated.Text style={tailwind.style('px-4 text-sm text-gray-600 dark:text-grayDark-600')}>
                   OR
                 </Animated.Text>
-                <View style={tailwind.style('flex-1 h-px bg-gray-300')} />
+                <View style={tailwind.style('flex-1 h-px bg-gray-300 dark:bg-grayDark-300')} />
               </View>
             </View>
           )}
@@ -198,21 +200,21 @@ const LoginScreen = () => {
             }}
             render={({ field: { onChange, onBlur, value } }) => (
               <View style={tailwind.style('pt-2 gap-2')}>
-                <Animated.Text style={tailwind.style('font-inter-420-20 text-gray-950')}>
+                <Animated.Text style={tailwind.style('font-inter-420-20 text-gray-950 dark:text-grayDark-950')}>
                   {i18n.t('LOGIN.EMAIL')}
                 </Animated.Text>
                 <TextInput
                   style={[
                     tailwind.style(
                       'text-base font-inter-normal-20 tracking-[0.24px] leading-[20px] android:leading-[18px]',
-                      'py-2 px-3 rounded-xl text-gray-950 bg-blackA-A4',
+                      'py-2 px-3 rounded-xl text-gray-950 dark:text-grayDark-950 bg-blackA-A4',
                       'h-10',
                     ),
                   ]}
                   onBlur={onBlur}
                   onChangeText={onChange}
                   value={value}
-                  placeholderTextColor={tailwind.color('text-gray-900')}
+                  placeholderTextColor={tailwind.color('text-gray-900 dark:text-grayDark-900')}
                   keyboardType="email-address"
                   autoCapitalize="none"
                 />
@@ -237,7 +239,7 @@ const LoginScreen = () => {
             }}
             render={({ field: { onChange, onBlur, value } }) => (
               <View style={tailwind.style('pt-8 gap-2')}>
-                <Animated.Text style={tailwind.style('font-inter-420-20  text-gray-950')}>
+                <Animated.Text style={tailwind.style('font-inter-420-20  text-gray-950 dark:text-grayDark-950')}>
                   {i18n.t('LOGIN.PASSWORD')}
                 </Animated.Text>
                 <View style={tailwind.style('relative')}>
@@ -245,14 +247,14 @@ const LoginScreen = () => {
                     style={[
                       tailwind.style(
                         'text-base font-inter-normal-20 tracking-[0.24px] leading-[20px] android:leading-[18px]',
-                        'py-2 pl-3 pr-10 rounded-xl text-gray-950 bg-blackA-A4',
+                        'py-2 pl-3 pr-10 rounded-xl text-gray-950 dark:text-grayDark-950 bg-blackA-A4',
                         'h-10',
                       ),
                     ]}
                     onBlur={onBlur}
                     onChangeText={onChange}
                     value={value}
-                    placeholderTextColor={tailwind.color('text-gray-500')}
+                    placeholderTextColor={tailwind.color('text-gray-500 dark:text-grayDark-500')}
                     secureTextEntry={!showPassword}
                   />
                   <Pressable
@@ -285,14 +287,14 @@ const LoginScreen = () => {
           <Pressable
             style={tailwind.style('flex-row justify-center items-center mt-6')}
             onPress={openConfigInstallationURL}>
-            <Animated.Text style={tailwind.style('text-sm text-gray-900')}>
+            <Animated.Text style={tailwind.style('text-sm text-gray-900 dark:text-grayDark-900')}>
               {i18n.t('LOGIN.CHANGE_URL')}
             </Animated.Text>
           </Pressable>
           <Pressable
             style={tailwind.style('flex-row justify-center items-center mt-4')}
             onPress={() => languagesModalSheetRef.current?.present()}>
-            <Animated.Text style={tailwind.style('text-sm text-gray-900')}>
+            <Animated.Text style={tailwind.style('text-sm text-gray-900 dark:text-grayDark-900')}>
               {i18n.t('LOGIN.CHANGE_LANGUAGE')}
             </Animated.Text>
           </Pressable>

--- a/src/screens/auth/LoginScreen.tsx
+++ b/src/screens/auth/LoginScreen.tsx
@@ -34,6 +34,7 @@ import {
 import { selectIsLoggingIn } from '@/store/auth/authSelectors';
 import { setLocale } from '@/store/settings/settingsSlice';
 import { useRefsContext } from '@/context/RefsContext';
+import { useTheme } from '@/context';
 import { SsoUtils } from '@/utils/ssoUtils';
 
 type FormData = {
@@ -43,6 +44,7 @@ type FormData = {
 
 const LoginScreen = () => {
   const navigation = useNavigation();
+  const { isDark } = useTheme();
   const [showPassword, setShowPassword] = useState(false);
   const {
     control,
@@ -139,13 +141,13 @@ const LoginScreen = () => {
   };
 
   return (
-    <SafeAreaView edges={['top']} style={tailwind.style('flex-1 bg-white')}>
+    <SafeAreaView edges={['top']} style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
       <StatusBar
         translucent
-        backgroundColor={tailwind.color('bg-white')}
-        barStyle={'dark-content'}
+        backgroundColor={tailwind.color('bg-white dark:bg-grayDark-50')}
+        barStyle={isDark ? 'light-content' : 'dark-content'}
       />
-      <View style={tailwind.style('flex-1 bg-white')}>
+      <View style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
         <KeyboardAwareScrollView
           showsVerticalScrollIndicator={false}
           keyboardShouldPersistTaps="handled"
@@ -158,12 +160,15 @@ const LoginScreen = () => {
             resizeMode="contain"
           />
           <View style={tailwind.style('pt-6 gap-4')}>
-            <Animated.Text style={tailwind.style('text-2xl text-gray-950 font-inter-semibold-20')}>
+            <Animated.Text
+              style={tailwind.style(
+                'text-2xl text-gray-950 dark:text-grayDark-950 font-inter-semibold-20',
+              )}>
               {i18n.t('LOGIN.TITLE')}
             </Animated.Text>
             <Animated.Text
               style={tailwind.style(
-                'font-inter-normal-20 leading-[18px] tracking-[0.32px] text-gray-900',
+                'font-inter-normal-20 leading-[18px] tracking-[0.32px] text-gray-900 dark:text-grayDark-900',
               )}>
               {i18n.t('LOGIN.DESCRIPTION', { baseUrl })}
             </Animated.Text>
@@ -181,11 +186,12 @@ const LoginScreen = () => {
               />
 
               <View style={tailwind.style('flex-row items-center my-6')}>
-                <View style={tailwind.style('flex-1 h-px bg-gray-300')} />
-                <Animated.Text style={tailwind.style('px-4 text-sm text-gray-600')}>
+                <View style={tailwind.style('flex-1 h-px bg-gray-300 dark:bg-grayDark-300')} />
+                <Animated.Text
+                  style={tailwind.style('px-4 text-sm text-gray-600 dark:text-grayDark-600')}>
                   OR
                 </Animated.Text>
-                <View style={tailwind.style('flex-1 h-px bg-gray-300')} />
+                <View style={tailwind.style('flex-1 h-px bg-gray-300 dark:bg-grayDark-300')} />
               </View>
             </View>
           )}
@@ -201,21 +207,22 @@ const LoginScreen = () => {
             }}
             render={({ field: { onChange, onBlur, value } }) => (
               <View style={tailwind.style('pt-2 gap-2')}>
-                <Animated.Text style={tailwind.style('font-inter-420-20 text-gray-950')}>
+                <Animated.Text
+                  style={tailwind.style('font-inter-420-20 text-gray-950 dark:text-grayDark-950')}>
                   {i18n.t('LOGIN.EMAIL')}
                 </Animated.Text>
                 <TextInput
                   style={[
                     tailwind.style(
                       'text-base font-inter-normal-20 tracking-[0.24px] leading-[20px] android:leading-[18px]',
-                      'py-2 px-3 rounded-xl text-gray-950 bg-blackA-A4',
+                      'py-2 px-3 rounded-xl text-gray-950 dark:text-grayDark-950 bg-blackA-A4',
                       'h-10',
                     ),
                   ]}
                   onBlur={onBlur}
                   onChangeText={onChange}
                   value={value}
-                  placeholderTextColor={tailwind.color('text-gray-900')}
+                  placeholderTextColor={tailwind.color('text-gray-900 dark:text-grayDark-900')}
                   keyboardType="email-address"
                   autoCapitalize="none"
                 />
@@ -240,7 +247,8 @@ const LoginScreen = () => {
             }}
             render={({ field: { onChange, onBlur, value } }) => (
               <View style={tailwind.style('pt-8 gap-2')}>
-                <Animated.Text style={tailwind.style('font-inter-420-20  text-gray-950')}>
+                <Animated.Text
+                  style={tailwind.style('font-inter-420-20  text-gray-950 dark:text-grayDark-950')}>
                   {i18n.t('LOGIN.PASSWORD')}
                 </Animated.Text>
                 <View style={tailwind.style('relative')}>
@@ -248,14 +256,14 @@ const LoginScreen = () => {
                     style={[
                       tailwind.style(
                         'text-base font-inter-normal-20 tracking-[0.24px] leading-[20px] android:leading-[18px]',
-                        'py-2 pl-3 pr-10 rounded-xl text-gray-950 bg-blackA-A4',
+                        'py-2 pl-3 pr-10 rounded-xl text-gray-950 dark:text-grayDark-950 bg-blackA-A4',
                         'h-10',
                       ),
                     ]}
                     onBlur={onBlur}
                     onChangeText={onChange}
                     value={value}
-                    placeholderTextColor={tailwind.color('text-gray-500')}
+                    placeholderTextColor={tailwind.color('text-gray-500 dark:text-grayDark-500')}
                     secureTextEntry={!showPassword}
                   />
                   <Pressable
@@ -288,14 +296,14 @@ const LoginScreen = () => {
           <Pressable
             style={tailwind.style('flex-row justify-center items-center mt-6')}
             onPress={openConfigInstallationURL}>
-            <Animated.Text style={tailwind.style('text-sm text-gray-900')}>
+            <Animated.Text style={tailwind.style('text-sm text-gray-900 dark:text-grayDark-900')}>
               {i18n.t('LOGIN.CHANGE_URL')}
             </Animated.Text>
           </Pressable>
           <Pressable
             style={tailwind.style('flex-row justify-center items-center mt-4')}
             onPress={() => languagesModalSheetRef.current?.present()}>
-            <Animated.Text style={tailwind.style('text-sm text-gray-900')}>
+            <Animated.Text style={tailwind.style('text-sm text-gray-900 dark:text-grayDark-900')}>
               {i18n.t('LOGIN.CHANGE_LANGUAGE')}
             </Animated.Text>
           </Pressable>

--- a/src/screens/auth/MFAScreen.tsx
+++ b/src/screens/auth/MFAScreen.tsx
@@ -9,6 +9,7 @@ import type { StatusType } from '@/components-next/verification-code';
 import { tailwind } from '@/theme';
 import { useAppDispatch, useAppSelector } from '@/hooks';
 import { resetSettings } from '@/store/settings/settingsSlice';
+import { useTheme } from '@/context';
 import { authActions } from '@/store/auth/authActions';
 import { resetAuth, clearAuthError } from '@/store/auth/authSlice';
 import i18n from '@/i18n';
@@ -16,6 +17,7 @@ import i18n from '@/i18n';
 const MFAScreen = () => {
   const navigation = useNavigation();
   const dispatch = useAppDispatch();
+  const { isDark } = useTheme();
   const { mfaToken, uiFlags, error } = useAppSelector(state => state.auth);
 
   const [activeTab, setActiveTab] = useState<'authenticator' | 'backup'>('authenticator');
@@ -98,29 +100,29 @@ const MFAScreen = () => {
   };
 
   return (
-    <SafeAreaView style={tailwind.style('flex-1 bg-white')}>
+    <SafeAreaView style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
       <StatusBar
         translucent
-        backgroundColor={tailwind.color('bg-white')}
-        barStyle={'dark-content'}
+        backgroundColor={tailwind.color('bg-white dark:bg-grayDark-50')}
+        barStyle={isDark ? 'light-content' : 'dark-content'}
       />
-      <View style={tailwind.style('flex-1 bg-white')}>
+      <View style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
         <ScrollView
           showsVerticalScrollIndicator={false}
           contentContainerStyle={tailwind.style('px-6 pt-8')}
           keyboardShouldPersistTaps="handled">
           <View style={tailwind.style('pt-6 gap-4')}>
             <Animated.Text
-              style={tailwind.style('text-2xl text-gray-950 font-inter-semibold-20 text-center')}>
+              style={tailwind.style('text-2xl text-gray-950 dark:text-grayDark-950 font-inter-semibold-20 text-center')}>
               {i18n.t('MFA.TITLE')}
             </Animated.Text>
           </View>
 
           {/* Tab Selector */}
-          <View style={tailwind.style('flex-row mt-8 mb-6 bg-gray-100 rounded-lg p-1')}>
+          <View style={tailwind.style('flex-row mt-8 mb-6 bg-gray-100 dark:bg-grayDark-100 rounded-lg p-1')}>
             <Pressable
               style={tailwind.style(
-                `flex-1 py-3 px-4 rounded-md ${activeTab === 'authenticator' ? 'bg-white' : ''}`,
+                `flex-1 py-3 px-4 rounded-md ${activeTab === 'authenticator' ? 'bg-white dark:bg-grayDark-50' : ''}`,
               )}
               onPress={() => {
                 setActiveTab('authenticator');
@@ -131,7 +133,7 @@ const MFAScreen = () => {
               <Text
                 style={tailwind.style(
                   `text-center font-inter-normal-20 ${
-                    activeTab === 'authenticator' ? 'text-gray-950' : 'text-gray-600'
+                    activeTab === 'authenticator' ? 'text-gray-950 dark:text-grayDark-950' : 'text-gray-600 dark:text-grayDark-600'
                   }`,
                 )}>
                 {i18n.t('MFA.TABS.AUTHENTICATOR_APP')}
@@ -139,7 +141,7 @@ const MFAScreen = () => {
             </Pressable>
             <Pressable
               style={tailwind.style(
-                `flex-1 py-3 px-4 rounded-md ${activeTab === 'backup' ? 'bg-white' : ''}`,
+                `flex-1 py-3 px-4 rounded-md ${activeTab === 'backup' ? 'bg-white dark:bg-grayDark-50' : ''}`,
               )}
               onPress={() => {
                 setActiveTab('backup');
@@ -150,7 +152,7 @@ const MFAScreen = () => {
               <Text
                 style={tailwind.style(
                   `text-center font-inter-normal-20 ${
-                    activeTab === 'backup' ? 'text-gray-950' : 'text-gray-600'
+                    activeTab === 'backup' ? 'text-gray-950 dark:text-grayDark-950' : 'text-gray-600 dark:text-grayDark-600'
                   }`,
                 )}>
                 {i18n.t('MFA.TABS.BACKUP_CODE')}
@@ -160,7 +162,7 @@ const MFAScreen = () => {
 
           {/* Code Input */}
           <View style={tailwind.style('mt-4')}>
-            <Text style={[tailwind.style('text-gray-700 font-inter-normal-20 mb-4 pl-2')]}>
+            <Text style={[tailwind.style('text-gray-700 dark:text-grayDark-700 font-inter-normal-20 mb-4 pl-2')]}>
               {activeTab === 'authenticator'
                 ? i18n.t('MFA.INSTRUCTIONS.AUTHENTICATOR')
                 : i18n.t('MFA.INSTRUCTIONS.BACKUP')}
@@ -208,7 +210,7 @@ const MFAScreen = () => {
                   <TextInput
                     ref={backupInputRef}
                     style={tailwind.style(
-                      'w-full p-4 border-2 rounded-lg text-left border-gray-300',
+                      'w-full p-4 border-2 rounded-lg text-left border-gray-300 dark:border-grayDark-300',
                     )}
                     value={backupCode}
                     onChangeText={text => {

--- a/src/screens/auth/MFAScreen.tsx
+++ b/src/screens/auth/MFAScreen.tsx
@@ -9,6 +9,7 @@ import type { StatusType } from '@/components-next/verification-code';
 import { tailwind } from '@/theme';
 import { useAppDispatch, useAppSelector } from '@/hooks';
 import { resetSettings } from '@/store/settings/settingsSlice';
+import { useTheme } from '@/context';
 import { authActions } from '@/store/auth/authActions';
 import { resetAuth, clearAuthError } from '@/store/auth/authSlice';
 import i18n from '@/i18n';
@@ -16,6 +17,7 @@ import i18n from '@/i18n';
 const MFAScreen = () => {
   const navigation = useNavigation();
   const dispatch = useAppDispatch();
+  const { isDark } = useTheme();
   const { mfaToken, uiFlags, error } = useAppSelector(state => state.auth);
 
   const [activeTab, setActiveTab] = useState<'authenticator' | 'backup'>('authenticator');
@@ -98,29 +100,34 @@ const MFAScreen = () => {
   };
 
   return (
-    <SafeAreaView style={tailwind.style('flex-1 bg-white')}>
+    <SafeAreaView style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
       <StatusBar
         translucent
-        backgroundColor={tailwind.color('bg-white')}
-        barStyle={'dark-content'}
+        backgroundColor={tailwind.color('bg-white dark:bg-grayDark-50')}
+        barStyle={isDark ? 'light-content' : 'dark-content'}
       />
-      <View style={tailwind.style('flex-1 bg-white')}>
+      <View style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
         <ScrollView
           showsVerticalScrollIndicator={false}
           contentContainerStyle={tailwind.style('px-6 pt-8')}
           keyboardShouldPersistTaps="handled">
           <View style={tailwind.style('pt-6 gap-4')}>
             <Animated.Text
-              style={tailwind.style('text-2xl text-gray-950 font-inter-semibold-20 text-center')}>
+              style={tailwind.style(
+                'text-2xl text-gray-950 dark:text-grayDark-950 font-inter-semibold-20 text-center',
+              )}>
               {i18n.t('MFA.TITLE')}
             </Animated.Text>
           </View>
 
           {/* Tab Selector */}
-          <View style={tailwind.style('flex-row mt-8 mb-6 bg-gray-100 rounded-lg p-1')}>
+          <View
+            style={tailwind.style(
+              'flex-row mt-8 mb-6 bg-gray-100 dark:bg-grayDark-100 rounded-lg p-1',
+            )}>
             <Pressable
               style={tailwind.style(
-                `flex-1 py-3 px-4 rounded-md ${activeTab === 'authenticator' ? 'bg-white' : ''}`,
+                `flex-1 py-3 px-4 rounded-md ${activeTab === 'authenticator' ? 'bg-white dark:bg-grayDark-50' : ''}`,
               )}
               onPress={() => {
                 setActiveTab('authenticator');
@@ -131,7 +138,9 @@ const MFAScreen = () => {
               <Text
                 style={tailwind.style(
                   `text-center font-inter-normal-20 ${
-                    activeTab === 'authenticator' ? 'text-gray-950' : 'text-gray-600'
+                    activeTab === 'authenticator'
+                      ? 'text-gray-950 dark:text-grayDark-950'
+                      : 'text-gray-600 dark:text-grayDark-600'
                   }`,
                 )}>
                 {i18n.t('MFA.TABS.AUTHENTICATOR_APP')}
@@ -139,7 +148,7 @@ const MFAScreen = () => {
             </Pressable>
             <Pressable
               style={tailwind.style(
-                `flex-1 py-3 px-4 rounded-md ${activeTab === 'backup' ? 'bg-white' : ''}`,
+                `flex-1 py-3 px-4 rounded-md ${activeTab === 'backup' ? 'bg-white dark:bg-grayDark-50' : ''}`,
               )}
               onPress={() => {
                 setActiveTab('backup');
@@ -150,7 +159,9 @@ const MFAScreen = () => {
               <Text
                 style={tailwind.style(
                   `text-center font-inter-normal-20 ${
-                    activeTab === 'backup' ? 'text-gray-950' : 'text-gray-600'
+                    activeTab === 'backup'
+                      ? 'text-gray-950 dark:text-grayDark-950'
+                      : 'text-gray-600 dark:text-grayDark-600'
                   }`,
                 )}>
                 {i18n.t('MFA.TABS.BACKUP_CODE')}
@@ -160,7 +171,12 @@ const MFAScreen = () => {
 
           {/* Code Input */}
           <View style={tailwind.style('mt-4')}>
-            <Text style={[tailwind.style('text-gray-700 font-inter-normal-20 mb-4 pl-2')]}>
+            <Text
+              style={[
+                tailwind.style(
+                  'text-gray-700 dark:text-grayDark-700 font-inter-normal-20 mb-4 pl-2',
+                ),
+              ]}>
               {activeTab === 'authenticator'
                 ? i18n.t('MFA.INSTRUCTIONS.AUTHENTICATOR')
                 : i18n.t('MFA.INSTRUCTIONS.BACKUP')}
@@ -208,7 +224,7 @@ const MFAScreen = () => {
                   <TextInput
                     ref={backupInputRef}
                     style={tailwind.style(
-                      'w-full p-4 border-2 rounded-lg text-left border-gray-300',
+                      'w-full p-4 border-2 rounded-lg text-left border-gray-300 dark:border-grayDark-300',
                     )}
                     value={backupCode}
                     onChangeText={text => {

--- a/src/screens/chat-screen/ChatScreen.tsx
+++ b/src/screens/chat-screen/ChatScreen.tsx
@@ -138,7 +138,7 @@ const ChatScreen = (props: ChatScreenProps) => {
 
   if (conversation) {
     return (
-      <SafeAreaView edges={['top']} style={tailwind.style('flex-1 bg-white')}>
+      <SafeAreaView edges={['top']} style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
         <LightBoxProvider>
           <ChatWindowProvider conversationId={conversationId}>
             <ChatScreenWrapper {...props} />
@@ -160,7 +160,7 @@ const ChatScreen = (props: ChatScreenProps) => {
 
   if (conversationError || !conversation) {
     return (
-      <SafeAreaView edges={['top']} style={tailwind.style('flex-1 bg-white')}>
+      <SafeAreaView edges={['top']} style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
         <Animated.View
           style={tailwind.style(
             'flex-1 items-center justify-center gap-8 px-4',
@@ -170,13 +170,13 @@ const ChatScreen = (props: ChatScreenProps) => {
           <Animated.View style={tailwind.style('flex items-center justify-center gap-4')}>
             <Animated.Text
               style={tailwind.style(
-                'text-2xl font-inter-420-20 text-gray-950 font-inter-semibold-20',
+                'text-2xl font-inter-420-20 text-gray-950 dark:text-grayDark-950 font-inter-semibold-20',
               )}>
               {conversationError || i18n.t('CONVERSATION.NOT_FOUND.TITLE')}
             </Animated.Text>
             <Animated.Text
               style={tailwind.style(
-                'font-inter-normal-20 font-base leading-[18px] tracking-[0.32px] text-gray-950 text-center',
+                'font-inter-normal-20 font-base leading-[18px] tracking-[0.32px] text-gray-950 dark:text-grayDark-950 text-center',
               )}>
               {i18n.t('CONVERSATION.NOT_FOUND.DESCRIPTION')}
             </Animated.Text>
@@ -190,7 +190,7 @@ const ChatScreen = (props: ChatScreenProps) => {
             <Pressable
               style={tailwind.style('flex-row justify-center items-center')}
               onPress={handleBackPress}>
-              <Animated.Text style={tailwind.style('text-base font-inter-medium-24 text-gray-900')}>
+              <Animated.Text style={tailwind.style('text-base font-inter-medium-24 text-gray-900 dark:text-grayDark-900')}>
                 {i18n.t('CONVERSATION.NOT_FOUND.BACK_TO_HOME')}
               </Animated.Text>
             </Pressable>

--- a/src/screens/chat-screen/ChatScreen.tsx
+++ b/src/screens/chat-screen/ChatScreen.tsx
@@ -138,7 +138,7 @@ const ChatScreen = (props: ChatScreenProps) => {
   if (conversation) {
     const { messageId } = props.route.params;
     return (
-      <SafeAreaView edges={['top']} style={tailwind.style('flex-1 bg-white')}>
+      <SafeAreaView edges={['top']} style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
         <ChatWindowProvider conversationId={conversationId} messageId={messageId}>
           <ChatScreenWrapper {...props} />
         </ChatWindowProvider>
@@ -158,7 +158,7 @@ const ChatScreen = (props: ChatScreenProps) => {
 
   if (conversationError || !conversation) {
     return (
-      <SafeAreaView edges={['top']} style={tailwind.style('flex-1 bg-white')}>
+      <SafeAreaView edges={['top']} style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
         <Animated.View
           style={tailwind.style(
             'flex-1 items-center justify-center gap-8 px-4',
@@ -168,13 +168,13 @@ const ChatScreen = (props: ChatScreenProps) => {
           <Animated.View style={tailwind.style('flex items-center justify-center gap-4')}>
             <Animated.Text
               style={tailwind.style(
-                'text-2xl font-inter-420-20 text-gray-950 font-inter-semibold-20',
+                'text-2xl font-inter-420-20 text-gray-950 dark:text-grayDark-950 font-inter-semibold-20',
               )}>
               {conversationError || i18n.t('CONVERSATION.NOT_FOUND.TITLE')}
             </Animated.Text>
             <Animated.Text
               style={tailwind.style(
-                'font-inter-normal-20 font-base leading-[18px] tracking-[0.32px] text-gray-950 text-center',
+                'font-inter-normal-20 font-base leading-[18px] tracking-[0.32px] text-gray-950 dark:text-grayDark-950 text-center',
               )}>
               {i18n.t('CONVERSATION.NOT_FOUND.DESCRIPTION')}
             </Animated.Text>
@@ -188,7 +188,10 @@ const ChatScreen = (props: ChatScreenProps) => {
             <Pressable
               style={tailwind.style('flex-row justify-center items-center')}
               onPress={handleBackPress}>
-              <Animated.Text style={tailwind.style('text-base font-inter-medium-24 text-gray-900')}>
+              <Animated.Text
+                style={tailwind.style(
+                  'text-base font-inter-medium-24 text-gray-900 dark:text-grayDark-900',
+                )}>
                 {i18n.t('CONVERSATION.NOT_FOUND.BACK_TO_HOME')}
               </Animated.Text>
             </Pressable>

--- a/src/screens/chat-screen/components/chat-header/ChatHeader.tsx
+++ b/src/screens/chat-screen/components/chat-header/ChatHeader.tsx
@@ -72,7 +72,7 @@ export const ChatHeader = ({
               <Animated.Text
                 numberOfLines={1}
                 style={tailwind.style(
-                  'text-[17px] font-inter-medium-24 tracking-[0.32px] text-gray-950',
+                  'text-[17px] font-inter-medium-24 tracking-[0.32px] text-gray-950 dark:text-grayDark-950',
                 )}>
                 {name}
               </Animated.Text>

--- a/src/screens/chat-screen/components/chat-header/DropdownMenu.tsx
+++ b/src/screens/chat-screen/components/chat-header/DropdownMenu.tsx
@@ -35,7 +35,7 @@ const DropdownMenuItem = DropdownMenu.create<React.ComponentProps<typeof Dropdow
       <View style={tailwind.style('flex flex-row items-center')}>
         <DropdownMenu.ItemTitle
           style={tailwind.style(
-            'text-base text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px] capitalize',
+            'text-base text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px] capitalize',
           )}>
           {props.children}
         </DropdownMenu.ItemTitle>
@@ -144,12 +144,12 @@ export const ChatDropdownMenu = (props: PropsWithChildren<ChatDropdownMenuProps>
                       style={tailwind.style(
                         'flex-1 flex-row justify-between py-[11px] pr-3',
                         index !== dropdownMenuList.length - 1
-                          ? 'border-b-[1px] border-blackA-A3'
+                          ? 'border-b-[1px] border-blackA-A3 dark:border-grayDark-200'
                           : '',
                       )}>
                       <Animated.Text
                         style={tailwind.style(
-                          'text-base text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px] capitalize',
+                          'text-base text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px] capitalize',
                         )}>
                         {option.title}
                       </Animated.Text>

--- a/src/screens/chat-screen/components/chat-header/SLAEventItem.tsx
+++ b/src/screens/chat-screen/components/chat-header/SLAEventItem.tsx
@@ -17,7 +17,7 @@ export const SlaEvents = ({ label, items }: SlaEventsProps) => {
     <Animated.View style={tailwind.style('flex flex-row justify-between')}>
       <Text
         style={tailwind.style(
-          'text-sm  text-gray-950 font-inter-medium-24 leading-[21px] tracking-[0.16px]',
+          'text-sm  text-gray-950 dark:text-grayDark-950 font-inter-medium-24 leading-[21px] tracking-[0.16px]',
         )}>
         {label}
       </Text>
@@ -26,7 +26,7 @@ export const SlaEvents = ({ label, items }: SlaEventsProps) => {
           <Text
             key={item.id}
             style={tailwind.style(
-              'text-sm  text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
+              'text-sm  text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
             )}>
             {formatDate(item.createdAt)}
           </Text>

--- a/src/screens/chat-screen/components/chat-header/SlaEvents.tsx
+++ b/src/screens/chat-screen/components/chat-header/SlaEvents.tsx
@@ -20,14 +20,14 @@ export const SlaEvents = ({ slaEvents, statusText }: SlaEventsProps) => {
     <Animated.View style={tailwind.style('py-6 px-6 gap-3')}>
       <Text
         style={tailwind.style(
-          'text-[17px]  text-gray-950 font-inter-medium-24 leading-[21px] tracking-[0.16px]',
+          'text-[17px]  text-gray-950 dark:text-grayDark-950 font-inter-medium-24 leading-[21px] tracking-[0.16px]',
         )}>
         {statusText}
       </Text>
 
       <Text
         style={tailwind.style(
-          'text-md  text-gray-900 font-inter-medium-24 leading-[21px] tracking-[0.16px]',
+          'text-md  text-gray-900 dark:text-grayDark-900 font-inter-medium-24 leading-[21px] tracking-[0.16px]',
         )}>
         {i18n.t('SLA.MISSES.TITLE')}
       </Text>

--- a/src/screens/chat-screen/components/macros/MacroDetails.tsx
+++ b/src/screens/chat-screen/components/macros/MacroDetails.tsx
@@ -89,7 +89,7 @@ const MacroDetails = ({ macro, onBack, onClose }: MacroDetailsProps) => {
         <Animated.View style={animatedStyle}>
           <Pressable
             style={tailwind.style(
-              'px-3 py-[7px] rounded-lg bg-gray-100 flex flex-row items-center justify-center min-w-[60px] min-h-[32px]',
+              'px-3 py-[7px] rounded-lg bg-gray-100 dark:bg-grayDark-100 flex flex-row items-center justify-center min-w-[60px] min-h-[32px]',
             )}
             onPress={onPress}
             {...handlers}>
@@ -98,7 +98,7 @@ const MacroDetails = ({ macro, onBack, onClose }: MacroDetailsProps) => {
             ) : (
               <Animated.Text
                 style={tailwind.style(
-                  'text-sm font-inter-580-24 leading-[16px] tracking-[0.24px] capitalize text-gray-900',
+                  'text-sm font-inter-580-24 leading-[16px] tracking-[0.24px] capitalize text-gray-900 dark:text-grayDark-900',
                 )}>
                 {i18n.t('MACRO.ACTIONS.RUN')}
               </Animated.Text>
@@ -115,17 +115,17 @@ const MacroDetails = ({ macro, onBack, onClose }: MacroDetailsProps) => {
               {macro.actions && index !== macro.actions.length - 1 && (
                 <View
                   style={tailwind.style(
-                    'absolute top-[14px] bottom-0 left-[5px] w-[1px] bg-gray-200',
+                    'absolute top-[14px] bottom-0 left-[5px] w-[1px] bg-gray-200 dark:bg-grayDark-200',
                   )}
                 />
               )}
               <View
                 style={tailwind.style(
-                  'absolute left-0 top-[2px] w-3 h-3 rounded-full bg-gray-300 border-2 border-gray-300',
+                  'absolute left-0 top-[2px] w-3 h-3 rounded-full bg-gray-300 dark:bg-grayDark-300 border-2 border-gray-300 dark:border-grayDark-300',
                 )}
               />
               <Animated.Text style={tailwind.style('mb-1')}>{action.actionName}</Animated.Text>
-              <Animated.Text style={tailwind.style('text-sm text-gray-900')}>
+              <Animated.Text style={tailwind.style('text-sm text-gray-900 dark:text-grayDark-900')}>
                 {action.actionValue}
               </Animated.Text>
             </View>

--- a/src/screens/chat-screen/components/macros/MacroStack.tsx
+++ b/src/screens/chat-screen/components/macros/MacroStack.tsx
@@ -22,7 +22,7 @@ const MacroStack = (props: MacroStackProps) => {
           isInsideBottomSheet ? 'py-1' : '',
           'flex-1 items-center justify-center',
         )}>
-        <Animated.Text style={tailwind.style('pt-6 text-md  tracking-[0.32px] text-gray-800')}>
+        <Animated.Text style={tailwind.style('pt-6 text-md  tracking-[0.32px] text-gray-800 dark:text-grayDark-800')}>
           {i18n.t('MACRO.NO_MACROS')}
         </Animated.Text>
       </Animated.View>

--- a/src/screens/chat-screen/components/macros/MacroStack.tsx
+++ b/src/screens/chat-screen/components/macros/MacroStack.tsx
@@ -22,7 +22,10 @@ const MacroStack = (props: MacroStackProps) => {
           isInsideBottomSheet ? 'py-1' : '',
           'flex-1 items-center justify-center',
         )}>
-        <Animated.Text style={tailwind.style('pt-6 text-md  tracking-[0.32px] text-gray-800')}>
+        <Animated.Text
+          style={tailwind.style(
+            'pt-6 text-md  tracking-[0.32px] text-gray-800 dark:text-grayDark-800',
+          )}>
           {i18n.t('MACRO.NO_MACROS')}
         </Animated.Text>
       </Animated.View>

--- a/src/screens/chat-screen/components/macros/MacrosList.tsx
+++ b/src/screens/chat-screen/components/macros/MacrosList.tsx
@@ -54,7 +54,7 @@ export const MacrosList = ({ conversationId }: { conversationId: number }) => {
                 <View style={tailwind.style('px-4 pt-1 pb-4 items-center')}>
                   <Animated.Text
                     style={tailwind.style(
-                      'text-gray-700 font-inter-580-24 leading-[17px] tracking-[0.32px]',
+                      'text-gray-700 dark:text-grayDark-700 font-inter-580-24 leading-[17px] tracking-[0.32px]',
                     )}>
                     {i18n.t('MACRO.SELECT_MACRO')}
                   </Animated.Text>

--- a/src/screens/chat-screen/components/message-components/AttachedMedia.tsx
+++ b/src/screens/chat-screen/components/message-components/AttachedMedia.tsx
@@ -207,7 +207,7 @@ const AttachedFile = (props: AttachedFileProps) => {
             ellipsizeMode={'middle'}
             style={[
               tailwind.style(
-                'text-base tracking-[0.32px] leading-[22px] font-inter-normal-20 pt-1 text-gray-950',
+                'text-base tracking-[0.32px] leading-[22px] font-inter-normal-20 pt-1 text-gray-950 dark:text-grayDark-950',
               ),
             ]}>
             {item.fileName}

--- a/src/screens/chat-screen/components/message-components/AudioBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioBubble.tsx
@@ -149,7 +149,7 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
 
   const sliderProps = useMemo(
     () => ({
-      trackColor: variant === MESSAGE_VARIANTS.USER ? 'bg-whiteA-A9' : 'bg-gray-500',
+      trackColor: variant === MESSAGE_VARIANTS.USER ? 'bg-whiteA-A9' : 'bg-gray-500 dark:bg-grayDark-500',
       filledTrackColor: variant === MESSAGE_VARIANTS.USER ? 'bg-white' : 'bg-blue-700',
       knobStyle: variant === MESSAGE_VARIANTS.USER ? 'border-blue-300' : 'border-blue-700',
       manualSeekTo,

--- a/src/screens/chat-screen/components/message-components/AudioBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioBubble.tsx
@@ -149,7 +149,8 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
 
   const sliderProps = useMemo(
     () => ({
-      trackColor: variant === MESSAGE_VARIANTS.USER ? 'bg-whiteA-A9' : 'bg-gray-500',
+      trackColor:
+        variant === MESSAGE_VARIANTS.USER ? 'bg-whiteA-A9' : 'bg-gray-500 dark:bg-grayDark-500',
       filledTrackColor: variant === MESSAGE_VARIANTS.USER ? 'bg-white' : 'bg-blue-700',
       knobStyle: variant === MESSAGE_VARIANTS.USER ? 'border-blue-300' : 'border-blue-700',
       manualSeekTo,

--- a/src/screens/chat-screen/components/message-components/AudioCell.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioCell.tsx
@@ -174,7 +174,7 @@ export const AudioPlayer = (props: AudioPlayerProps) => {
         )}
       </Pressable>
       <Slider
-        trackColor={isIncoming ? 'bg-whiteA-A9' : 'bg-gray-500'}
+        trackColor={isIncoming ? 'bg-whiteA-A9' : 'bg-gray-500 dark:bg-grayDark-500'}
         filledTrackColor={isIncoming ? 'bg-white' : 'bg-blue-700'}
         knobStyle={isIncoming ? 'border-blue-300' : 'border-blue-700'}
         {...{ manualSeekTo, currentPosition, totalDuration, pauseAudio }}
@@ -223,7 +223,7 @@ export const AudioCell: React.FC<AudioCellProps> = props => {
               tailwind.style(
                 'relative flex flex-row items-center w-[300px] pl-3 pr-2.5 py-2 rounded-2xl overflow-hidden',
                 isIncoming ? 'bg-blue-700' : '',
-                isOutgoing ? 'bg-gray-100' : '',
+                isOutgoing ? 'bg-gray-100 dark:bg-grayDark-100' : '',
                 shouldRenderAvatar
                   ? isOutgoing
                     ? 'rounded-br-none'
@@ -242,7 +242,7 @@ export const AudioCell: React.FC<AudioCellProps> = props => {
                 style={tailwind.style(
                   'text-xs font-inter-420-20 tracking-[0.32px] leading-[14px] pr-1',
                   isIncoming ? 'text-whiteA-A11' : '',
-                  isOutgoing ? 'text-gray-700' : '',
+                  isOutgoing ? 'text-gray-700 dark:text-grayDark-700' : '',
                 )}>
                 {unixTimestampToReadableTime(timeStamp)}
               </Text>

--- a/src/screens/chat-screen/components/message-components/BotTextCell.tsx
+++ b/src/screens/chat-screen/components/message-components/BotTextCell.tsx
@@ -68,7 +68,7 @@ export const BotTextCell = (props: BotTextCellProps) => {
     <Animated.View
       style={[
         tailwind.style(
-          'relative max-w-[300px] pl-3 pr-2.5 py-2 rounded-2xl overflow-hidden bg-blue-100',
+          'relative max-w-[300px] pl-3 pr-2.5 py-2 rounded-2xl overflow-hidden bg-blue-100 dark:bg-grayDark-100',
           `max-w-[${TEXT_MAX_WIDTH}px]`,
           // singleLineShortText ? "flex flex-row" : "",
           isAvatarRendered ? 'rounded-br-none' : '',
@@ -80,7 +80,7 @@ export const BotTextCell = (props: BotTextCellProps) => {
           "text-base tracking-[0.32px] leading-[22px] font-inter-normal-20 text-gray-950",
         )}
       >
-        {text} 
+        {text}
       </Text> */}
       <MarkdownDisplay isBotText messageContent={text} />
 
@@ -92,7 +92,7 @@ export const BotTextCell = (props: BotTextCellProps) => {
           // multiLineShortText ? " absolute bottom-0.5 right-2.5" : "",
         )}>
         <Text
-          style={tailwind.style('text-xs font-inter-420-20 tracking-[0.32px] pr-1 text-gray-700')}>
+          style={tailwind.style('text-xs font-inter-420-20 tracking-[0.32px] pr-1 text-gray-700 dark:text-grayDark-700')}>
           {unixTimestampToReadableTime(timeStamp)}
         </Text>
         <DeliveryStatus

--- a/src/screens/chat-screen/components/message-components/BotTextCell.tsx
+++ b/src/screens/chat-screen/components/message-components/BotTextCell.tsx
@@ -68,7 +68,7 @@ export const BotTextCell = (props: BotTextCellProps) => {
     <Animated.View
       style={[
         tailwind.style(
-          'relative max-w-[300px] pl-3 pr-2.5 py-2 rounded-2xl overflow-hidden bg-blue-100',
+          'relative max-w-[300px] pl-3 pr-2.5 py-2 rounded-2xl overflow-hidden bg-blue-100 dark:bg-grayDark-100',
           `max-w-[${TEXT_MAX_WIDTH}px]`,
           // singleLineShortText ? "flex flex-row" : "",
           isAvatarRendered ? 'rounded-br-none' : '',
@@ -80,7 +80,7 @@ export const BotTextCell = (props: BotTextCellProps) => {
           "text-base tracking-[0.32px] leading-[22px] font-inter-normal-20 text-gray-950",
         )}
       >
-        {text} 
+        {text}
       </Text> */}
       <MarkdownDisplay isBotText messageContent={text} />
 
@@ -92,7 +92,9 @@ export const BotTextCell = (props: BotTextCellProps) => {
           // multiLineShortText ? " absolute bottom-0.5 right-2.5" : "",
         )}>
         <Text
-          style={tailwind.style('text-xs font-inter-420-20 tracking-[0.32px] pr-1 text-gray-700')}>
+          style={tailwind.style(
+            'text-xs font-inter-420-20 tracking-[0.32px] pr-1 text-gray-700 dark:text-grayDark-700',
+          )}>
           {unixTimestampToReadableTime(timeStamp)}
         </Text>
         <DeliveryStatus

--- a/src/screens/chat-screen/components/message-components/CommandOptionsMenu.tsx
+++ b/src/screens/chat-screen/components/message-components/CommandOptionsMenu.tsx
@@ -205,7 +205,7 @@ const MenuOption = (props: MenuOptionProps) => {
           </Animated.View>
           <Text
             style={tailwind.style(
-              'text-base font-inter-normal-20 leading-[18px] tracking-[0.24px] text-gray-950 pl-5',
+              'text-base font-inter-normal-20 leading-[18px] tracking-[0.24px] text-gray-950 dark:text-grayDark-950 pl-5',
             )}>
             {menuOption.title}
           </Text>

--- a/src/screens/chat-screen/components/message-components/CommandOptionsMenu.tsx
+++ b/src/screens/chat-screen/components/message-components/CommandOptionsMenu.tsx
@@ -211,7 +211,7 @@ const MenuOption = (props: MenuOptionProps) => {
           </Animated.View>
           <Text
             style={tailwind.style(
-              'text-base font-inter-normal-20 leading-[18px] tracking-[0.24px] text-gray-950 pl-5',
+              'text-base font-inter-normal-20 leading-[18px] tracking-[0.24px] text-gray-950 dark:text-grayDark-950 pl-5',
             )}>
             {menuOption.title}
           </Text>

--- a/src/screens/chat-screen/components/message-components/ComposedBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/ComposedBubble.tsx
@@ -85,11 +85,11 @@ export const ComposedBubble = (props: ComposedBubbleProps) => {
                 <Animated.View
                   key={attachment.fileType + index}
                   style={tailwind.style(
-                    'flex flex-row items-center justify-center py-8 bg-slate-100 gap-1 rounded-lg',
+                    'flex flex-row items-center justify-center py-8 bg-slate-100 dark:bg-grayDark-100 gap-1 rounded-lg',
                   )}>
                   <Icon icon={<FileErrorIcon fill={tailwind.color('text-gray-900')} />} />
                   <Animated.Text
-                    style={tailwind.style('text-cxs font-inter-420-20 text-gray-900 mt-[1px]')}>
+                    style={tailwind.style('text-cxs font-inter-420-20 text-gray-900 dark:text-grayDark-900 mt-[1px]')}>
                     {i18n.t('CONVERSATION.STORY_NOT_AVAILABLE')}
                   </Animated.Text>
                 </Animated.View>

--- a/src/screens/chat-screen/components/message-components/ComposedBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/ComposedBubble.tsx
@@ -85,11 +85,13 @@ export const ComposedBubble = (props: ComposedBubbleProps) => {
                 <Animated.View
                   key={attachment.fileType + index}
                   style={tailwind.style(
-                    'flex flex-row items-center justify-center py-8 bg-slate-100 gap-1 rounded-lg',
+                    'flex flex-row items-center justify-center py-8 bg-slate-100 dark:bg-grayDark-100 gap-1 rounded-lg',
                   )}>
                   <Icon icon={<FileErrorIcon fill={tailwind.color('text-gray-900')} />} />
                   <Animated.Text
-                    style={tailwind.style('text-cxs font-inter-420-20 text-gray-900 mt-[1px]')}>
+                    style={tailwind.style(
+                      'text-cxs font-inter-420-20 text-gray-900 dark:text-grayDark-900 mt-[1px]',
+                    )}>
                     {i18n.t('CONVERSATION.STORY_NOT_AVAILABLE')}
                   </Animated.Text>
                 </Animated.View>

--- a/src/screens/chat-screen/components/message-components/ComposedCell.tsx
+++ b/src/screens/chat-screen/components/message-components/ComposedCell.tsx
@@ -114,8 +114,8 @@ export const ComposedCell = (props: ComposedCellProps) => {
                 'relative pl-3 pr-2.5 py-2 h-full rounded-2xl overflow-hidden',
                 isEmailMessage ? `max-w-[${EMAIL_MESSAGE_WIDTH}px]` : `max-w-[${TEXT_MAX_WIDTH}px]`,
                 isIncoming ? 'bg-blue-700' : '',
-                isOutgoing ? 'bg-gray-100' : '',
-                isPrivate ? ' bg-amber-100' : '',
+                isOutgoing ? 'bg-gray-100 dark:bg-grayDark-100' : '',
+                isPrivate ? ' bg-amber-100 dark:bg-grayDark-100' : '',
                 shouldRenderAvatar
                   ? isOutgoing
                     ? 'rounded-br-none'
@@ -156,12 +156,12 @@ export const ComposedCell = (props: ComposedCellProps) => {
                       return isAnInstagramStory && isInstagramStoryExpired ? (
                         <Animated.View
                           style={tailwind.style(
-                            'flex flex-row items-center justify-center py-8 bg-slate-100 gap-1',
+                            'flex flex-row items-center justify-center py-8 bg-slate-100 dark:bg-grayDark-100 gap-1',
                           )}>
                           <Icon icon={<FileErrorIcon fill={tailwind.color('text-gray-900')} />} />
                           <Animated.Text
                             style={tailwind.style(
-                              'text-cxs font-inter-420-20 text-gray-900 mt-[1px]',
+                              'text-cxs font-inter-420-20 text-gray-900 dark:text-grayDark-900 mt-[1px]',
                             )}>
                             {i18n.t('CONVERSATION.STORY_NOT_AVAILABLE')}
                           </Animated.Text>
@@ -216,7 +216,7 @@ export const ComposedCell = (props: ComposedCellProps) => {
                     style={tailwind.style(
                       'text-xs font-inter-420-20 tracking-[0.32px] pr-1',
                       isIncoming ? 'text-whiteA-A11' : '',
-                      isOutgoing ? 'text-gray-700' : '',
+                      isOutgoing ? 'text-gray-700 dark:text-grayDark-700' : '',
                       isPrivate ? 'pl-1' : '',
                     )}>
                     {unixTimestampToReadableTime(createdAt)}

--- a/src/screens/chat-screen/components/message-components/Email.tsx
+++ b/src/screens/chat-screen/components/message-components/Email.tsx
@@ -54,7 +54,7 @@ export const Email = (props: EmailProps) => {
     <Animated.View
       style={[
         tailwind.style(
-          'relative pl-3 pr-2.5 py-2 rounded-2xl overflow-hidden bg-gray-100',
+          'relative pl-3 pr-2.5 py-2 rounded-2xl overflow-hidden bg-gray-100 dark:bg-grayDark-100',
           `max-w-[${WIDTH}px]`,
           isMessageFailed ? 'bg-ruby-700' : '',
           isAvatarRendered
@@ -67,7 +67,7 @@ export const Email = (props: EmailProps) => {
         ),
       ]}>
       {contentAttributes && <EmailMeta {...{ contentAttributes, sender }} />}
-      <Animated.View style={[tailwind.style('flex bg-white rounded-2xl w-full')]}>
+      <Animated.View style={[tailwind.style('flex bg-white dark:bg-grayDark-50 rounded-2xl w-full')]}>
         <Animated.View style={tailwind.style('px-4 py-2 w-full')}>
           <AutoHeightWebView
             style={{ width: '100%', minHeight: 1, minWidth: '100%' }}
@@ -76,7 +76,7 @@ export const Email = (props: EmailProps) => {
         * {
           font-family: system,-apple-system,".SFNSText-Regular","San Francisco",Roboto,"Segoe UI","Helvetica Neue","Lucida Grande",sans-serif;
           font-size: 14px;
-        } 
+        }
         img{
           max-width: 100% !important;
         }
@@ -92,7 +92,7 @@ export const Email = (props: EmailProps) => {
         style={tailwind.style('h-[21px] pt-[6px] pb-0.5 flex flex-row items-center justify-end')}>
         <Text
           style={tailwind.style(
-            'text-xs font-inter-420-20 tracking-[0.32px] pr-1 text-gray-700',
+            'text-xs font-inter-420-20 tracking-[0.32px] pr-1 text-gray-700 dark:text-grayDark-700',
             isMessageFailed ? 'text-whiteA-A11' : '',
           )}>
           {unixTimestampToReadableTime(timeStamp)}

--- a/src/screens/chat-screen/components/message-components/Email.tsx
+++ b/src/screens/chat-screen/components/message-components/Email.tsx
@@ -54,7 +54,7 @@ export const Email = (props: EmailProps) => {
     <Animated.View
       style={[
         tailwind.style(
-          'relative pl-3 pr-2.5 py-2 rounded-2xl overflow-hidden bg-gray-100',
+          'relative pl-3 pr-2.5 py-2 rounded-2xl overflow-hidden bg-gray-100 dark:bg-grayDark-100',
           `max-w-[${WIDTH}px]`,
           isMessageFailed ? 'bg-ruby-700' : '',
           isAvatarRendered
@@ -67,7 +67,8 @@ export const Email = (props: EmailProps) => {
         ),
       ]}>
       {contentAttributes && <EmailMeta {...{ contentAttributes, sender }} />}
-      <Animated.View style={[tailwind.style('flex bg-white rounded-2xl w-full')]}>
+      <Animated.View
+        style={[tailwind.style('flex bg-white dark:bg-grayDark-50 rounded-2xl w-full')]}>
         <Animated.View style={tailwind.style('px-4 py-2 w-full')}>
           <AutoHeightWebView
             style={{ width: '100%', minHeight: 1, minWidth: '100%' }}
@@ -76,7 +77,7 @@ export const Email = (props: EmailProps) => {
         * {
           font-family: system,-apple-system,".SFNSText-Regular","San Francisco",Roboto,"Segoe UI","Helvetica Neue","Lucida Grande",sans-serif;
           font-size: 14px;
-        } 
+        }
         img{
           max-width: 100% !important;
         }
@@ -92,7 +93,7 @@ export const Email = (props: EmailProps) => {
         style={tailwind.style('h-[21px] pt-[6px] pb-0.5 flex flex-row items-center justify-end')}>
         <Text
           style={tailwind.style(
-            'text-xs font-inter-420-20 tracking-[0.32px] pr-1 text-gray-700',
+            'text-xs font-inter-420-20 tracking-[0.32px] pr-1 text-gray-700 dark:text-grayDark-700',
             isMessageFailed ? 'text-whiteA-A11' : '',
           )}>
           {unixTimestampToReadableTime(timeStamp)}

--- a/src/screens/chat-screen/components/message-components/EmailMeta.tsx
+++ b/src/screens/chat-screen/components/message-components/EmailMeta.tsx
@@ -36,39 +36,39 @@ export const EmailMeta = (props: EmailMetaProps) => {
     <Animated.View style={tailwind.style('flex flex-col gap-1')}>
       {fromEmail[0] && (
         <Animated.Text
-          style={tailwind.style('text-md text-gray-950 font-inter-normal-20 tracking-[0.16px]')}>
+          style={tailwind.style('text-md text-gray-950 dark:text-grayDark-950 font-inter-normal-20 tracking-[0.16px]')}>
           {senderName} &lt;{fromEmail[0]}&gt;
         </Animated.Text>
       )}
 
       {toEmail.length > 0 && (
         <Animated.Text
-          style={tailwind.style('text-md text-gray-900 font-inter-normal-20 tracking-[0.32px]')}>
+          style={tailwind.style('text-md text-gray-900 dark:text-grayDark-900 font-inter-normal-20 tracking-[0.32px]')}>
           {i18n.t('CONVERSATION.EMAIL_HEADER.TO')}: {toEmail.join(', ')}
         </Animated.Text>
       )}
 
       {ccEmail.length > 0 && (
         <Animated.Text
-          style={tailwind.style(' text-md text-gray-900 font-inter-normal-20 tracking-[0.32px]')}>
+          style={tailwind.style(' text-md text-gray-900 dark:text-grayDark-900 font-inter-normal-20 tracking-[0.32px]')}>
           {i18n.t('CONVERSATION.EMAIL_HEADER.CC')}: {ccEmail.join(', ')}
         </Animated.Text>
       )}
 
       {bccEmail.length > 0 && (
         <Animated.Text
-          style={tailwind.style(' text-md text-gray-900 font-inter-normal-20 tracking-[0.32px]')}>
+          style={tailwind.style(' text-md text-gray-900 dark:text-grayDark-900 font-inter-normal-20 tracking-[0.32px]')}>
           {i18n.t('CONVERSATION.EMAIL_HEADER.BCC')}: {bccEmail}
         </Animated.Text>
       )}
 
       {subject && (
         <Animated.Text
-          style={tailwind.style('text-md text-gray-950 font-inter-normal-20 tracking-[0.32px]')}>
+          style={tailwind.style('text-md text-gray-950 dark:text-grayDark-950 font-inter-normal-20 tracking-[0.32px]')}>
           {i18n.t('CONVERSATION.EMAIL_HEADER.SUBJECT')}: {subject}
         </Animated.Text>
       )}
-      <Animated.View style={tailwind.style('h-[1px] my-2 bg-gray-300')} />
+      <Animated.View style={tailwind.style('h-[1px] my-2 bg-gray-300 dark:bg-grayDark-300')} />
     </Animated.View>
   );
 };

--- a/src/screens/chat-screen/components/message-components/EmailMeta.tsx
+++ b/src/screens/chat-screen/components/message-components/EmailMeta.tsx
@@ -36,39 +36,49 @@ export const EmailMeta = (props: EmailMetaProps) => {
     <Animated.View style={tailwind.style('flex flex-col gap-1')}>
       {fromEmail[0] && (
         <Animated.Text
-          style={tailwind.style('text-md text-gray-950 font-inter-normal-20 tracking-[0.16px]')}>
+          style={tailwind.style(
+            'text-md text-gray-950 dark:text-grayDark-950 font-inter-normal-20 tracking-[0.16px]',
+          )}>
           {senderName} &lt;{fromEmail[0]}&gt;
         </Animated.Text>
       )}
 
       {toEmail.length > 0 && (
         <Animated.Text
-          style={tailwind.style('text-md text-gray-900 font-inter-normal-20 tracking-[0.32px]')}>
+          style={tailwind.style(
+            'text-md text-gray-900 dark:text-grayDark-900 font-inter-normal-20 tracking-[0.32px]',
+          )}>
           {i18n.t('CONVERSATION.EMAIL_HEADER.TO')}: {toEmail.join(', ')}
         </Animated.Text>
       )}
 
       {ccEmail.length > 0 && (
         <Animated.Text
-          style={tailwind.style(' text-md text-gray-900 font-inter-normal-20 tracking-[0.32px]')}>
+          style={tailwind.style(
+            ' text-md text-gray-900 dark:text-grayDark-900 font-inter-normal-20 tracking-[0.32px]',
+          )}>
           {i18n.t('CONVERSATION.EMAIL_HEADER.CC')}: {ccEmail.join(', ')}
         </Animated.Text>
       )}
 
       {bccEmail.length > 0 && (
         <Animated.Text
-          style={tailwind.style(' text-md text-gray-900 font-inter-normal-20 tracking-[0.32px]')}>
+          style={tailwind.style(
+            ' text-md text-gray-900 dark:text-grayDark-900 font-inter-normal-20 tracking-[0.32px]',
+          )}>
           {i18n.t('CONVERSATION.EMAIL_HEADER.BCC')}: {bccEmail}
         </Animated.Text>
       )}
 
       {subject && (
         <Animated.Text
-          style={tailwind.style('text-md text-gray-950 font-inter-normal-20 tracking-[0.32px]')}>
+          style={tailwind.style(
+            'text-md text-gray-950 dark:text-grayDark-950 font-inter-normal-20 tracking-[0.32px]',
+          )}>
           {i18n.t('CONVERSATION.EMAIL_HEADER.SUBJECT')}: {subject}
         </Animated.Text>
       )}
-      <Animated.View style={tailwind.style('h-[1px] my-2 bg-gray-300')} />
+      <Animated.View style={tailwind.style('h-[1px] my-2 bg-gray-300 dark:bg-grayDark-300')} />
     </Animated.View>
   );
 };

--- a/src/screens/chat-screen/components/message-components/ErrorInformation.tsx
+++ b/src/screens/chat-screen/components/message-components/ErrorInformation.tsx
@@ -12,14 +12,14 @@ export const ErrorInformation = ({ errorCode, errorMessage }: ErrorInformationPr
     {errorCode && (
       <Text
         style={tailwind.style(
-          'text-base  text-gray-950 font-inter-medium-24 leading-[21px] tracking-[0.16px]',
+          'text-base  text-gray-950 dark:text-grayDark-950 font-inter-medium-24 leading-[21px] tracking-[0.16px]',
         )}>
         {errorCode}
       </Text>
     )}
     <Text
       style={tailwind.style(
-        'text-md text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px] mt-2',
+        'text-md text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px] mt-2',
       )}>
       {errorMessage}
     </Text>

--- a/src/screens/chat-screen/components/message-components/FileBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/FileBubble.tsx
@@ -115,7 +115,7 @@ export const FileBubblePreview = (props: FilePreviewProps) => {
                 variant === MESSAGE_VARIANTS.USER
                   ? 'text-white'
                   : variant === MESSAGE_VARIANTS.AGENT
-                    ? 'text-gray-700'
+                    ? 'text-gray-700 dark:text-grayDark-700'
                     : '',
               ),
               style.androidTextOnlyStyle,

--- a/src/screens/chat-screen/components/message-components/FileCell.tsx
+++ b/src/screens/chat-screen/components/message-components/FileCell.tsx
@@ -94,7 +94,7 @@ export const FilePreview = (props: FilePreviewProps) => {
                   ? 'text-base tracking-[0.32px] leading-[22px] font-inter-normal-20'
                   : '',
                 isIncoming ? 'text-white' : '',
-                isOutgoing ? 'text-blue-800' : '',
+                isOutgoing ? 'text-blue-800 dark:text-grayDark-800' : '',
               ),
               style.androidTextOnlyStyle,
             ]}>
@@ -170,7 +170,7 @@ export const FileCell = (props: FileCellProps) => {
               tailwind.style(
                 'flex flex-row items-center relative max-w-[300px] pl-3 pr-2.5 py-2 rounded-2xl overflow-hidden',
                 isIncoming ? 'bg-blue-700' : '',
-                isOutgoing ? 'bg-gray-100' : '',
+                isOutgoing ? 'bg-gray-100 dark:bg-grayDark-100' : '',
                 shouldRenderAvatar
                   ? isOutgoing
                     ? 'rounded-br-none'
@@ -187,7 +187,7 @@ export const FileCell = (props: FileCellProps) => {
                 style={tailwind.style(
                   'text-xs font-inter-420-20 tracking-[0.32px] leading-[14px] pr-1',
                   isIncoming ? 'text-whiteA-A11' : '',
-                  isOutgoing ? 'text-gray-700' : '',
+                  isOutgoing ? 'text-gray-700 dark:text-grayDark-700' : '',
                 )}>
                 {unixTimestampToReadableTime(timeStamp)}
               </Animated.Text>

--- a/src/screens/chat-screen/components/message-components/ImageBubble.android.tsx
+++ b/src/screens/chat-screen/components/message-components/ImageBubble.android.tsx
@@ -25,7 +25,7 @@ export const ImageBubbleContainer = (props: ImageContainerProps) => {
       <AnimatedExpoImage
         source={{ uri: imageSrc }}
         contentFit="cover"
-        style={[tailwind.style('h-full w-full bg-gray-100 overflow-hidden')]}
+        style={[tailwind.style('h-full w-full bg-gray-100 dark:bg-grayDark-100 overflow-hidden')]}
       />
     </LightBox>
   );

--- a/src/screens/chat-screen/components/message-components/ImageBubble.android.tsx
+++ b/src/screens/chat-screen/components/message-components/ImageBubble.android.tsx
@@ -16,7 +16,7 @@ export const ImageBubbleContainer = (props: ImageContainerProps) => {
       overlayBackgroundColor="#000000"
       imageBackgroundColor="#F3F4F6"
       isTranslucent
-      style={[tailwind.style('bg-gray-100 overflow-hidden'), imageStyle]}
+      style={[tailwind.style('bg-gray-100 dark:bg-grayDark-100 overflow-hidden'), imageStyle]}
     />
   );
 };

--- a/src/screens/chat-screen/components/message-components/ImageBubble.ios.tsx
+++ b/src/screens/chat-screen/components/message-components/ImageBubble.ios.tsx
@@ -22,7 +22,7 @@ export const ImageBubbleContainer = (props: ImageContainerProps) => {
           source={{ uri: imageSrc }}
           contentFit="cover"
           style={[
-            tailwind.style('h-full w-full bg-gray-100 overflow-hidden'),
+            tailwind.style('h-full w-full bg-gray-100 dark:bg-grayDark-100 overflow-hidden'),
             { width: width, height: height },
           ]}
         />

--- a/src/screens/chat-screen/components/message-components/ImageBubble.ios.tsx
+++ b/src/screens/chat-screen/components/message-components/ImageBubble.ios.tsx
@@ -15,7 +15,7 @@ export const ImageBubbleContainer = (props: ImageContainerProps) => {
         <Image
           source={{ uri: imageSrc }}
           contentFit="contain"
-          style={[tailwind.style('bg-gray-100 overflow-hidden'), imageStyle]}
+          style={[tailwind.style('bg-gray-100 dark:bg-grayDark-100 overflow-hidden'), imageStyle]}
         />
       </Galeria.Image>
     </Galeria>

--- a/src/screens/chat-screen/components/message-components/ImageCell.tsx
+++ b/src/screens/chat-screen/components/message-components/ImageCell.tsx
@@ -64,8 +64,8 @@ export const ImageCell = (props: ImageCellProps) => {
               tailwind.style(
                 'relative pl-3 pr-2.5 py-2 rounded-2xl overflow-hidden',
                 isIncoming ? 'bg-blue-700' : '',
-                isOutgoing ? 'bg-gray-100' : '',
-                isPrivate ? ' bg-amber-100' : '',
+                isOutgoing ? 'bg-gray-100 dark:bg-grayDark-100' : '',
+                isPrivate ? ' bg-amber-100 dark:bg-grayDark-100' : '',
                 shouldRenderAvatar
                   ? isOutgoing
                     ? 'rounded-br-none'

--- a/src/screens/chat-screen/components/message-components/LocationBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/LocationBubble.tsx
@@ -30,7 +30,7 @@ export const LocationBubble: React.FC<LocationBubbleProps> = props => {
             ? 'text-base tracking-[0.32px] leading-[22px] font-inter-normal-20 underline'
             : '',
           variant === MESSAGE_VARIANTS.USER ? 'text-white' : '',
-          variant === MESSAGE_VARIANTS.AGENT ? 'text-gray-950' : '',
+          variant === MESSAGE_VARIANTS.AGENT ? 'text-gray-950 dark:text-grayDark-950' : '',
         )}>
         See on map
       </Text>

--- a/src/screens/chat-screen/components/message-components/LocationCell.tsx
+++ b/src/screens/chat-screen/components/message-components/LocationCell.tsx
@@ -72,7 +72,7 @@ export const LocationCell: React.FC<LocationCellProps> = props => {
                 'relative pl-3 pr-2.5 py-2 rounded-2xl overflow-hidden',
                 `max-w-[${TEXT_MAX_WIDTH}px]`,
                 isIncoming ? 'bg-blue-700' : '',
-                isOutgoing ? 'bg-gray-100' : '',
+                isOutgoing ? 'bg-gray-100 dark:bg-grayDark-100' : '',
                 isMessageFailed ? 'bg-ruby-400' : '',
                 shouldRenderAvatar
                   ? isOutgoing
@@ -93,7 +93,7 @@ export const LocationCell: React.FC<LocationCellProps> = props => {
                     ? 'text-base tracking-[0.32px] leading-[22px] font-inter-normal-20 underline'
                     : '',
                   isIncoming ? 'text-white' : '',
-                  isOutgoing ? 'text-gray-950' : '',
+                  isOutgoing ? 'text-gray-950 dark:text-grayDark-950' : '',
                 )}>
                 See on map
               </Text>
@@ -107,7 +107,7 @@ export const LocationCell: React.FC<LocationCellProps> = props => {
                 style={tailwind.style(
                   'text-xs font-inter-420-20 tracking-[0.32px] pr-1',
                   isIncoming ? 'text-whiteA-A11' : '',
-                  isOutgoing ? 'text-gray-700' : '',
+                  isOutgoing ? 'text-gray-700 dark:text-grayDark-700' : '',
                   isMessageFailed ? 'text-ruby-900' : '',
                 )}>
                 {unixTimestampToReadableTime(timeStamp)}

--- a/src/screens/chat-screen/components/message-components/MarkdownBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/MarkdownBubble.tsx
@@ -12,12 +12,12 @@ type MarkdownBubbleProps = {
 };
 
 const variantTextMap = {
-  [MESSAGE_VARIANTS.AGENT]: 'text-gray-950',
+  [MESSAGE_VARIANTS.AGENT]: 'text-gray-950 dark:text-grayDark-950',
   [MESSAGE_VARIANTS.USER]: 'text-white',
-  [MESSAGE_VARIANTS.BOT]: 'text-gray-950',
-  [MESSAGE_VARIANTS.TEMPLATE]: 'text-gray-950',
+  [MESSAGE_VARIANTS.BOT]: 'text-gray-950 dark:text-grayDark-950',
+  [MESSAGE_VARIANTS.TEMPLATE]: 'text-gray-950 dark:text-grayDark-950',
   [MESSAGE_VARIANTS.ERROR]: 'text-white',
-  [MESSAGE_VARIANTS.PRIVATE]: 'text-amber-950 font-inter-medium-24',
+  [MESSAGE_VARIANTS.PRIVATE]: 'text-amber-950 dark:text-grayDark-950 font-inter-medium-24',
 };
 
 export const MarkdownBubble = (props: MarkdownBubbleProps) => {

--- a/src/screens/chat-screen/components/message-components/MarkdownDisplay.tsx
+++ b/src/screens/chat-screen/components/message-components/MarkdownDisplay.tsx
@@ -22,8 +22,8 @@ export const MarkdownDisplay = (props: MarkdownDisplayProps) => {
 
   const textStyle = tailwind.style(
     isIncoming ? 'text-white' : '',
-    isOutgoing || isBotText ? 'text-gray-950' : '',
-    isPrivate ? 'text-amber-950 font-inter-medium-24' : '',
+    isOutgoing || isBotText ? 'text-gray-950 dark:text-grayDark-950' : '',
+    isPrivate ? 'text-amber-950 dark:text-grayDark-950 font-inter-medium-24' : '',
     isMessageFailed ? 'text-white' : '',
   );
 

--- a/src/screens/chat-screen/components/message-components/MessageTextCell.tsx
+++ b/src/screens/chat-screen/components/message-components/MessageTextCell.tsx
@@ -90,7 +90,7 @@ export const MessageTextCell = (props: MessageTextCellProps) => {
           'relative pl-3 pr-2.5 py-2 rounded-2xl overflow-hidden',
           isEmailMessage ? `max-w-[${EMAIL_MESSAGE_WIDTH}px]` : `max-w-[${TEXT_MAX_WIDTH}px]`,
           isIncoming ? 'bg-blue-700' : '',
-          isOutgoing ? 'bg-gray-100' : '',
+          isOutgoing ? 'bg-gray-100 dark:bg-grayDark-100' : '',
           isMessageFailed ? 'bg-ruby-700' : '',
           isAvatarRendered
             ? isOutgoing
@@ -111,7 +111,7 @@ export const MessageTextCell = (props: MessageTextCellProps) => {
             : "",
           isIncoming ? "text-white" : "",
           isOutgoing ? "text-gray-950" : "",
-        )} 
+        )}
       >
         {text}
       </Text> */}
@@ -126,7 +126,7 @@ export const MessageTextCell = (props: MessageTextCellProps) => {
           style={tailwind.style(
             'text-xs font-inter-420-20 tracking-[0.32px] pr-1',
             isIncoming ? 'text-whiteA-A11' : '',
-            isOutgoing ? 'text-gray-700' : '',
+            isOutgoing ? 'text-gray-700 dark:text-grayDark-700' : '',
             isMessageFailed ? 'text-whiteA-A11' : '',
           )}>
           {unixTimestampToReadableTime(timeStamp)}

--- a/src/screens/chat-screen/components/message-components/PrivateTextCell.tsx
+++ b/src/screens/chat-screen/components/message-components/PrivateTextCell.tsx
@@ -52,13 +52,13 @@ export const PrivateTextCell = (props: PrivateTextCellProps) => {
     <Animated.View
       style={[
         tailwind.style(
-          'relative max-w-[300px] pl-2 pr-2.5 py-2 rounded-t-2xl rounded-bl-2xl overflow-hidden bg-amber-100',
+          'relative max-w-[300px] pl-2 pr-2.5 py-2 rounded-t-2xl rounded-bl-2xl overflow-hidden bg-amber-100 dark:bg-grayDark-100',
           `max-w-[${TEXT_MAX_WIDTH}px]`,
           // singleLineShortText ? "flex flex-row" : "",
         ),
       ]}>
       <Animated.View style={tailwind.style('flex flex-row')}>
-        <Animated.View style={tailwind.style('w-[3px] bg-amber-700 h-auto rounded-[4px]')} />
+        <Animated.View style={tailwind.style('w-[3px] bg-amber-700 dark:bg-grayDark-700 h-auto rounded-[4px]')} />
         <Animated.View style={tailwind.style('pl-2.5')}>
           {/* <Text
             // onTextLayout={handleTextLayout}

--- a/src/screens/chat-screen/components/message-components/PrivateTextCell.tsx
+++ b/src/screens/chat-screen/components/message-components/PrivateTextCell.tsx
@@ -52,13 +52,15 @@ export const PrivateTextCell = (props: PrivateTextCellProps) => {
     <Animated.View
       style={[
         tailwind.style(
-          'relative max-w-[300px] pl-2 pr-2.5 py-2 rounded-t-2xl rounded-bl-2xl overflow-hidden bg-amber-100',
+          'relative max-w-[300px] pl-2 pr-2.5 py-2 rounded-t-2xl rounded-bl-2xl overflow-hidden bg-amber-100 dark:bg-grayDark-100',
           `max-w-[${TEXT_MAX_WIDTH}px]`,
           // singleLineShortText ? "flex flex-row" : "",
         ),
       ]}>
       <Animated.View style={tailwind.style('flex flex-row')}>
-        <Animated.View style={tailwind.style('w-[3px] bg-amber-700 h-auto rounded-[4px]')} />
+        <Animated.View
+          style={tailwind.style('w-[3px] bg-amber-700 dark:bg-grayDark-700 h-auto rounded-[4px]')}
+        />
         <Animated.View style={tailwind.style('pl-2.5')}>
           {/* <Text
             // onTextLayout={handleTextLayout}

--- a/src/screens/chat-screen/components/message-components/ReplyMessageBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/ReplyMessageBubble.tsx
@@ -17,7 +17,7 @@ type ReplyMessageBubbleProps = {
 };
 
 const variantBaseMap = {
-  [MESSAGE_VARIANTS.AGENT]: 'bg-white',
+  [MESSAGE_VARIANTS.AGENT]: 'bg-white dark:bg-grayDark-50',
   [MESSAGE_VARIANTS.USER]: 'bg-blackA-A7',
 };
 
@@ -66,7 +66,7 @@ export const ReplyMessageBubble = (props: ReplyMessageBubbleProps) => {
         ),
       ]}>
       <Animated.View style={tailwind.style('flex flex-row')}>
-        <Animated.View style={tailwind.style('w-[3px] bg-gray-300 h-auto rounded-[4px]')} />
+        <Animated.View style={tailwind.style('w-[3px] bg-gray-300 dark:bg-grayDark-300 h-auto rounded-[4px]')} />
         <Animated.View style={tailwind.style('pl-2.5')}>
           <Animated.Text
             style={tailwind.style(
@@ -79,7 +79,7 @@ export const ReplyMessageBubble = (props: ReplyMessageBubbleProps) => {
               {renderAttachmentSection()}
               <Animated.Text
                 style={tailwind.style(
-                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950 capitalize pl-1.5',
+                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950 dark:text-grayDark-950 capitalize pl-1.5',
                 )}>
                 {replyMessageItem?.attachments[0].fileType}
               </Animated.Text>
@@ -96,7 +96,7 @@ export const ReplyMessageBubble = (props: ReplyMessageBubbleProps) => {
               <Animated.Text
                 numberOfLines={1}
                 style={tailwind.style(
-                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950 capitalize',
+                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950 dark:text-grayDark-950 capitalize',
                 )}>
                 {replyMessageItem?.content}
               </Animated.Text>

--- a/src/screens/chat-screen/components/message-components/ReplyMessageBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/ReplyMessageBubble.tsx
@@ -17,7 +17,7 @@ type ReplyMessageBubbleProps = {
 };
 
 const variantBaseMap = {
-  [MESSAGE_VARIANTS.AGENT]: 'bg-white',
+  [MESSAGE_VARIANTS.AGENT]: 'bg-white dark:bg-grayDark-50',
   [MESSAGE_VARIANTS.USER]: 'bg-blackA-A7',
 };
 
@@ -64,7 +64,9 @@ export const ReplyMessageBubble = (props: ReplyMessageBubbleProps) => {
         ),
       ]}>
       <Animated.View style={tailwind.style('flex flex-row')}>
-        <Animated.View style={tailwind.style('w-[3px] bg-gray-300 h-auto rounded-[4px]')} />
+        <Animated.View
+          style={tailwind.style('w-[3px] bg-gray-300 dark:bg-grayDark-300 h-auto rounded-[4px]')}
+        />
         <Animated.View style={tailwind.style('pl-2.5')}>
           <Animated.Text
             style={tailwind.style(
@@ -77,7 +79,7 @@ export const ReplyMessageBubble = (props: ReplyMessageBubbleProps) => {
               {renderAttachmentSection()}
               <Animated.Text
                 style={tailwind.style(
-                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950 pl-1.5',
+                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950 dark:text-grayDark-950 capitalize pl-1.5',
                 )}>
                 {replyMessageItem?.attachments[0].fileType}
               </Animated.Text>
@@ -94,7 +96,7 @@ export const ReplyMessageBubble = (props: ReplyMessageBubbleProps) => {
               <Animated.Text
                 numberOfLines={1}
                 style={tailwind.style(
-                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950',
+                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950 dark:text-grayDark-950',
                 )}>
                 {replyMessageItem?.content}
               </Animated.Text>

--- a/src/screens/chat-screen/components/message-components/ReplyMessageCell.tsx
+++ b/src/screens/chat-screen/components/message-components/ReplyMessageCell.tsx
@@ -61,12 +61,12 @@ export const ReplyMessageCell = (props: ReplyMessageCellProps) => {
           'relative max-w-[300px] pl-2 pr-2.5 py-2 mb-2 rounded-[10px] overflow-hidden -ml-[5px]',
           `max-w-[${TEXT_MAX_WIDTH}px]`,
           isIncoming ? 'bg-blackA-A7' : '',
-          isOutgoing ? 'bg-white' : '',
+          isOutgoing ? 'bg-white dark:bg-grayDark-50' : '',
           // singleLineShortText ? "flex flex-row" : "",
         ),
       ]}>
       <Animated.View style={tailwind.style('flex flex-row')}>
-        <Animated.View style={tailwind.style('w-[3px] bg-gray-300 h-auto rounded-[4px]')} />
+        <Animated.View style={tailwind.style('w-[3px] bg-gray-300 dark:bg-grayDark-300 h-auto rounded-[4px]')} />
         <Animated.View style={tailwind.style('pl-2.5')}>
           <Animated.Text
             style={tailwind.style(
@@ -79,7 +79,7 @@ export const ReplyMessageCell = (props: ReplyMessageCellProps) => {
               {renderAttachmentSection()}
               <Animated.Text
                 style={tailwind.style(
-                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950 capitalize pl-1.5',
+                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950 dark:text-grayDark-950 capitalize pl-1.5',
                 )}>
                 {replyMessageItem?.attachments[0].fileType}
               </Animated.Text>
@@ -98,7 +98,7 @@ export const ReplyMessageCell = (props: ReplyMessageCellProps) => {
               <Animated.Text
                 numberOfLines={1}
                 style={tailwind.style(
-                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950 capitalize',
+                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950 dark:text-grayDark-950 capitalize',
                 )}>
                 {replyMessageItem?.content}
               </Animated.Text>

--- a/src/screens/chat-screen/components/message-components/ReplyMessageCell.tsx
+++ b/src/screens/chat-screen/components/message-components/ReplyMessageCell.tsx
@@ -59,12 +59,14 @@ export const ReplyMessageCell = (props: ReplyMessageCellProps) => {
           'relative max-w-[300px] pl-2 pr-2.5 py-2 mb-2 rounded-[10px] overflow-hidden -ml-[5px]',
           `max-w-[${TEXT_MAX_WIDTH}px]`,
           isIncoming ? 'bg-blackA-A7' : '',
-          isOutgoing ? 'bg-white' : '',
+          isOutgoing ? 'bg-white dark:bg-grayDark-50' : '',
           // singleLineShortText ? "flex flex-row" : "",
         ),
       ]}>
       <Animated.View style={tailwind.style('flex flex-row')}>
-        <Animated.View style={tailwind.style('w-[3px] bg-gray-300 h-auto rounded-[4px]')} />
+        <Animated.View
+          style={tailwind.style('w-[3px] bg-gray-300 dark:bg-grayDark-300 h-auto rounded-[4px]')}
+        />
         <Animated.View style={tailwind.style('pl-2.5')}>
           <Animated.Text
             style={tailwind.style(
@@ -77,7 +79,7 @@ export const ReplyMessageCell = (props: ReplyMessageCellProps) => {
               {renderAttachmentSection()}
               <Animated.Text
                 style={tailwind.style(
-                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950 pl-1.5',
+                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950 dark:text-grayDark-950 capitalize pl-1.5',
                 )}>
                 {replyMessageItem?.attachments[0].fileType}
               </Animated.Text>
@@ -96,7 +98,7 @@ export const ReplyMessageCell = (props: ReplyMessageCellProps) => {
               <Animated.Text
                 numberOfLines={1}
                 style={tailwind.style(
-                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950',
+                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950 dark:text-grayDark-950',
                 )}>
                 {replyMessageItem?.content}
               </Animated.Text>

--- a/src/screens/chat-screen/components/message-components/UnsupportedBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/UnsupportedBubble.tsx
@@ -7,9 +7,9 @@ export const UnsupportedBubble = () => {
   return (
     <View
       style={tailwind.style(
-        'px-4 py-3 bg-amber-100 border border-dashed border-amber-700 rounded-lg',
+        'px-4 py-3 bg-amber-100 dark:bg-grayDark-100 border border-dashed border-amber-700 dark:border-grayDark-700 rounded-lg',
       )}>
-      <Text style={tailwind.style('text-gray-950')}>
+      <Text style={tailwind.style('text-gray-950 dark:text-grayDark-950')}>
         {i18n.t('CONVERSATION.UNSUPPORTED_MESSAGE')}
       </Text>
     </View>

--- a/src/screens/chat-screen/components/message-item/Message.tsx
+++ b/src/screens/chat-screen/components/message-item/Message.tsx
@@ -62,32 +62,32 @@ type MessageWrapperProps = {
 };
 
 const variantTextMap = {
-  [MESSAGE_VARIANTS.AGENT]: 'text-gray-700',
+  [MESSAGE_VARIANTS.AGENT]: 'text-gray-700 dark:text-grayDark-700',
   [MESSAGE_VARIANTS.USER]: 'text-white',
-  [MESSAGE_VARIANTS.BOT]: 'text-gray-700',
-  [MESSAGE_VARIANTS.TEMPLATE]: 'text-gray-700',
+  [MESSAGE_VARIANTS.BOT]: 'text-gray-700 dark:text-grayDark-700',
+  [MESSAGE_VARIANTS.TEMPLATE]: 'text-gray-700 dark:text-grayDark-700',
   [MESSAGE_VARIANTS.ERROR]: 'text-white',
 };
 
 const variantBaseMap = {
-  [MESSAGE_VARIANTS.AGENT]: 'bg-gray-100',
-  [MESSAGE_VARIANTS.PRIVATE]: 'bg-amber-100',
+  [MESSAGE_VARIANTS.AGENT]: 'bg-gray-100 dark:bg-grayDark-100',
+  [MESSAGE_VARIANTS.PRIVATE]: 'bg-amber-100 dark:bg-grayDark-100',
   [MESSAGE_VARIANTS.USER]: 'bg-blue-700',
-  [MESSAGE_VARIANTS.BOT]: 'bg-blue-100',
-  [MESSAGE_VARIANTS.TEMPLATE]: 'bg-blue-100',
+  [MESSAGE_VARIANTS.BOT]: 'bg-blue-100 dark:bg-grayDark-100',
+  [MESSAGE_VARIANTS.TEMPLATE]: 'bg-blue-100 dark:bg-grayDark-100',
   [MESSAGE_VARIANTS.ERROR]: 'bg-ruby-700',
-  [MESSAGE_VARIANTS.EMAIL]: 'bg-gray-100',
-  [MESSAGE_VARIANTS.UNSUPPORTED]: 'bg-amber-100 border border-dashed border-amber-700',
+  [MESSAGE_VARIANTS.EMAIL]: 'bg-gray-100 dark:bg-grayDark-100',
+  [MESSAGE_VARIANTS.UNSUPPORTED]: 'bg-amber-100 dark:bg-grayDark-100 border border-dashed border-amber-700 dark:border-grayDark-700',
 };
 
 const variantBorderMap = {
-  [MESSAGE_VARIANTS.AGENT]: 'border-gray-100',
-  [MESSAGE_VARIANTS.USER]: 'border-gray-100',
-  [MESSAGE_VARIANTS.BOT]: 'border-gray-100',
-  [MESSAGE_VARIANTS.TEMPLATE]: 'border-gray-100',
-  [MESSAGE_VARIANTS.ERROR]: 'border-gray-100',
-  [MESSAGE_VARIANTS.EMAIL]: 'border-gray-100',
-  [MESSAGE_VARIANTS.UNSUPPORTED]: 'border-gray-100',
+  [MESSAGE_VARIANTS.AGENT]: 'border-gray-100 dark:border-grayDark-100',
+  [MESSAGE_VARIANTS.USER]: 'border-gray-100 dark:border-grayDark-100',
+  [MESSAGE_VARIANTS.BOT]: 'border-gray-100 dark:border-grayDark-100',
+  [MESSAGE_VARIANTS.TEMPLATE]: 'border-gray-100 dark:border-grayDark-100',
+  [MESSAGE_VARIANTS.ERROR]: 'border-gray-100 dark:border-grayDark-100',
+  [MESSAGE_VARIANTS.EMAIL]: 'border-gray-100 dark:border-grayDark-100',
+  [MESSAGE_VARIANTS.UNSUPPORTED]: 'border-gray-100 dark:border-grayDark-100',
 };
 
 const MessageWrapper = ({

--- a/src/screens/chat-screen/components/message-item/Message.tsx
+++ b/src/screens/chat-screen/components/message-item/Message.tsx
@@ -33,7 +33,7 @@ import {
 } from '@/constants';
 import i18n from '@/i18n';
 import Clipboard from '@react-native-clipboard/clipboard';
-import { CopyIcon, Trash, ReplyIcon, TranslateIcon} from '@/svg-icons';
+import { CopyIcon, Trash, ReplyIcon, TranslateIcon } from '@/svg-icons';
 import { setQuoteMessage } from '@/store/conversation/sendMessageSlice';
 import { inboxSupportsReplyTo } from '@/utils';
 import { MenuOption, MessageMenu } from '../message-menu';
@@ -70,32 +70,33 @@ type MessageWrapperProps = {
 };
 
 const variantTextMap = {
-  [MESSAGE_VARIANTS.AGENT]: 'text-gray-700',
+  [MESSAGE_VARIANTS.AGENT]: 'text-gray-700 dark:text-grayDark-700',
   [MESSAGE_VARIANTS.USER]: 'text-white',
-  [MESSAGE_VARIANTS.BOT]: 'text-gray-700',
-  [MESSAGE_VARIANTS.TEMPLATE]: 'text-gray-700',
+  [MESSAGE_VARIANTS.BOT]: 'text-gray-700 dark:text-grayDark-700',
+  [MESSAGE_VARIANTS.TEMPLATE]: 'text-gray-700 dark:text-grayDark-700',
   [MESSAGE_VARIANTS.ERROR]: 'text-white',
 };
 
 const variantBaseMap = {
-  [MESSAGE_VARIANTS.AGENT]: 'bg-gray-100',
-  [MESSAGE_VARIANTS.PRIVATE]: 'bg-amber-100',
+  [MESSAGE_VARIANTS.AGENT]: 'bg-gray-100 dark:bg-grayDark-100',
+  [MESSAGE_VARIANTS.PRIVATE]: 'bg-amber-100 dark:bg-grayDark-100',
   [MESSAGE_VARIANTS.USER]: 'bg-blue-700',
-  [MESSAGE_VARIANTS.BOT]: 'bg-blue-100',
-  [MESSAGE_VARIANTS.TEMPLATE]: 'bg-blue-100',
+  [MESSAGE_VARIANTS.BOT]: 'bg-blue-100 dark:bg-grayDark-100',
+  [MESSAGE_VARIANTS.TEMPLATE]: 'bg-blue-100 dark:bg-grayDark-100',
   [MESSAGE_VARIANTS.ERROR]: 'bg-ruby-700',
-  [MESSAGE_VARIANTS.EMAIL]: 'bg-gray-100',
-  [MESSAGE_VARIANTS.UNSUPPORTED]: 'bg-amber-100 border border-dashed border-amber-700',
+  [MESSAGE_VARIANTS.EMAIL]: 'bg-gray-100 dark:bg-grayDark-100',
+  [MESSAGE_VARIANTS.UNSUPPORTED]:
+    'bg-amber-100 dark:bg-grayDark-100 border border-dashed border-amber-700 dark:border-grayDark-700',
 };
 
 const variantBorderMap = {
-  [MESSAGE_VARIANTS.AGENT]: 'border-gray-100',
-  [MESSAGE_VARIANTS.USER]: 'border-gray-100',
-  [MESSAGE_VARIANTS.BOT]: 'border-gray-100',
-  [MESSAGE_VARIANTS.TEMPLATE]: 'border-gray-100',
-  [MESSAGE_VARIANTS.ERROR]: 'border-gray-100',
-  [MESSAGE_VARIANTS.EMAIL]: 'border-gray-100',
-  [MESSAGE_VARIANTS.UNSUPPORTED]: 'border-gray-100',
+  [MESSAGE_VARIANTS.AGENT]: 'border-gray-100 dark:border-grayDark-100',
+  [MESSAGE_VARIANTS.USER]: 'border-gray-100 dark:border-grayDark-100',
+  [MESSAGE_VARIANTS.BOT]: 'border-gray-100 dark:border-grayDark-100',
+  [MESSAGE_VARIANTS.TEMPLATE]: 'border-gray-100 dark:border-grayDark-100',
+  [MESSAGE_VARIANTS.ERROR]: 'border-gray-100 dark:border-grayDark-100',
+  [MESSAGE_VARIANTS.EMAIL]: 'border-gray-100 dark:border-grayDark-100',
+  [MESSAGE_VARIANTS.UNSUPPORTED]: 'border-gray-100 dark:border-grayDark-100',
 };
 
 const MessageWrapper = ({
@@ -178,10 +179,7 @@ const MessageWrapper = ({
             {/* Highlight overlay for target message */}
             {isTargetMessage && (
               <Animated.View
-                style={[
-                  tailwind.style('absolute inset-0 bg-white rounded-2xl'),
-                  highlightStyle,
-                ]}
+                style={[tailwind.style('absolute inset-0 bg-white rounded-2xl'), highlightStyle]}
                 pointerEvents="none"
               />
             )}
@@ -219,7 +217,13 @@ const MessageWrapper = ({
 export const MessageComponent = (props: MessageComponentProps) => {
   const dispatch = useAppDispatch();
   const { conversationId } = useChatWindowContext();
-  const { item, currentUserId, isEmailInbox, isTargetMessage = false, isListPositioned = true } = props;
+  const {
+    item,
+    currentUserId,
+    isEmailInbox,
+    isTargetMessage = false,
+    isListPositioned = true,
+  } = props;
   const {
     messageType,
     contentType,
@@ -281,8 +285,8 @@ export const MessageComponent = (props: MessageComponentProps) => {
 
   const handleQuoteReply = (message: Message) => {
     dispatch(setQuoteMessage(message));
-  }
-  
+  };
+
   const handleTranslateMessage = async (messageId: number) => {
     hapticSelection?.();
     const targetLanguage = i18n.locale?.split('_')[0] || 'en';
@@ -297,7 +301,13 @@ export const MessageComponent = (props: MessageComponentProps) => {
   };
 
   const getMenuOptions = (message: Message): MenuOption[] => {
-    const { messageType, content, attachments, private: isPrivate, status: messageStatus } = message;
+    const {
+      messageType,
+      content,
+      attachments,
+      private: isPrivate,
+      status: messageStatus,
+    } = message;
     const hasText = !!content;
     const hasAttachments = !!(attachments && attachments.length > 0);
     const isDeleted = message.contentAttributes?.deleted;

--- a/src/screens/chat-screen/components/message-list/MessagesListContainer.tsx
+++ b/src/screens/chat-screen/components/message-list/MessagesListContainer.tsx
@@ -170,7 +170,7 @@ export const MessagesListContainer = () => {
 
   return (
     <PlatformSpecificKeyboardWrapperComponent
-      style={tailwind.style('flex-1 bg-white')}
+      style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}
       interpolator="linear">
       <MessagesList
         messages={messagesWithGrouping}

--- a/src/screens/chat-screen/components/message-list/MessagesListContainer.tsx
+++ b/src/screens/chat-screen/components/message-list/MessagesListContainer.tsx
@@ -294,7 +294,7 @@ export const MessagesListContainer = () => {
 
   return (
     <PlatformSpecificKeyboardWrapperComponent
-      style={tailwind.style('flex-1 bg-white')}
+      style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}
       interpolator="linear">
       <View style={[tailwind.style('flex-1'), !isListVisible && messageId ? { opacity: 0 } : {}]}>
         <MessagesList

--- a/src/screens/chat-screen/components/message-menu/MessageMenu.tsx
+++ b/src/screens/chat-screen/components/message-menu/MessageMenu.tsx
@@ -143,11 +143,11 @@ export const MessageMenu = (props: PropsWithChildren<MessageMenuProps>) => {
                     <Animated.View
                       style={tailwind.style(
                         'flex-1 ml-3 flex-row justify-between py-[11px] pr-3',
-                        index !== menuOptions.length - 1 ? 'border-b-[1px] border-blackA-A3' : '',
+                        index !== menuOptions.length - 1 ? 'border-b-[1px] border-blackA-A3 dark:border-grayDark-200' : '',
                       )}>
                       <Animated.Text
                         style={tailwind.style(
-                          'text-base text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px] capitalize',
+                          'text-base text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px] capitalize',
                         )}>
                         {option.title}
                       </Animated.Text>

--- a/src/screens/chat-screen/components/message-menu/MessageMenu.tsx
+++ b/src/screens/chat-screen/components/message-menu/MessageMenu.tsx
@@ -143,11 +143,13 @@ export const MessageMenu = (props: PropsWithChildren<MessageMenuProps>) => {
                     <Animated.View
                       style={tailwind.style(
                         'flex-1 ml-3 flex-row justify-between py-[11px] pr-3',
-                        index !== menuOptions.length - 1 ? 'border-b-[1px] border-blackA-A3' : '',
+                        index !== menuOptions.length - 1
+                          ? 'border-b-[1px] border-blackA-A3 dark:border-grayDark-200'
+                          : '',
                       )}>
                       <Animated.Text
                         style={tailwind.style(
-                          'text-base text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px] capitalize',
+                          'text-base text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px] capitalize',
                         )}>
                         {option.title}
                       </Animated.Text>

--- a/src/screens/chat-screen/components/reply-box/CannedResponses.tsx
+++ b/src/screens/chat-screen/components/reply-box/CannedResponses.tsx
@@ -25,12 +25,12 @@ const CannedResponseItem = ({
     <Pressable
       onPress={() => onSelect(item)}
       style={tailwind.style(
-        'w-full flex-row justify-between items-center border-b border-gray-200 py-3 px-4',
+        'w-full flex-row justify-between items-center border-b border-gray-200 dark:border-grayDark-200 py-3 px-4',
       )}>
-      <Animated.Text numberOfLines={1} style={tailwind.style('text-md flex-1 text-gray-950')}>
+      <Animated.Text numberOfLines={1} style={tailwind.style('text-md flex-1 text-gray-950 dark:text-grayDark-950')}>
         {item.content.replace(/\n/g, ' ')}
       </Animated.Text>
-      <Animated.Text style={tailwind.style('text-sm text-gray-900 ml-2')}>
+      <Animated.Text style={tailwind.style('text-sm text-gray-900 dark:text-grayDark-900 ml-2')}>
         {`/${item.shortCode}`}
       </Animated.Text>
     </Pressable>
@@ -55,7 +55,7 @@ export const CannedResponses = (props: CannedResponsesProps) => {
     <Animated.View
       style={[
         tailwind.style(
-          'left-0 right-0 bg-white border-t border-gray-200 max-h-[180px] relative bottom-0 h-[180px]',
+          'left-0 right-0 bg-white dark:bg-grayDark-50 border-t border-gray-200 dark:border-grayDark-200 max-h-[180px] relative bottom-0 h-[180px]',
         ),
       ]}>
       <FlashList

--- a/src/screens/chat-screen/components/reply-box/CannedResponses.tsx
+++ b/src/screens/chat-screen/components/reply-box/CannedResponses.tsx
@@ -25,12 +25,14 @@ const CannedResponseItem = ({
     <Pressable
       onPress={() => onSelect(item)}
       style={tailwind.style(
-        'w-full flex-row justify-between items-center border-b border-gray-200 py-3 px-4',
+        'w-full flex-row justify-between items-center border-b border-gray-200 dark:border-grayDark-200 py-3 px-4',
       )}>
-      <Animated.Text numberOfLines={1} style={tailwind.style('text-md flex-1 text-gray-950')}>
+      <Animated.Text
+        numberOfLines={1}
+        style={tailwind.style('text-md flex-1 text-gray-950 dark:text-grayDark-950')}>
         {item.content.replace(/\n/g, ' ')}
       </Animated.Text>
-      <Animated.Text style={tailwind.style('text-sm text-gray-900 ml-2')}>
+      <Animated.Text style={tailwind.style('text-sm text-gray-900 dark:text-grayDark-900 ml-2')}>
         {`/${item.shortCode}`}
       </Animated.Text>
     </Pressable>
@@ -55,7 +57,7 @@ export const CannedResponses = (props: CannedResponsesProps) => {
     <Animated.View
       style={[
         tailwind.style(
-          'left-0 right-0 bg-white border-t border-gray-200 max-h-[180px] relative bottom-0 h-[180px]',
+          'left-0 right-0 bg-white dark:bg-grayDark-50 border-t border-gray-200 dark:border-grayDark-200 max-h-[180px] relative bottom-0 h-[180px]',
         ),
       ]}>
       <FlashList

--- a/src/screens/chat-screen/components/reply-box/MentionUser.tsx
+++ b/src/screens/chat-screen/components/reply-box/MentionUser.tsx
@@ -17,12 +17,12 @@ export const MentionUser = (props: MentionUserProps) => {
       <Animated.View
         style={tailwind.style(
           'flex-1 ml-3 flex-row justify-between py-[11px] pr-3',
-          !lastItem ? 'border-b-[1px] border-blackA-A3' : '',
+          !lastItem ? 'border-b-[1px] border-blackA-A3 dark:border-grayDark-200' : '',
         )}>
         <Animated.Text
           style={[
             tailwind.style(
-              'text-base text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
+              'text-base text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
             ),
           ]}>
           {agent.name}

--- a/src/screens/chat-screen/components/reply-box/MessageTextInput.tsx
+++ b/src/screens/chat-screen/components/reply-box/MessageTextInput.tsx
@@ -191,7 +191,7 @@ export const MessageTextInput = ({
         <Animated.View
           style={[
             tailwind.style(
-              'bg-white border-t border-gray-200 rounded-[13px] mx-4 px-2 w-full max-h-[250px]',
+              'bg-white dark:bg-grayDark-50 border-t border-gray-200 dark:border-grayDark-200 rounded-[13px] mx-4 px-2 w-full max-h-[250px]',
               Platform.OS === 'ios' ? 'absolute bottom-full' : 'relative h-[150px]',
             ),
             styles.listShadow,
@@ -243,13 +243,13 @@ export const MessageTextInput = ({
           style={[
             tailwind.style(
               'text-base font-inter-normal-20 tracking-[0.24px] leading-[20px] android:leading-[18px]',
-              'ml-[5px] mr-2 py-2 pl-3 pr-[36px] rounded-2xl text-gray-950',
+              'ml-[5px] mr-2 py-2 pl-3 pr-[36px] rounded-2xl text-gray-950 dark:text-grayDark-950',
               'min-h-9 max-h-[76px]',
-              isPrivateMessage ? 'bg-amber-100' : 'bg-blackA-A4',
+              isPrivateMessage ? 'bg-amber-100 dark:bg-amber-900' : 'bg-blackA-A4 dark:bg-grayDark-100',
             ),
             // TODO: Try settings includeFontPadding to false and have a single lineHeight value of 20
           ]}
-          placeholderTextColor={tailwind.color('bg-gray-800')}
+          placeholderTextColor={tailwind.color('bg-gray-800 dark:bg-grayDark-800')}
           maxLength={maxLength}
           placeholder={
             isPrivateMessage

--- a/src/screens/chat-screen/components/reply-box/MessageTextInput.tsx
+++ b/src/screens/chat-screen/components/reply-box/MessageTextInput.tsx
@@ -191,7 +191,7 @@ export const MessageTextInput = ({
         <Animated.View
           style={[
             tailwind.style(
-              'bg-white border-t border-gray-200 rounded-[13px] mx-4 px-2 w-full max-h-[250px]',
+              'bg-white dark:bg-grayDark-50 border-t border-gray-200 dark:border-grayDark-200 rounded-[13px] mx-4 px-2 w-full max-h-[250px]',
               Platform.OS === 'ios' ? 'absolute bottom-full' : 'relative h-[150px]',
             ),
             styles.listShadow,
@@ -243,13 +243,15 @@ export const MessageTextInput = ({
           style={[
             tailwind.style(
               'text-base font-inter-normal-20 tracking-[0.24px] leading-[20px] android:leading-[18px]',
-              'ml-[5px] mr-2 py-2 pl-3 pr-[36px] rounded-2xl text-gray-950',
+              'ml-[5px] mr-2 py-2 pl-3 pr-[36px] rounded-2xl text-gray-950 dark:text-grayDark-950',
               'min-h-9 max-h-[76px]',
-              isPrivateMessage ? 'bg-amber-100' : 'bg-blackA-A4',
+              isPrivateMessage
+                ? 'bg-amber-100 dark:bg-amber-900'
+                : 'bg-blackA-A4 dark:bg-grayDark-100',
             ),
             // TODO: Try settings includeFontPadding to false and have a single lineHeight value of 20
           ]}
-          placeholderTextColor={tailwind.color('bg-gray-800')}
+          placeholderTextColor={tailwind.color('bg-gray-800 dark:bg-grayDark-800')}
           maxLength={maxLength}
           placeholder={
             isPrivateMessage

--- a/src/screens/chat-screen/components/reply-box/QuoteReply.tsx
+++ b/src/screens/chat-screen/components/reply-box/QuoteReply.tsx
@@ -104,7 +104,7 @@ export const QuoteReply = () => {
   return (
     <Pressable
       onPress={handleScrollToMessage}
-      style={tailwind.style('flex flex-row items-center px-2.5 pb-[14px] bg-white -z-10')}>
+      style={tailwind.style('flex flex-row items-center px-2.5 pb-[14px] bg-white dark:bg-grayDark-50 -z-10')}>
       {quoteMessage?.attachments?.length && quoteMessage?.attachments?.length > 0 ? (
         <Animated.View style={tailwind.style('h-9.5 w-9.5 mr-3 rounded-lg overflow-hidden')}>
           {quoteMessage?.attachments?.length > 0 &&
@@ -130,7 +130,7 @@ export const QuoteReply = () => {
         <Animated.View>
           <Animated.Text
             style={tailwind.style(
-              'text-cxs tracking-[0.32px] leading-[15px] font-inter-420-20 text-blackA-A11',
+              'text-cxs tracking-[0.32px] leading-[15px] font-inter-420-20 text-blackA-A11 dark:text-grayDark-900',
             )}>
             Replying to {quoteMessage?.sender?.name}
           </Animated.Text>

--- a/src/screens/chat-screen/components/reply-box/QuoteReply.tsx
+++ b/src/screens/chat-screen/components/reply-box/QuoteReply.tsx
@@ -104,7 +104,9 @@ export const QuoteReply = () => {
   return (
     <Pressable
       onPress={handleScrollToMessage}
-      style={tailwind.style('flex flex-row items-center px-2.5 pb-[14px] bg-white -z-10')}>
+      style={tailwind.style(
+        'flex flex-row items-center px-2.5 pb-[14px] bg-white dark:bg-grayDark-50 -z-10',
+      )}>
       {quoteMessage?.attachments?.length && quoteMessage?.attachments?.length > 0 ? (
         <Animated.View style={tailwind.style('h-9.5 w-9.5 mr-3 rounded-lg overflow-hidden')}>
           {quoteMessage?.attachments?.length > 0 &&
@@ -130,7 +132,7 @@ export const QuoteReply = () => {
         <Animated.View>
           <Animated.Text
             style={tailwind.style(
-              'text-cxs tracking-[0.32px] leading-[15px] font-inter-420-20 text-blackA-A11',
+              'text-cxs tracking-[0.32px] leading-[15px] font-inter-420-20 text-blackA-A11 dark:text-grayDark-900',
             )}>
             Replying to {quoteMessage?.sender?.name}
           </Animated.Text>
@@ -159,8 +161,7 @@ export const QuoteReply = () => {
               </Text>
             )
           ) : (
-            <Text
-              style={tailwind.style('text-md font-inter-normal-20 tracking-[0.32px]')}>
+            <Text style={tailwind.style('text-md font-inter-normal-20 tracking-[0.32px]')}>
               {quoteMessage?.attachments?.[0]?.fileType}
             </Text>
           )}

--- a/src/screens/chat-screen/components/reply-box/ReplyBoxContainer.tsx
+++ b/src/screens/chat-screen/components/reply-box/ReplyBoxContainer.tsx
@@ -378,7 +378,7 @@ const BottomSheetContent = () => {
   const shouldShowCannedResponses = messageContent?.charAt(0) === '/';
 
   return (
-    <AnimatedKeyboardStickyView style={[tailwind.style('bg-white'), animatedInputWrapperStyle]}>
+    <AnimatedKeyboardStickyView style={[tailwind.style('bg-white dark:bg-grayDark-50'), animatedInputWrapperStyle]}>
       {!canReply && inbox && conversation && (
         <Animated.View entering={FadeIn.duration(250)} exiting={FadeOut.duration(10)}>
           <ReplyWarning inbox={inbox} conversation={conversation} />
@@ -391,7 +391,7 @@ const BottomSheetContent = () => {
       <Animated.View
         layout={LinearTransition.springify().damping(38).stiffness(240)}
         style={tailwind.style(
-          `pb-2 border-t-[1px] border-t-blackA-A3 ${shouldShowReplyHeader ? 'pt-0' : 'pt-2'}`,
+          `pb-2 border-t-[1px] border-t-blackA-A3 dark:border-t-grayDark-200 ${shouldShowReplyHeader ? 'pt-0' : 'pt-2'}`,
         )}>
         {quoteMessage && (
           <Animated.View entering={FadeIn.duration(250)} exiting={FadeOut.duration(10)}>

--- a/src/screens/chat-screen/components/reply-box/ReplyBoxContainer.tsx
+++ b/src/screens/chat-screen/components/reply-box/ReplyBoxContainer.tsx
@@ -312,9 +312,7 @@ const BottomSheetContent = () => {
   const handleCopilotFollowUp = (message: string) => {
     if (followUpContext && message.trim().length > 0) {
       copilotAbortRef.current?.abort();
-      const promise = dispatch(
-        sendCopilotFollowUp({ followUpContext, message, conversationId }),
-      );
+      const promise = dispatch(sendCopilotFollowUp({ followUpContext, message, conversationId }));
       copilotAbortRef.current = promise;
       promise.unwrap().catch((err: { name?: string }) => {
         if (err?.name === 'AbortError') return;
@@ -502,7 +500,8 @@ const BottomSheetContent = () => {
   const shouldShowCannedResponses = messageContent?.charAt(0) === '/';
 
   return (
-    <AnimatedKeyboardStickyView style={[tailwind.style('bg-white'), animatedInputWrapperStyle]}>
+    <AnimatedKeyboardStickyView
+      style={[tailwind.style('bg-white dark:bg-grayDark-50'), animatedInputWrapperStyle]}>
       {!canReply && inbox && conversation && (
         <Animated.View entering={FadeIn.duration(250)} exiting={FadeOut.duration(10)}>
           <ReplyWarning inbox={inbox} conversation={conversation} />
@@ -513,9 +512,11 @@ const BottomSheetContent = () => {
       )}
 
       <Animated.View
-        layout={isCopilotActive ? undefined : LinearTransition.springify().damping(38).stiffness(240)}
+        layout={
+          isCopilotActive ? undefined : LinearTransition.springify().damping(38).stiffness(240)
+        }
         style={tailwind.style(
-          `pb-2 border-t-[1px] border-t-blackA-A3 ${shouldShowReplyHeader ? 'pt-0' : 'pt-2'}`,
+          `pb-2 border-t-[1px] border-t-blackA-A3 dark:border-t-grayDark-200 ${shouldShowReplyHeader ? 'pt-0' : 'pt-2'}`,
         )}>
         {quoteMessage && !isPrivate && (
           <Animated.View entering={FadeIn.duration(250)} exiting={FadeOut.duration(10)}>
@@ -551,7 +552,9 @@ const BottomSheetContent = () => {
         ) : null}
         {!isVoiceRecorderOpen ? (
           <Animated.View
-            layout={isCopilotActive ? undefined : LinearTransition.springify().damping(20).stiffness(180)}
+            layout={
+              isCopilotActive ? undefined : LinearTransition.springify().damping(20).stiffness(180)
+            }
             style={tailwind.style('flex flex-row px-1 items-end z-20 relative')}>
             {!isCopilotActive && attachmentsLength === 0 && shouldShowFileUpload && (
               <AddCommandButton

--- a/src/screens/chat-screen/components/reply-box/ReplyEmailHead.tsx
+++ b/src/screens/chat-screen/components/reply-box/ReplyEmailHead.tsx
@@ -21,12 +21,12 @@ export const ReplyEmailHead = (props: EmailMetaProps) => {
   return (
     <Animated.View style={tailwind.style('flex flex-col mb-2')}>
       <Animated.View
-        style={tailwind.style('flex flex-col gap-1 px-3 py-1 border-b border-b-blackA-A3')}>
+        style={tailwind.style('flex flex-col gap-1 px-3 py-1 border-b border-b-blackA-A3 dark:border-b-grayDark-200')}>
         {toEmails && (
           <Animated.View style={tailwind.style('flex flex-row items-center gap-1 ')}>
             <Text
               style={tailwind.style(
-                'text-md text-gray-950 font-inter-normal-20 tracking-[0.16px] min-w-[30px]',
+                'text-md text-gray-950 dark:text-grayDark-950 font-inter-normal-20 tracking-[0.16px] min-w-[30px]',
               )}>
               {i18n.t('CONVERSATION.EMAIL_HEAD.TO')}
             </Text>
@@ -35,18 +35,18 @@ export const ReplyEmailHead = (props: EmailMetaProps) => {
               value={toEmails}
               onChangeText={onUpdateTo}
               placeholder="Emails separated by commas"
-              placeholderTextColor={tailwind.color('text-gray-300')}
+              placeholderTextColor={tailwind.color('text-gray-300 dark:text-grayDark-300')}
             />
           </Animated.View>
         )}
       </Animated.View>
       <Animated.View
         style={tailwind.style(
-          'flex flex-row items-center gap-1 py-1 px-3 border-b border-b-blackA-A3',
+          'flex flex-row items-center gap-1 py-1 px-3 border-b border-b-blackA-A3 dark:border-b-grayDark-200',
         )}>
         <Text
           style={tailwind.style(
-            'text-md text-gray-950 font-inter-normal-20 tracking-[0.16px] min-w-[30px]',
+            'text-md text-gray-950 dark:text-grayDark-950 font-inter-normal-20 tracking-[0.16px] min-w-[30px]',
           )}>
           {i18n.t('CONVERSATION.EMAIL_HEAD.CC')}
         </Text>
@@ -55,10 +55,10 @@ export const ReplyEmailHead = (props: EmailMetaProps) => {
           value={ccEmails}
           onChangeText={onUpdateCC}
           placeholder="Emails separated by commas"
-          placeholderTextColor={tailwind.color('text-gray-300')}
+          placeholderTextColor={tailwind.color('text-gray-300 dark:text-grayDark-300')}
         />
         <Pressable style={tailwind.style('')} onPress={() => setShowBcc(!showBcc)}>
-          <Animated.Text style={tailwind.style('text-blue-800')}>
+          <Animated.Text style={tailwind.style('text-blue-800 dark:text-blue-600')}>
             {i18n.t('CONVERSATION.EMAIL_HEAD.BCC')}
           </Animated.Text>
         </Pressable>
@@ -66,11 +66,11 @@ export const ReplyEmailHead = (props: EmailMetaProps) => {
       {showBcc && (
         <Animated.View
           style={tailwind.style(
-            'flex flex-row items-center gap-1 px-3 border-b py-1 border-b-blackA-A3',
+            'flex flex-row items-center gap-1 px-3 border-b py-1 border-b-blackA-A3 dark:border-b-grayDark-200',
           )}>
           <Text
             style={tailwind.style(
-              'text-md text-gray-950 font-inter-normal-20 tracking-[0.16px] min-w-[30px]',
+              'text-md text-gray-950 dark:text-grayDark-950 font-inter-normal-20 tracking-[0.16px] min-w-[30px]',
             )}>
             {i18n.t('CONVERSATION.EMAIL_HEAD.BCC')}
           </Text>
@@ -79,7 +79,7 @@ export const ReplyEmailHead = (props: EmailMetaProps) => {
             value={bccEmails}
             onChangeText={onUpdateBCC}
             placeholder="Emails separated by commas"
-            placeholderTextColor={tailwind.color('text-gray-300')}
+            placeholderTextColor={tailwind.color('text-gray-300 dark:text-grayDark-300')}
           />
         </Animated.View>
       )}

--- a/src/screens/chat-screen/components/reply-box/ReplyEmailHead.tsx
+++ b/src/screens/chat-screen/components/reply-box/ReplyEmailHead.tsx
@@ -21,12 +21,14 @@ export const ReplyEmailHead = (props: EmailMetaProps) => {
   return (
     <Animated.View style={tailwind.style('flex flex-col mb-2')}>
       <Animated.View
-        style={tailwind.style('flex flex-col gap-1 px-3 py-1 border-b border-b-blackA-A3')}>
+        style={tailwind.style(
+          'flex flex-col gap-1 px-3 py-1 border-b border-b-blackA-A3 dark:border-b-grayDark-200',
+        )}>
         {toEmails && (
           <Animated.View style={tailwind.style('flex flex-row items-center gap-1 ')}>
             <Text
               style={tailwind.style(
-                'text-md text-gray-950 font-inter-normal-20 tracking-[0.16px] min-w-[30px]',
+                'text-md text-gray-950 dark:text-grayDark-950 font-inter-normal-20 tracking-[0.16px] min-w-[30px]',
               )}>
               {i18n.t('CONVERSATION.EMAIL_HEAD.TO')}
             </Text>
@@ -35,18 +37,18 @@ export const ReplyEmailHead = (props: EmailMetaProps) => {
               value={toEmails}
               onChangeText={onUpdateTo}
               placeholder="Emails separated by commas"
-              placeholderTextColor={tailwind.color('text-gray-300')}
+              placeholderTextColor={tailwind.color('text-gray-300 dark:text-grayDark-300')}
             />
           </Animated.View>
         )}
       </Animated.View>
       <Animated.View
         style={tailwind.style(
-          'flex flex-row items-center gap-1 py-1 px-3 border-b border-b-blackA-A3',
+          'flex flex-row items-center gap-1 py-1 px-3 border-b border-b-blackA-A3 dark:border-b-grayDark-200',
         )}>
         <Text
           style={tailwind.style(
-            'text-md text-gray-950 font-inter-normal-20 tracking-[0.16px] min-w-[30px]',
+            'text-md text-gray-950 dark:text-grayDark-950 font-inter-normal-20 tracking-[0.16px] min-w-[30px]',
           )}>
           {i18n.t('CONVERSATION.EMAIL_HEAD.CC')}
         </Text>
@@ -55,10 +57,10 @@ export const ReplyEmailHead = (props: EmailMetaProps) => {
           value={ccEmails}
           onChangeText={onUpdateCC}
           placeholder="Emails separated by commas"
-          placeholderTextColor={tailwind.color('text-gray-300')}
+          placeholderTextColor={tailwind.color('text-gray-300 dark:text-grayDark-300')}
         />
         <Pressable style={tailwind.style('')} onPress={() => setShowBcc(!showBcc)}>
-          <Animated.Text style={tailwind.style('text-blue-800')}>
+          <Animated.Text style={tailwind.style('text-blue-800 dark:text-blue-600')}>
             {i18n.t('CONVERSATION.EMAIL_HEAD.BCC')}
           </Animated.Text>
         </Pressable>
@@ -66,11 +68,11 @@ export const ReplyEmailHead = (props: EmailMetaProps) => {
       {showBcc && (
         <Animated.View
           style={tailwind.style(
-            'flex flex-row items-center gap-1 px-3 border-b py-1 border-b-blackA-A3',
+            'flex flex-row items-center gap-1 px-3 border-b py-1 border-b-blackA-A3 dark:border-b-grayDark-200',
           )}>
           <Text
             style={tailwind.style(
-              'text-md text-gray-950 font-inter-normal-20 tracking-[0.16px] min-w-[30px]',
+              'text-md text-gray-950 dark:text-grayDark-950 font-inter-normal-20 tracking-[0.16px] min-w-[30px]',
             )}>
             {i18n.t('CONVERSATION.EMAIL_HEAD.BCC')}
           </Text>
@@ -79,7 +81,7 @@ export const ReplyEmailHead = (props: EmailMetaProps) => {
             value={bccEmails}
             onChangeText={onUpdateBCC}
             placeholder="Emails separated by commas"
-            placeholderTextColor={tailwind.color('text-gray-300')}
+            placeholderTextColor={tailwind.color('text-gray-300 dark:text-grayDark-300')}
           />
         </Animated.View>
       )}

--- a/src/screens/chat-screen/components/reply-box/TypingIndicator.tsx
+++ b/src/screens/chat-screen/components/reply-box/TypingIndicator.tsx
@@ -13,11 +13,11 @@ export const TypingIndicator = ({ typingText }: TypingIndicatorProps) => {
     <View style={tailwind.style('absolute w-full items-center -top-14')}>
       <View
         style={tailwind.style(
-          'flex-row items-center py-1 px-4 shadow-md rounded-full bg-white my-1 mx-auto',
+          'flex-row items-center py-1 px-4 shadow-md rounded-full bg-white dark:bg-grayDark-100 my-1 mx-auto',
         )}>
         <Text
           style={tailwind.style(
-            'text-cxs font-inter-medium-24 tracking-[0.32px] leading-[18px] text-blackA-A11 text-center',
+            'text-cxs font-inter-medium-24 tracking-[0.32px] leading-[18px] text-blackA-A11 dark:text-grayDark-900 text-center',
           )}>
           {typingText}
         </Text>

--- a/src/screens/chat-screen/components/reply-box/buttons/SendMessageButton.tsx
+++ b/src/screens/chat-screen/components/reply-box/buttons/SendMessageButton.tsx
@@ -23,8 +23,8 @@ export const SendMessageButton = (props: SendMessageButtonProps) => {
         style={[tailwind.style('flex items-center justify-center h-10 w-10'), animatedStyle]}>
         <Animated.View
           style={tailwind.style(
-            'flex items-center justify-center h-7 w-7 rounded-full bg-gray-950',
-            isPrivateMessage ? 'bg-amber-700' : 'bg-gray-950',
+            'flex items-center justify-center h-7 w-7 rounded-full bg-gray-950 dark:bg-grayDark-950',
+            isPrivateMessage ? 'bg-amber-700 dark:bg-amber-800' : 'bg-gray-950 dark:bg-grayDark-950',
           )}>
           <Icon icon={<SendIcon />} size={16} />
         </Animated.View>

--- a/src/screens/chat-screen/components/reply-box/buttons/SendMessageButton.tsx
+++ b/src/screens/chat-screen/components/reply-box/buttons/SendMessageButton.tsx
@@ -19,9 +19,9 @@ export const SendMessageButton = (props: SendMessageButtonProps) => {
     if (variant === 'copilot') {
       return disabled ? 'bg-[#9B9EF0]' : 'bg-[#5B5BD6]';
     }
-    if (disabled) return 'bg-gray-400';
-    if (isPrivateMessage) return 'bg-amber-700';
-    return 'bg-gray-950';
+    if (disabled) return 'bg-gray-400 dark:bg-grayDark-400';
+    if (isPrivateMessage) return 'bg-amber-700 dark:bg-amber-800';
+    return 'bg-gray-950 dark:bg-grayDark-950';
   };
 
   return (
@@ -30,7 +30,10 @@ export const SendMessageButton = (props: SendMessageButtonProps) => {
         layout={LinearTransition.springify().damping(20).stiffness(180)}
         entering={sendIconEnterAnimation}
         exiting={sendIconExitAnimation}
-        style={[tailwind.style('flex items-center justify-center h-10 w-10'), disabled ? {} : animatedStyle]}>
+        style={[
+          tailwind.style('flex items-center justify-center h-10 w-10'),
+          disabled ? {} : animatedStyle,
+        ]}>
         <Animated.View
           style={tailwind.style(
             'flex items-center justify-center h-7 w-7 rounded-full',

--- a/src/screens/chat-screen/conversation-actions/components/AddParticipantList.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/AddParticipantList.tsx
@@ -19,7 +19,7 @@ const ListItem = (props: ListItemProps) => {
     <Pressable
       key={index}
       style={({ pressed }) => [
-        tailwind.style(pressed ? 'bg-gray-100' : '', index === 0 ? 'rounded-t-[13px]' : ''),
+        tailwind.style(pressed ? 'bg-gray-100 dark:bg-grayDark-100' : '', index === 0 ? 'rounded-t-[13px]' : ''),
       ]}>
       <Animated.View style={tailwind.style('flex flex-row items-center ml-3')}>
         <Animated.View>
@@ -29,7 +29,7 @@ const ListItem = (props: ListItemProps) => {
           style={tailwind.style('flex-1 py-[11px] ml-2 border-b-[1px] border-b-blackA-A3')}>
           <Animated.Text
             style={tailwind.style(
-              'text-base font-inter-420-20 leading-[22px] tracking-[0.16px] text-gray-950',
+              'text-base font-inter-420-20 leading-[22px] tracking-[0.16px] text-gray-950 dark:text-grayDark-950',
             )}>
             {listItem.name}
           </Animated.Text>
@@ -41,7 +41,7 @@ const ListItem = (props: ListItemProps) => {
 
 const ParticipantOverflowCell = ({ count }: { count: number }) => {
   return (
-    <Pressable style={({ pressed }) => [tailwind.style(pressed ? 'bg-gray-100' : '')]}>
+    <Pressable style={({ pressed }) => [tailwind.style(pressed ? 'bg-gray-100 dark:bg-grayDark-100' : '')]}>
       <Animated.View style={tailwind.style('flex flex-row items-center ml-3')}>
         <Animated.View>
           <Icon icon={<Overflow stroke={tailwind.color('text-gray-600')} />} size={28} />
@@ -50,7 +50,7 @@ const ParticipantOverflowCell = ({ count }: { count: number }) => {
           style={tailwind.style('flex-1 py-[11px] ml-2 border-b-[1px] border-b-blackA-A3')}>
           <Animated.Text
             style={tailwind.style(
-              'text-base font-inter-420-20 leading-[22px] tracking-[0.16px] text-gray-950',
+              'text-base font-inter-420-20 leading-[22px] tracking-[0.16px] text-gray-950 dark:text-grayDark-950',
             )}>
             {count} participants
           </Animated.Text>
@@ -74,12 +74,12 @@ export const AddParticipantList = (props: AddParticipantListProps) => {
       <Animated.View style={tailwind.style('pl-4 pb-3')}>
         <Animated.Text
           style={tailwind.style(
-            'text-sm font-inter-medium-24 tracking-[0.32px] leading-[16px] text-gray-700',
+            'text-sm font-inter-medium-24 tracking-[0.32px] leading-[16px] text-gray-700 dark:text-grayDark-700',
           )}>
           {i18n.t('CONVERSATION_PARTICIPANTS.TITLE')}
         </Animated.Text>
       </Animated.View>
-      <Animated.View style={[tailwind.style('rounded-[13px] mx-4 bg-white'), styles.listShadow]}>
+      <Animated.View style={[tailwind.style('rounded-[13px] mx-4 bg-white dark:bg-grayDark-50'), styles.listShadow]}>
         {conversationParticipants &&
           conversationParticipants.slice(0, 4).map((listItem, index) => {
             return <ListItem key={index} {...{ listItem, index }} />;
@@ -88,7 +88,7 @@ export const AddParticipantList = (props: AddParticipantListProps) => {
         <Pressable
           onPress={onAddParticipant}
           style={({ pressed }) => [
-            tailwind.style('rounded-b-[13px]', pressed ? 'bg-blue-100' : ''),
+            tailwind.style('rounded-b-[13px]', pressed ? 'bg-blue-100 dark:bg-blue-900' : ''),
           ]}>
           <Animated.View style={tailwind.style('flex flex-row items-center ml-3')}>
             <Animated.View style={tailwind.style('p-0.5')}>

--- a/src/screens/chat-screen/conversation-actions/components/AddParticipantList.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/AddParticipantList.tsx
@@ -19,7 +19,10 @@ const ListItem = (props: ListItemProps) => {
     <Pressable
       key={index}
       style={({ pressed }) => [
-        tailwind.style(pressed ? 'bg-gray-100' : '', index === 0 ? 'rounded-t-[13px]' : ''),
+        tailwind.style(
+          pressed ? 'bg-gray-100 dark:bg-grayDark-100' : '',
+          index === 0 ? 'rounded-t-[13px]' : '',
+        ),
       ]}>
       <Animated.View style={tailwind.style('flex flex-row items-center ml-3')}>
         <Animated.View>
@@ -29,7 +32,7 @@ const ListItem = (props: ListItemProps) => {
           style={tailwind.style('flex-1 py-[11px] ml-2 border-b-[1px] border-b-blackA-A3')}>
           <Animated.Text
             style={tailwind.style(
-              'text-base font-inter-420-20 leading-[22px] tracking-[0.16px] text-gray-950',
+              'text-base font-inter-420-20 leading-[22px] tracking-[0.16px] text-gray-950 dark:text-grayDark-950',
             )}>
             {listItem.name}
           </Animated.Text>
@@ -41,7 +44,8 @@ const ListItem = (props: ListItemProps) => {
 
 const ParticipantOverflowCell = ({ count }: { count: number }) => {
   return (
-    <Pressable style={({ pressed }) => [tailwind.style(pressed ? 'bg-gray-100' : '')]}>
+    <Pressable
+      style={({ pressed }) => [tailwind.style(pressed ? 'bg-gray-100 dark:bg-grayDark-100' : '')]}>
       <Animated.View style={tailwind.style('flex flex-row items-center ml-3')}>
         <Animated.View>
           <Icon icon={<Overflow stroke={tailwind.color('text-gray-600')} />} size={28} />
@@ -50,7 +54,7 @@ const ParticipantOverflowCell = ({ count }: { count: number }) => {
           style={tailwind.style('flex-1 py-[11px] ml-2 border-b-[1px] border-b-blackA-A3')}>
           <Animated.Text
             style={tailwind.style(
-              'text-base font-inter-420-20 leading-[22px] tracking-[0.16px] text-gray-950',
+              'text-base font-inter-420-20 leading-[22px] tracking-[0.16px] text-gray-950 dark:text-grayDark-950',
             )}>
             {count} participants
           </Animated.Text>
@@ -74,12 +78,16 @@ export const AddParticipantList = (props: AddParticipantListProps) => {
       <Animated.View style={tailwind.style('pl-4 pb-3')}>
         <Animated.Text
           style={tailwind.style(
-            'text-sm font-inter-medium-24 tracking-[0.32px] leading-[16px] text-gray-700',
+            'text-sm font-inter-medium-24 tracking-[0.32px] leading-[16px] text-gray-700 dark:text-grayDark-700',
           )}>
           {i18n.t('CONVERSATION_PARTICIPANTS.TITLE')}
         </Animated.Text>
       </Animated.View>
-      <Animated.View style={[tailwind.style('rounded-[13px] mx-4 bg-white'), styles.listShadow]}>
+      <Animated.View
+        style={[
+          tailwind.style('rounded-[13px] mx-4 bg-white dark:bg-grayDark-50'),
+          styles.listShadow,
+        ]}>
         {conversationParticipants &&
           conversationParticipants.slice(0, 4).map((listItem, index) => {
             return <ListItem key={index} {...{ listItem, index }} />;
@@ -88,7 +96,7 @@ export const AddParticipantList = (props: AddParticipantListProps) => {
         <Pressable
           onPress={onAddParticipant}
           style={({ pressed }) => [
-            tailwind.style('rounded-b-[13px]', pressed ? 'bg-blue-100' : ''),
+            tailwind.style('rounded-b-[13px]', pressed ? 'bg-blue-100 dark:bg-blue-900' : ''),
           ]}>
           <Animated.View style={tailwind.style('flex flex-row items-center ml-3')}>
             <Animated.View style={tailwind.style('p-0.5')}>

--- a/src/screens/chat-screen/conversation-actions/components/AssigneePanel.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/AssigneePanel.tsx
@@ -29,7 +29,7 @@ const AssigneePanel = ({ assignee, onPress }: AssigneePanelProps) => {
   return (
     <Pressable
       onPress={onPress}
-      style={({ pressed }) => [tailwind.style(pressed ? 'bg-gray-100' : '', 'rounded-t-[13px]')]}>
+      style={({ pressed }) => [tailwind.style(pressed ? 'bg-gray-100 dark:bg-grayDark-100' : '', 'rounded-t-[13px]')]}>
       <Animated.View style={tailwind.style('flex-row items-center justify-between pl-3')}>
         {assigneeAvatar(assignee)}
         <Animated.View
@@ -38,14 +38,14 @@ const AssigneePanel = ({ assignee, onPress }: AssigneePanelProps) => {
           )}>
           <Animated.Text
             style={tailwind.style(
-              'text-base font-inter-420-20 leading-[22px] tracking-[0.16px] text-gray-950',
+              'text-base font-inter-420-20 leading-[22px] tracking-[0.16px] text-gray-950 dark:text-grayDark-950',
             )}>
             {assigneeName}
           </Animated.Text>
           <Animated.View style={tailwind.style('flex-row items-center pr-3')}>
             <Animated.Text
               style={tailwind.style(
-                'text-base font-inter-normal-20 leading-[22px] tracking-[0.16px] text-gray-900',
+                'text-base font-inter-normal-20 leading-[22px] tracking-[0.16px] text-gray-900 dark:text-grayDark-900',
               )}>
               {assigneeActionText}
             </Animated.Text>

--- a/src/screens/chat-screen/conversation-actions/components/AssigneePanel.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/AssigneePanel.tsx
@@ -29,7 +29,9 @@ const AssigneePanel = ({ assignee, onPress }: AssigneePanelProps) => {
   return (
     <Pressable
       onPress={onPress}
-      style={({ pressed }) => [tailwind.style(pressed ? 'bg-gray-100' : '', 'rounded-t-[13px]')]}>
+      style={({ pressed }) => [
+        tailwind.style(pressed ? 'bg-gray-100 dark:bg-grayDark-100' : '', 'rounded-t-[13px]'),
+      ]}>
       <Animated.View style={tailwind.style('flex-row items-center justify-between pl-3')}>
         {assigneeAvatar(assignee)}
         <Animated.View
@@ -38,14 +40,14 @@ const AssigneePanel = ({ assignee, onPress }: AssigneePanelProps) => {
           )}>
           <Animated.Text
             style={tailwind.style(
-              'text-base font-inter-420-20 leading-[22px] tracking-[0.16px] text-gray-950',
+              'text-base font-inter-420-20 leading-[22px] tracking-[0.16px] text-gray-950 dark:text-grayDark-950',
             )}>
             {assigneeName}
           </Animated.Text>
           <Animated.View style={tailwind.style('flex-row items-center pr-3')}>
             <Animated.Text
               style={tailwind.style(
-                'text-base font-inter-normal-20 leading-[22px] tracking-[0.16px] text-gray-900',
+                'text-base font-inter-normal-20 leading-[22px] tracking-[0.16px] text-gray-900 dark:text-grayDark-900',
               )}>
               {assigneeActionText}
             </Animated.Text>

--- a/src/screens/chat-screen/conversation-actions/components/ConversationBasicActions.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/ConversationBasicActions.tsx
@@ -134,7 +134,7 @@ const ConversationActionOption = (props: ConversationActionOptionProps) => {
         <Icon icon={conversationAction.actionIcon} size={32} />
         <Animated.Text
           style={tailwind.style(
-            'text-md font-inter-normal-20 leading-[17px] tracking-[0.32px] text-center pt-5 capitalize text-gray-950 ',
+            'text-md font-inter-normal-20 leading-[17px] tracking-[0.32px] text-center pt-5 capitalize text-gray-950 dark:text-grayDark-950',
           )}>
           {conversationAction.actionText}
         </Animated.Text>

--- a/src/screens/chat-screen/conversation-actions/components/ConversationLabelActions.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/ConversationLabelActions.tsx
@@ -105,7 +105,7 @@ export const ConversationLabelActions = (props: LabelSectionProps) => {
       <Animated.View style={tailwind.style('pl-4')}>
         <Animated.Text
           style={tailwind.style(
-            'text-sm font-inter-medium-24 leading-[16px] tracking-[0.32px] text-gray-700',
+            'text-sm font-inter-medium-24 leading-[16px] tracking-[0.32px] text-gray-700 dark:text-grayDark-700',
           )}>
           Labels
         </Animated.Text>
@@ -119,8 +119,8 @@ export const ConversationLabelActions = (props: LabelSectionProps) => {
           style={({ pressed }) => [
             styles.labelShadow,
             tailwind.style(
-              'flex flex-row items-center bg-white px-3 py-[7px] rounded-lg mr-2 mt-3',
-              pressed ? 'bg-blue-100' : '',
+              'flex flex-row items-center bg-white dark:bg-grayDark-50 px-3 py-[7px] rounded-lg mr-2 mt-3',
+              pressed ? 'bg-blue-100 dark:bg-blue-900' : '',
             ),
           ]}>
           <Icon icon={<LabelTag />} size={16} />

--- a/src/screens/chat-screen/conversation-actions/components/ConversationSettingsPanel.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/ConversationSettingsPanel.tsx
@@ -26,7 +26,7 @@ export const ConversationSettingsPanel = ({
   onChangePriority,
 }: ConversationSettingsPanelProps) => {
   return (
-    <Animated.View style={[tailwind.style('rounded-[13px] mx-4 bg-white'), styles.listShadow]}>
+    <Animated.View style={[tailwind.style('rounded-[13px] mx-4 bg-white dark:bg-grayDark-50'), styles.listShadow]}>
       <AssigneePanel assignee={assignee} onPress={onChangeAssignee} />
       <TeamPanel team={team} onPress={onChangeTeamAssignee} />
       <PriorityPanel priority={priority} onPress={onChangePriority} />

--- a/src/screens/chat-screen/conversation-actions/components/ConversationSettingsPanel.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/ConversationSettingsPanel.tsx
@@ -26,7 +26,11 @@ export const ConversationSettingsPanel = ({
   onChangePriority,
 }: ConversationSettingsPanelProps) => {
   return (
-    <Animated.View style={[tailwind.style('rounded-[13px] mx-4 bg-white'), styles.listShadow]}>
+    <Animated.View
+      style={[
+        tailwind.style('rounded-[13px] mx-4 bg-white dark:bg-grayDark-50'),
+        styles.listShadow,
+      ]}>
       <AssigneePanel assignee={assignee} onPress={onChangeAssignee} />
       <TeamPanel team={team} onPress={onChangeTeamAssignee} />
       <PriorityPanel priority={priority} onPress={onChangePriority} />

--- a/src/screens/chat-screen/conversation-actions/components/PriorityPanel.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/PriorityPanel.tsx
@@ -24,7 +24,7 @@ const PriorityPanel = ({ priority, onPress }: PriorityPanelProps) => {
   return (
     <Pressable
       onPress={onPress}
-      style={({ pressed }) => [tailwind.style(pressed ? 'bg-gray-100' : '', 'rounded-t-[13px]')]}>
+      style={({ pressed }) => [tailwind.style(pressed ? 'bg-gray-100 dark:bg-grayDark-100' : '', 'rounded-t-[13px]')]}>
       <Animated.View style={tailwind.style('flex-row items-center justify-between pl-3')}>
         {priorityAvatar(priority)}
         <Animated.View
@@ -33,14 +33,14 @@ const PriorityPanel = ({ priority, onPress }: PriorityPanelProps) => {
           )}>
           <Animated.Text
             style={tailwind.style(
-              'text-base font-inter-420-20 leading-[22.4px] tracking-[0.16px] text-gray-950 capitalize',
+              'text-base font-inter-420-20 leading-[22.4px] tracking-[0.16px] text-gray-950 dark:text-grayDark-950 capitalize',
             )}>
             {priorityName}
           </Animated.Text>
           <Animated.View style={tailwind.style('flex-row items-center pr-3')}>
             <Animated.Text
               style={tailwind.style(
-                'text-base font-inter-normal-20 leading-[22px] tracking-[0.16px] text-gray-900',
+                'text-base font-inter-normal-20 leading-[22px] tracking-[0.16px] text-gray-900 dark:text-grayDark-900',
               )}>
               {i18n.t('CONVERSATION.ACTIONS.PRIORITY.EDIT')}
             </Animated.Text>

--- a/src/screens/chat-screen/conversation-actions/components/PriorityPanel.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/PriorityPanel.tsx
@@ -26,7 +26,9 @@ const PriorityPanel = ({ priority, onPress }: PriorityPanelProps) => {
   return (
     <Pressable
       onPress={onPress}
-      style={({ pressed }) => [tailwind.style(pressed ? 'bg-gray-100' : '', 'rounded-t-[13px]')]}>
+      style={({ pressed }) => [
+        tailwind.style(pressed ? 'bg-gray-100 dark:bg-grayDark-100' : '', 'rounded-t-[13px]'),
+      ]}>
       <Animated.View style={tailwind.style('flex-row items-center justify-between pl-3')}>
         {priorityAvatar(priority)}
         <Animated.View
@@ -35,14 +37,14 @@ const PriorityPanel = ({ priority, onPress }: PriorityPanelProps) => {
           )}>
           <Animated.Text
             style={tailwind.style(
-              'text-base font-inter-420-20 leading-[22.4px] tracking-[0.16px] text-gray-950 capitalize',
+              'text-base font-inter-420-20 leading-[22.4px] tracking-[0.16px] text-gray-950 dark:text-grayDark-950 capitalize',
             )}>
             {priorityName}
           </Animated.Text>
           <Animated.View style={tailwind.style('flex-row items-center pr-3')}>
             <Animated.Text
               style={tailwind.style(
-                'text-base font-inter-normal-20 leading-[22px] tracking-[0.16px] text-gray-900',
+                'text-base font-inter-normal-20 leading-[22px] tracking-[0.16px] text-gray-900 dark:text-grayDark-900',
               )}>
               {i18n.t('CONVERSATION.ACTIONS.PRIORITY.EDIT')}
             </Animated.Text>

--- a/src/screens/chat-screen/conversation-actions/components/TeamPanel.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/TeamPanel.tsx
@@ -17,7 +17,7 @@ const TeamPanel = ({ team, onPress }: TeamPanelProps) => {
   return (
     <Pressable
       onPress={onPress}
-      style={({ pressed }) => [tailwind.style(pressed ? 'bg-gray-100' : '', 'rounded-t-[13px]')]}>
+      style={({ pressed }) => [tailwind.style(pressed ? 'bg-gray-100 dark:bg-grayDark-100' : '', 'rounded-t-[13px]')]}>
       <Animated.View style={tailwind.style('flex-row items-center justify-between pl-3')}>
         <Icon icon={<TeamIcon />} />
         <Animated.View
@@ -26,14 +26,14 @@ const TeamPanel = ({ team, onPress }: TeamPanelProps) => {
           )}>
           <Animated.Text
             style={tailwind.style(
-              'text-base font-inter-420-20 leading-[22.4px] tracking-[0.16px] text-gray-950 capitalize',
+              'text-base font-inter-420-20 leading-[22.4px] tracking-[0.16px] text-gray-950 dark:text-grayDark-950 capitalize',
             )}>
             {teamName}
           </Animated.Text>
           <Animated.View style={tailwind.style('flex-row items-center pr-3')}>
             <Animated.Text
               style={tailwind.style(
-                'text-base font-inter-normal-20 leading-[22px] tracking-[0.16px] text-gray-900',
+                'text-base font-inter-normal-20 leading-[22px] tracking-[0.16px] text-gray-900 dark:text-grayDark-900',
               )}>
               {i18n.t('CONVERSATION.ACTIONS.TEAM.ASSIGN')}
             </Animated.Text>

--- a/src/screens/chat-screen/conversation-actions/components/TeamPanel.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/TeamPanel.tsx
@@ -17,7 +17,9 @@ const TeamPanel = ({ team, onPress }: TeamPanelProps) => {
   return (
     <Pressable
       onPress={onPress}
-      style={({ pressed }) => [tailwind.style(pressed ? 'bg-gray-100' : '', 'rounded-t-[13px]')]}>
+      style={({ pressed }) => [
+        tailwind.style(pressed ? 'bg-gray-100 dark:bg-grayDark-100' : '', 'rounded-t-[13px]'),
+      ]}>
       <Animated.View style={tailwind.style('flex-row items-center justify-between pl-3')}>
         <Icon icon={<TeamIcon />} />
         <Animated.View
@@ -26,14 +28,14 @@ const TeamPanel = ({ team, onPress }: TeamPanelProps) => {
           )}>
           <Animated.Text
             style={tailwind.style(
-              'text-base font-inter-420-20 leading-[22.4px] tracking-[0.16px] text-gray-950 capitalize',
+              'text-base font-inter-420-20 leading-[22.4px] tracking-[0.16px] text-gray-950 dark:text-grayDark-950 capitalize',
             )}>
             {teamName}
           </Animated.Text>
           <Animated.View style={tailwind.style('flex-row items-center pr-3')}>
             <Animated.Text
               style={tailwind.style(
-                'text-base font-inter-normal-20 leading-[22px] tracking-[0.16px] text-gray-900',
+                'text-base font-inter-normal-20 leading-[22px] tracking-[0.16px] text-gray-900 dark:text-grayDark-900',
               )}>
               {i18n.t('CONVERSATION.ACTIONS.TEAM.ASSIGN')}
             </Animated.Text>

--- a/src/screens/chat-screen/conversation-actions/components/UpdateParticipant.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/UpdateParticipant.tsx
@@ -40,7 +40,7 @@ const ParticipantCell = (props: ParticipantCellProps) => {
         <Animated.Text
           style={[
             tailwind.style(
-              'text-base text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
+              'text-base text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
             ),
           ]}>
           {value.name}

--- a/src/screens/chat-screen/conversation-actions/components/UpdateParticipant.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/UpdateParticipant.tsx
@@ -39,7 +39,7 @@ const ParticipantCell = (props: ParticipantCellProps) => {
         <Animated.Text
           style={[
             tailwind.style(
-              'text-base text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
+              'text-base text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
             ),
           ]}>
           {value.name}

--- a/src/screens/contact-details/ContactDetailsScreen.tsx
+++ b/src/screens/contact-details/ContactDetailsScreen.tsx
@@ -209,7 +209,7 @@ const ContactDetailsScreen = (props: ContactDetailsScreenProps) => {
   return (
     <View
       style={tailwind.style(
-        `flex-1 bg-white pt-6 ${Platform.OS === 'android' ? 'pt-12' : 'pt-6'}`,
+        `flex-1 bg-white dark:bg-grayDark-50 pt-6 ${Platform.OS === 'android' ? 'pt-12' : 'pt-6'}`,
       )}>
       <ContactDetailsScreenHeader
         name={name || contactName || ''}

--- a/src/screens/contact-details/ContactDetailsScreen.tsx
+++ b/src/screens/contact-details/ContactDetailsScreen.tsx
@@ -191,8 +191,7 @@ const ContactDetailsScreen = (props: ContactDetailsScreenProps) => {
       type: 'link',
     }));
 
-  const fullLocation =
-    location || [city, country].filter(Boolean).join(', ') || null;
+  const fullLocation = location || [city, country].filter(Boolean).join(', ') || null;
 
   const userDetails: GenericListType[] = [
     {
@@ -227,7 +226,7 @@ const ContactDetailsScreen = (props: ContactDetailsScreenProps) => {
     <BottomSheetModalProvider>
       <View
         style={tailwind.style(
-          `flex-1 bg-white pt-6 ${Platform.OS === 'android' ? 'pt-12' : 'pt-6'}`,
+          `flex-1 bg-white dark:bg-grayDark-50 pt-6 ${Platform.OS === 'android' ? 'pt-12' : 'pt-6'}`,
         )}>
         <ContactDetailsScreenHeader
           name={name || contactName || ''}

--- a/src/screens/contact-details/components/ContactBasicActions.tsx
+++ b/src/screens/contact-details/components/ContactBasicActions.tsx
@@ -39,9 +39,9 @@ const ContactOptionComponent = (props: ContactOptionProps) => {
       <Pressable
         style={({ pressed }) => [
           tailwind.style(
-            'flex items-center justify-center flex-1 rounded-xl bg-gray-50 py-3',
+            'flex items-center justify-center flex-1 rounded-xl bg-gray-50 dark:bg-grayDark-50 py-3',
             `w-[${OPTION_WIDTH}px]`,
-            pressed ? 'bg-gray-100' : '',
+            pressed ? 'bg-gray-100 dark:bg-grayDark-100' : '',
           ),
         ]}
         onPress={handleOnPress}

--- a/src/screens/contact-details/components/ContactDetailsScreenHeader.tsx
+++ b/src/screens/contact-details/components/ContactDetailsScreenHeader.tsx
@@ -35,12 +35,12 @@ export const ContactDetailsScreenHeader = (props: ContactDetailsScreenHeaderProp
         <Animated.View style={tailwind.style('flex items-center')}>
           <Avatar size="4xl" src={thumbnail ? { uri: thumbnail } : undefined} name={name} />
           <Animated.View style={tailwind.style('flex flex-col items-center gap-1 pt-3')}>
-            <Animated.Text style={tailwind.style('text-[21px] font-inter-580-24 text-gray-950')}>
+            <Animated.Text style={tailwind.style('text-[21px] font-inter-580-24 text-gray-950 dark:text-grayDark-950')}>
               {name}
             </Animated.Text>
             <Animated.Text
               style={tailwind.style(
-                'text-[15px] font-inter-420-20 leading-[17.25px] text-gray-900',
+                'text-[15px] font-inter-420-20 leading-[17.25px] text-gray-900 dark:text-grayDark-900',
               )}>
               {bio}
             </Animated.Text>

--- a/src/screens/contact-details/components/ContactDetailsScreenHeader.tsx
+++ b/src/screens/contact-details/components/ContactDetailsScreenHeader.tsx
@@ -35,12 +35,15 @@ export const ContactDetailsScreenHeader = (props: ContactDetailsScreenHeaderProp
         <Animated.View style={tailwind.style('flex items-center')}>
           <Avatar size="4xl" src={thumbnail ? { uri: thumbnail } : undefined} name={name} />
           <Animated.View style={tailwind.style('flex flex-col items-center gap-1 pt-3')}>
-            <Animated.Text style={tailwind.style('text-[21px] font-inter-580-24 text-gray-950')}>
+            <Animated.Text
+              style={tailwind.style(
+                'text-[21px] font-inter-580-24 text-gray-950 dark:text-grayDark-950',
+              )}>
               {name}
             </Animated.Text>
             <Animated.Text
               style={tailwind.style(
-                'text-[15px] font-inter-420-20 leading-[17.25px] text-gray-900',
+                'text-[15px] font-inter-420-20 leading-[17.25px] text-gray-900 dark:text-grayDark-900',
               )}>
               {bio}
             </Animated.Text>

--- a/src/screens/conversations/ConversationScreen.tsx
+++ b/src/screens/conversations/ConversationScreen.tsx
@@ -36,6 +36,7 @@ import {
   ConversationListStateProvider,
   useConversationListStateContext,
   useRefsContext,
+  useTheme,
 } from '@/context';
 
 import { tailwind } from '@/theme';
@@ -250,7 +251,7 @@ const ConversationList = () => {
         `pb-[${TAB_BAR_HEIGHT}px]`,
       )}>
       <EmptyStateIcon />
-      <Animated.Text style={tailwind.style('pt-6 text-md  tracking-[0.32px] text-gray-800')}>
+      <Animated.Text style={tailwind.style('pt-6 text-md  tracking-[0.32px] text-gray-800 dark:text-grayDark-800')}>
         {i18n.t('CONVERSATION.EMPTY')}
       </Animated.Text>
     </Animated.ScrollView>
@@ -276,6 +277,7 @@ const ConversationList = () => {
 const ConversationScreen = () => {
   const currentBottomSheet = useAppSelector(selectBottomSheetState);
   const dispatch = useAppDispatch();
+  const { isDark } = useTheme();
 
   const animationConfigs = useBottomSheetSpringConfigs({
     mass: 1.2,
@@ -310,11 +312,11 @@ const ConversationScreen = () => {
   }, [currentBottomSheet]);
 
   return (
-    <SafeAreaView edges={['top']} style={tailwind.style('flex-1 bg-white')}>
+    <SafeAreaView edges={['top']} style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
       <StatusBar
         translucent
-        backgroundColor={tailwind.color('bg-white')}
-        barStyle={'dark-content'}
+        backgroundColor={tailwind.color('bg-white dark:bg-grayDark-50')}
+        barStyle={isDark ? 'light-content' : 'dark-content'}
       />
       <ConversationListStateProvider>
         <ConversationHeader />

--- a/src/screens/conversations/ConversationScreen.tsx
+++ b/src/screens/conversations/ConversationScreen.tsx
@@ -36,6 +36,7 @@ import {
   ConversationListStateProvider,
   useConversationListStateContext,
   useRefsContext,
+  useTheme,
 } from '@/context';
 
 import { tailwind } from '@/theme';
@@ -250,7 +251,10 @@ const ConversationList = () => {
         `pb-[${TAB_BAR_HEIGHT}px]`,
       )}>
       <EmptyStateIcon />
-      <Animated.Text style={tailwind.style('pt-6 text-md  tracking-[0.32px] text-gray-800')}>
+      <Animated.Text
+        style={tailwind.style(
+          'pt-6 text-md  tracking-[0.32px] text-gray-800 dark:text-grayDark-800',
+        )}>
         {i18n.t('CONVERSATION.EMPTY')}
       </Animated.Text>
     </Animated.ScrollView>
@@ -276,6 +280,7 @@ const ConversationList = () => {
 const ConversationScreen = () => {
   const currentBottomSheet = useAppSelector(selectBottomSheetState);
   const dispatch = useAppDispatch();
+  const { isDark } = useTheme();
 
   const animationConfigs = useBottomSheetSpringConfigs({
     mass: 1.2,
@@ -310,11 +315,11 @@ const ConversationScreen = () => {
   }, [currentBottomSheet]);
 
   return (
-    <SafeAreaView edges={['top']} style={tailwind.style('flex-1 bg-white')}>
+    <SafeAreaView edges={['top']} style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
       <StatusBar
         translucent
-        backgroundColor={tailwind.color('bg-white')}
-        barStyle={'dark-content'}
+        backgroundColor={tailwind.color('bg-white dark:bg-grayDark-50')}
+        barStyle={isDark ? 'light-content' : 'dark-content'}
       />
       <ConversationListStateProvider>
         <ConversationHeader />

--- a/src/screens/conversations/components/conversation-actions/UpdateAssignee.tsx
+++ b/src/screens/conversations/components/conversation-actions/UpdateAssignee.tsx
@@ -46,7 +46,7 @@ const AssigneeCell = (props: AssigneeCellProps) => {
         <Animated.Text
           style={[
             tailwind.style(
-              'text-base text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
+              'text-base text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
             ),
           ]}>
           {agent.name}

--- a/src/screens/conversations/components/conversation-actions/UpdatePriority.tsx
+++ b/src/screens/conversations/components/conversation-actions/UpdatePriority.tsx
@@ -48,7 +48,7 @@ const PriorityCell = (props: PriorityCellProps) => {
         )}>
         <Animated.Text
           style={tailwind.style(
-            'text-base text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px] capitalize',
+            'text-base text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px] capitalize',
           )}>
           {i18n.t(`CONVERSATION.PRIORITY.OPTIONS.${PriorityOptions[value.id].toUpperCase()}`)}
         </Animated.Text>

--- a/src/screens/conversations/components/conversation-actions/UpdateStatus.tsx
+++ b/src/screens/conversations/components/conversation-actions/UpdateStatus.tsx
@@ -46,7 +46,7 @@ const StatusCell = (props: StatusCellProps) => {
         )}>
         <Animated.Text
           style={tailwind.style(
-            'text-base text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px] capitalize',
+            'text-base text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px] capitalize',
           )}>
           {i18n.t(`CONVERSATION.ASSIGNEE.STATUS.OPTIONS.${StatusOptions[value.id].toUpperCase()}`)}
         </Animated.Text>

--- a/src/screens/conversations/components/conversation-actions/UpdateTeam.tsx
+++ b/src/screens/conversations/components/conversation-actions/UpdateTeam.tsx
@@ -58,7 +58,7 @@ const TeamCell = (props: TeamCellProps) => {
         <Animated.Text
           style={[
             tailwind.style(
-              'text-base text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
+              'text-base text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
             ),
           ]}>
           {value.name}

--- a/src/screens/conversations/components/conversation-filters/AssigneeTypeFilters.tsx
+++ b/src/screens/conversations/components/conversation-filters/AssigneeTypeFilters.tsx
@@ -47,7 +47,7 @@ const AssigneeTypeCell = (props: AssigneeTypeCellProps) => {
         )}>
         <Animated.Text
           style={tailwind.style(
-            'text-base text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px] capitalize',
+            'text-base text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px] capitalize',
           )}>
           {i18n.t(`CONVERSATION.FILTERS.ASSIGNEE_TYPE.OPTIONS.${value.toUpperCase()}`)}
         </Animated.Text>

--- a/src/screens/conversations/components/conversation-filters/InboxFilters.tsx
+++ b/src/screens/conversations/components/conversation-filters/InboxFilters.tsx
@@ -51,7 +51,7 @@ const InboxCell = (props: InboxCellProps) => {
 
           <Animated.Text
             style={tailwind.style(
-              'text-base text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px] capitalize ml-2',
+              'text-base text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px] capitalize ml-2',
             )}>
             {value.name}
           </Animated.Text>

--- a/src/screens/conversations/components/conversation-filters/SortByFilters.tsx
+++ b/src/screens/conversations/components/conversation-filters/SortByFilters.tsx
@@ -45,7 +45,7 @@ const SortByCell = (props: SortByCellProps) => {
         )}>
         <Animated.Text
           style={tailwind.style(
-            'text-base text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px] capitalize',
+            'text-base text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px] capitalize',
           )}>
           {i18n.t(`CONVERSATION.FILTERS.SORT_BY.OPTIONS.${value.toUpperCase()}`)}
         </Animated.Text>

--- a/src/screens/conversations/components/conversation-filters/StatusFilters.tsx
+++ b/src/screens/conversations/components/conversation-filters/StatusFilters.tsx
@@ -52,7 +52,7 @@ const StatusCell = (props: StatusCellProps) => {
         )}>
         <Animated.Text
           style={tailwind.style(
-            'text-base text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px] capitalize',
+            'text-base text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px] capitalize',
           )}>
           {i18n.t(`CONVERSATION.FILTERS.STATUS.OPTIONS.${StatusOptions[value.id].toUpperCase()}`)}
         </Animated.Text>

--- a/src/screens/conversations/components/conversation-header/ConversationHeaderPresenter.tsx
+++ b/src/screens/conversations/components/conversation-header/ConversationHeaderPresenter.tsx
@@ -42,7 +42,7 @@ const HeaderTitle = () => (
   <Animated.View style={tailwind.style('flex-1')}>
     <Text
       style={tailwind.style(
-        'text-[17px] font-inter-medium-24 tracking-[0.32px] leading-[17px] text-center text-gray-950',
+        'text-[17px] font-inter-medium-24 tracking-[0.32px] leading-[17px] text-center text-gray-950 dark:text-grayDark-950',
       )}>
       {i18n.t('CONVERSATION.HEADER.TITLE')}
     </Text>
@@ -73,7 +73,7 @@ const LeftSection = ({ currentState, isSelectedAll, onLeftIconPress }: LeftSecti
               isSelectedAll ? (
                 <CheckedIcon />
               ) : (
-                <UncheckedIcon stroke={tailwind.color('text-gray-800')} />
+                <UncheckedIcon stroke={tailwind.color('text-gray-800 dark:text-grayDark-800')} />
               )
             }
           />
@@ -100,7 +100,7 @@ const FilterSection = ({
         <Text
           style={tailwind.style(
             'text-md font-inter-medium-24 leading-[17px] tracking-[0.24px]',
-            filtersAppliedCount === 0 ? 'text-gray-700' : 'text-blue-800',
+            filtersAppliedCount === 0 ? 'text-gray-700 dark:text-grayDark-700' : 'text-blue-800',
           )}>
           {i18n.t('CONVERSATION.HEADER.CLEAR_FILTER')}
           {filtersAppliedCount > 0 ? ` (${filtersAppliedCount})` : ''}

--- a/src/screens/conversations/components/conversation-header/ConversationHeaderPresenter.tsx
+++ b/src/screens/conversations/components/conversation-header/ConversationHeaderPresenter.tsx
@@ -42,7 +42,7 @@ const HeaderTitle = () => (
   <Animated.View style={tailwind.style('flex-1')}>
     <Text
       style={tailwind.style(
-        'text-[17px] font-inter-medium-24 tracking-[0.32px] leading-[17px] text-center text-gray-950',
+        'text-[17px] font-inter-medium-24 tracking-[0.32px] leading-[17px] text-center text-gray-950 dark:text-grayDark-950',
       )}>
       {i18n.t('CONVERSATION.HEADER.TITLE')}
     </Text>
@@ -75,7 +75,7 @@ const LeftSection = ({ currentState, isSelectedAll, onLeftIconPress }: LeftSecti
               isSelectedAll ? (
                 <CheckedIcon />
               ) : (
-                <UncheckedIcon stroke={tailwind.color('text-gray-800')} />
+                <UncheckedIcon stroke={tailwind.color('text-gray-800 dark:text-grayDark-800')} />
               )
             }
           />
@@ -102,7 +102,7 @@ const FilterSection = ({
         <Text
           style={tailwind.style(
             'text-md font-inter-medium-24 leading-[17px] tracking-[0.24px]',
-            filtersAppliedCount === 0 ? 'text-gray-700' : 'text-blue-800',
+            filtersAppliedCount === 0 ? 'text-gray-700 dark:text-grayDark-700' : 'text-blue-800',
           )}>
           {i18n.t('CONVERSATION.HEADER.CLEAR_FILTER')}
           {filtersAppliedCount > 0 ? ` (${filtersAppliedCount})` : ''}

--- a/src/screens/conversations/components/conversation-item/ConversationId.tsx
+++ b/src/screens/conversations/components/conversation-item/ConversationId.tsx
@@ -12,8 +12,8 @@ export const ConversationId = (props: ConversationIdProps) => {
   const { id } = props;
   return (
     <NativeView style={tailwind.style('flex flex-row items-center gap-0.5')}>
-      <Text style={tailwind.style('text-sm font-inter-420-20 text-gray-700')}>#</Text>
-      <Text style={tailwind.style('text-sm font-inter-420-20 text-gray-700')}>{id}</Text>
+      <Text style={tailwind.style('text-sm font-inter-420-20 text-gray-700 dark:text-grayDark-700')}>#</Text>
+      <Text style={tailwind.style('text-sm font-inter-420-20 text-gray-700 dark:text-grayDark-700')}>{id}</Text>
     </NativeView>
   );
 };

--- a/src/screens/conversations/components/conversation-item/ConversationId.tsx
+++ b/src/screens/conversations/components/conversation-item/ConversationId.tsx
@@ -12,8 +12,14 @@ export const ConversationId = (props: ConversationIdProps) => {
   const { id } = props;
   return (
     <NativeView style={tailwind.style('flex flex-row items-center gap-0.5')}>
-      <Text style={tailwind.style('text-sm font-inter-420-20 text-gray-700')}>#</Text>
-      <Text style={tailwind.style('text-sm font-inter-420-20 text-gray-700')}>{id}</Text>
+      <Text
+        style={tailwind.style('text-sm font-inter-420-20 text-gray-700 dark:text-grayDark-700')}>
+        #
+      </Text>
+      <Text
+        style={tailwind.style('text-sm font-inter-420-20 text-gray-700 dark:text-grayDark-700')}>
+        {id}
+      </Text>
     </NativeView>
   );
 };

--- a/src/screens/conversations/components/conversation-item/ConversationItemDetail.tsx
+++ b/src/screens/conversations/components/conversation-item/ConversationItemDetail.tsx
@@ -93,7 +93,7 @@ export const ConversationItemDetail = memo((props: ConversationDetailSubCellProp
           <Text
             numberOfLines={1}
             style={tailwind.style(
-              'text-base font-inter-medium-24 tracking-[0.24px] text-gray-950 capitalize',
+              'text-base font-inter-medium-24 tracking-[0.24px] text-gray-950 dark:text-grayDark-950 capitalize',
               // Calculated based on the widths of other content,
               // We might have to do a 10-20px offset based on the max width of the timestamp
               `max-w-[${width - 250}px]`,

--- a/src/screens/conversations/components/conversation-item/ConversationLastMessage.tsx
+++ b/src/screens/conversations/components/conversation-item/ConversationLastMessage.tsx
@@ -84,7 +84,7 @@ const MessageContent = ({
         <Text
           numberOfLines={1}
           style={tailwind.style(
-            'text-md flex-1 font-inter-420-20 tracking-[0.32px] leading-[21px] text-gray-900',
+            'text-md flex-1 font-inter-420-20 tracking-[0.32px] leading-[21px] text-gray-900 dark:text-grayDark-900',
           )}>
           <MessageType message={message} style={tailwind.style('ml-1')} />
           {i18n.t(`CONVERSATION.ATTACHMENTS.image.CONTENT`)}
@@ -97,13 +97,13 @@ const MessageContent = ({
         <Text
           numberOfLines={numberOfLines}
           style={tailwind.style(
-            'text-md flex-1 font-inter-420-20 tracking-[0.3px] leading-[21px] text-gray-900',
+            'text-md flex-1 font-inter-420-20 tracking-[0.3px] leading-[21px] text-gray-900 dark:text-grayDark-900',
           )}>
           <MessageType message={message} style={tailwind.style('ml-1')} />
           <Text
             numberOfLines={numberOfLines}
             style={tailwind.style(
-              'text-md flex-1 font-inter-420-20 tracking-[0.3px] leading-[21px] text-gray-900',
+              'text-md flex-1 font-inter-420-20 tracking-[0.3px] leading-[21px] text-gray-900 dark:text-grayDark-900',
             )}>
             {lastMessageContent}
           </Text>
@@ -118,7 +118,7 @@ const MessageContent = ({
         <Text
           numberOfLines={1}
           style={tailwind.style(
-            'text-md flex-1 font-inter-420-20 tracking-[0.32px] leading-[21px] text-gray-900',
+            'text-md flex-1 font-inter-420-20 tracking-[0.32px] leading-[21px] text-gray-900 dark:text-grayDark-900',
           )}>
           {i18n.t(`CONVERSATION.ATTACHMENTS.${lastMessageFileType}.CONTENT`)}
         </Text>
@@ -128,7 +128,7 @@ const MessageContent = ({
   return (
     <Text
       style={tailwind.style(
-        'text-md flex-1 font-inter-420-20 tracking-[0.32px] leading-[21px] text-gray-900',
+        'text-md flex-1 font-inter-420-20 tracking-[0.32px] leading-[21px] text-gray-900 dark:text-grayDark-900',
       )}>
       {i18n.t('CONVERSATION.NO_CONTENT')}
     </Text>

--- a/src/screens/conversations/components/conversation-item/LabelIndicator.tsx
+++ b/src/screens/conversations/components/conversation-item/LabelIndicator.tsx
@@ -23,7 +23,7 @@ const LabelText = ({ labelText, labelColor }: { labelText: string; labelColor: s
     <NativeView style={tailwind.style('h-[5px] w-[5px] rounded-full', `bg-[${labelColor}]`)} />
     <Text
       style={tailwind.style(
-        'pl-1 text-sm font-inter-420-20 leading-[16px] tracking-[0.32px] text-gray-700',
+        'pl-1 text-sm font-inter-420-20 leading-[16px] tracking-[0.32px] text-gray-700 dark:text-grayDark-700',
       )}>
       {labelText}
     </Text>

--- a/src/screens/conversations/components/conversation-item/LastActivityTime.tsx
+++ b/src/screens/conversations/components/conversation-item/LastActivityTime.tsx
@@ -45,7 +45,7 @@ export const LastActivityTime = ({ timestamp }: LastActivityTimeProps) => {
     <NativeView>
       <Text
         style={tailwind.style(
-          'text-sm font-inter-420-20 leading-[16px] tracking-[0.32px] text-gray-700',
+          'text-sm font-inter-420-20 leading-[16px] tracking-[0.32px] text-gray-700 dark:text-grayDark-700',
         )}>
         {lastActivityTime}
       </Text>

--- a/src/screens/conversations/components/conversation-item/SLAIndicator.tsx
+++ b/src/screens/conversations/components/conversation-item/SLAIndicator.tsx
@@ -85,7 +85,7 @@ export const SLAIndicator = ({
       <Text
         style={tailwind.style(
           'pl-1 text-sm leading-[20px] text-center',
-          slaStatus?.isSlaMissed ? 'text-ruby-800' : 'text-gray-800',
+          slaStatus?.isSlaMissed ? 'text-ruby-800' : 'text-gray-800 dark:text-grayDark-800',
         )}>
         {`${sLAStatusText()}: ${slaStatus?.threshold}`}
       </Text>

--- a/src/screens/dashboard/DashboardScreen.tsx
+++ b/src/screens/dashboard/DashboardScreen.tsx
@@ -54,7 +54,7 @@ const DashboardScreen = () => {
     <Animated.View style={tailwind.style('flex-1')}>
       <Animated.View
         style={tailwind.style(
-          'flex flex-row items-center justify-between px-4 border-b-[1px] border-b-blackA-A3 py-[12px] bg-white',
+          'flex flex-row items-center justify-between px-4 border-b-[1px] border-b-blackA-A3 py-[12px] bg-white dark:bg-grayDark-50',
         )}>
         <Pressable hitSlop={16} onPress={handleBackPress}>
           <Animated.View>
@@ -64,7 +64,7 @@ const DashboardScreen = () => {
         <Animated.View>
           <Animated.Text
             style={tailwind.style(
-              'text-[17px] font-inter-medium-24 tracking-[0.32px] text-gray-950',
+              'text-[17px] font-inter-medium-24 tracking-[0.32px] text-gray-950 dark:text-grayDark-950',
             )}>
             {title}
           </Animated.Text>

--- a/src/screens/inbox/InboxScreen.tsx
+++ b/src/screens/inbox/InboxScreen.tsx
@@ -10,7 +10,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { FlashList, ListRenderItem } from '@shopify/flash-list';
 
 import { TAB_BAR_HEIGHT } from '@/constants';
-import { InboxListStateProvider } from '@/context';
+import { InboxListStateProvider, useTheme } from '@/context';
 import type { Notification } from '@/types/Notification';
 import { tailwind } from '@/theme';
 import { useAppDispatch, useAppSelector } from '@/hooks';
@@ -147,7 +147,7 @@ const InboxList = () => {
         `pb-[${TAB_BAR_HEIGHT}px]`,
       )}>
       <EmptyStateIcon />
-      <Animated.Text style={tailwind.style('pt-6 text-md tracking-[0.32px] text-gray-800')}>
+      <Animated.Text style={tailwind.style('pt-6 text-md tracking-[0.32px] text-gray-800 dark:text-grayDark-800')}>
         {i18n.t('NOTIFICATION.EMPTY')}
       </Animated.Text>
     </Animated.ScrollView>
@@ -170,6 +170,7 @@ const InboxList = () => {
 
 const InboxScreen = () => {
   const dispatch = useAppDispatch();
+  const { isDark } = useTheme();
 
   // Memoize the markAllAsRead callback
   const markAllAsRead = useCallback(async () => {
@@ -180,11 +181,11 @@ const InboxScreen = () => {
   }, [dispatch]);
 
   return (
-    <SafeAreaView edges={['top']} style={tailwind.style('flex-1 bg-white')}>
+    <SafeAreaView edges={['top']} style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
       <StatusBar
         translucent
-        backgroundColor={tailwind.color('bg-white')}
-        barStyle={'dark-content'}
+        backgroundColor={tailwind.color('bg-white dark:bg-grayDark-50')}
+        barStyle={isDark ? 'light-content' : 'dark-content'}
       />
       <InboxListStateProvider>
         <InboxHeader markAllAsRead={markAllAsRead} />

--- a/src/screens/inbox/InboxScreen.tsx
+++ b/src/screens/inbox/InboxScreen.tsx
@@ -10,7 +10,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { FlashList, ListRenderItem } from '@shopify/flash-list';
 
 import { TAB_BAR_HEIGHT } from '@/constants';
-import { InboxListStateProvider } from '@/context';
+import { InboxListStateProvider, useTheme } from '@/context';
 import type { Notification } from '@/types/Notification';
 import { tailwind } from '@/theme';
 import { useAppDispatch, useAppSelector } from '@/hooks';
@@ -147,7 +147,10 @@ const InboxList = () => {
         `pb-[${TAB_BAR_HEIGHT}px]`,
       )}>
       <EmptyStateIcon />
-      <Animated.Text style={tailwind.style('pt-6 text-md tracking-[0.32px] text-gray-800')}>
+      <Animated.Text
+        style={tailwind.style(
+          'pt-6 text-md tracking-[0.32px] text-gray-800 dark:text-grayDark-800',
+        )}>
         {i18n.t('NOTIFICATION.EMPTY')}
       </Animated.Text>
     </Animated.ScrollView>
@@ -170,6 +173,7 @@ const InboxList = () => {
 
 const InboxScreen = () => {
   const dispatch = useAppDispatch();
+  const { isDark } = useTheme();
 
   // Memoize the markAllAsRead callback
   const markAllAsRead = useCallback(async () => {
@@ -180,11 +184,11 @@ const InboxScreen = () => {
   }, [dispatch]);
 
   return (
-    <SafeAreaView edges={['top']} style={tailwind.style('flex-1 bg-white')}>
+    <SafeAreaView edges={['top']} style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50')}>
       <StatusBar
         translucent
-        backgroundColor={tailwind.color('bg-white')}
-        barStyle={'dark-content'}
+        backgroundColor={tailwind.color('bg-white dark:bg-grayDark-50')}
+        barStyle={isDark ? 'light-content' : 'dark-content'}
       />
       <InboxListStateProvider>
         <InboxHeader markAllAsRead={markAllAsRead} />

--- a/src/screens/inbox/components/InboxFilters.tsx
+++ b/src/screens/inbox/components/InboxFilters.tsx
@@ -42,7 +42,7 @@ const SortByCell = (props: SortByCellProps) => {
         )}>
         <Animated.Text
           style={tailwind.style(
-            'text-base text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px] capitalize',
+            'text-base text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px] capitalize',
           )}>
           {i18n.t(`NOTIFICATION.FILTERS.SORT_BY.OPTIONS.${value.toUpperCase()}`)}
         </Animated.Text>

--- a/src/screens/inbox/components/InboxHeader.tsx
+++ b/src/screens/inbox/components/InboxHeader.tsx
@@ -41,7 +41,7 @@ export const InboxHeader = (props: InboxHeaderProps) => {
         <Animated.View style={tailwind.style('flex-1')}>
           <Animated.Text
             style={tailwind.style(
-              'text-[17px] text-center leading-[17px] tracking-[0.32px] font-inter-medium-24 text-gray-950',
+              'text-[17px] text-center leading-[17px] tracking-[0.32px] font-inter-medium-24 text-gray-950 dark:text-grayDark-950',
             )}>
             {i18n.t('NOTIFICATION.INBOX')}
           </Animated.Text>

--- a/src/screens/inbox/components/InboxItem.tsx
+++ b/src/screens/inbox/components/InboxItem.tsx
@@ -59,16 +59,16 @@ export const InboxItemComponent = (props: InboxItemProps) => {
             <Animated.Text
               numberOfLines={1}
               style={tailwind.style(
-                'text-base font-inter-medium-24 tracking-[0.24px] text-gray-950 capitalize',
+                'text-base font-inter-medium-24 tracking-[0.24px] text-gray-950 dark:text-grayDark-950 capitalize',
                 `max-w-[${width - 250}px]`,
               )}>
               {sender.name || ''}
             </Animated.Text>
             <NativeView style={tailwind.style('flex flex-row items-center gap-0.5')}>
-              <Animated.Text style={tailwind.style('text-sm font-inter-420-20 text-gray-700')}>
+              <Animated.Text style={tailwind.style('text-sm font-inter-420-20 text-gray-700 dark:text-grayDark-700')}>
                 #
               </Animated.Text>
-              <Animated.Text style={tailwind.style('text-sm font-inter-420-20 text-gray-700')}>
+              <Animated.Text style={tailwind.style('text-sm font-inter-420-20 text-gray-700 dark:text-grayDark-700')}>
                 {conversationId}
               </Animated.Text>
             </NativeView>
@@ -81,7 +81,7 @@ export const InboxItemComponent = (props: InboxItemProps) => {
             <NativeView>
               <Animated.Text
                 style={tailwind.style(
-                  'text-sm font-inter-420-20 leading-[16px] tracking-[0.32px] text-gray-700',
+                  'text-sm font-inter-420-20 leading-[16px] tracking-[0.32px] text-gray-700 dark:text-grayDark-700',
                 )}>
                 {lastActivityAt()}
               </Animated.Text>
@@ -101,7 +101,7 @@ export const InboxItemComponent = (props: InboxItemProps) => {
 
             <Animated.Text
               style={tailwind.style(
-                'font-inter-420-20 text-md text-gray-900 leading-[17px] tracking-[0.32px] flex-shrink',
+                'font-inter-420-20 text-md text-gray-900 dark:text-grayDark-900 leading-[17px] tracking-[0.32px] flex-shrink',
               )}
               numberOfLines={1}
               ellipsizeMode="tail">
@@ -112,7 +112,7 @@ export const InboxItemComponent = (props: InboxItemProps) => {
         </Animated.View>
       </Animated.View>
       {isRead && (
-        <Animated.View style={tailwind.style('absolute bg-white opacity-50 inset-0 z-20')} />
+        <Animated.View style={tailwind.style('absolute bg-white dark:bg-grayDark-50 opacity-50 inset-0 z-20')} />
       )}
     </Animated.View>
   );

--- a/src/screens/inbox/components/InboxItem.tsx
+++ b/src/screens/inbox/components/InboxItem.tsx
@@ -59,16 +59,22 @@ export const InboxItemComponent = (props: InboxItemProps) => {
             <Animated.Text
               numberOfLines={1}
               style={tailwind.style(
-                'text-base font-inter-medium-24 tracking-[0.24px] text-gray-950 capitalize',
+                'text-base font-inter-medium-24 tracking-[0.24px] text-gray-950 dark:text-grayDark-950 capitalize',
                 `max-w-[${width - 250}px]`,
               )}>
               {sender.name || ''}
             </Animated.Text>
             <NativeView style={tailwind.style('flex flex-row items-center gap-0.5')}>
-              <Animated.Text style={tailwind.style('text-sm font-inter-420-20 text-gray-700')}>
+              <Animated.Text
+                style={tailwind.style(
+                  'text-sm font-inter-420-20 text-gray-700 dark:text-grayDark-700',
+                )}>
                 #
               </Animated.Text>
-              <Animated.Text style={tailwind.style('text-sm font-inter-420-20 text-gray-700')}>
+              <Animated.Text
+                style={tailwind.style(
+                  'text-sm font-inter-420-20 text-gray-700 dark:text-grayDark-700',
+                )}>
                 {conversationId}
               </Animated.Text>
             </NativeView>
@@ -81,7 +87,7 @@ export const InboxItemComponent = (props: InboxItemProps) => {
             <NativeView>
               <Animated.Text
                 style={tailwind.style(
-                  'text-sm font-inter-420-20 leading-[16px] tracking-[0.32px] text-gray-700',
+                  'text-sm font-inter-420-20 leading-[16px] tracking-[0.32px] text-gray-700 dark:text-grayDark-700',
                 )}>
                 {lastActivityAt()}
               </Animated.Text>
@@ -101,7 +107,7 @@ export const InboxItemComponent = (props: InboxItemProps) => {
 
             <Animated.Text
               style={tailwind.style(
-                'font-inter-420-20 text-md text-gray-900 leading-[17px] tracking-[0.32px] flex-shrink',
+                'font-inter-420-20 text-md text-gray-900 dark:text-grayDark-900 leading-[17px] tracking-[0.32px] flex-shrink',
               )}
               numberOfLines={1}
               ellipsizeMode="tail">
@@ -112,7 +118,9 @@ export const InboxItemComponent = (props: InboxItemProps) => {
         </Animated.View>
       </Animated.View>
       {isRead && (
-        <Animated.View style={tailwind.style('absolute bg-white opacity-50 inset-0 z-20')} />
+        <Animated.View
+          style={tailwind.style('absolute bg-white dark:bg-grayDark-50 opacity-50 inset-0 z-20')}
+        />
       )}
     </Animated.View>
   );

--- a/src/screens/settings/SettingsHeader.tsx
+++ b/src/screens/settings/SettingsHeader.tsx
@@ -10,7 +10,7 @@ export const SettingsHeader = () => {
       <Animated.View style={tailwind.style('flex flex-row px-4 pt-2 pb-[12px]')}>
         <Animated.View style={tailwind.style('flex-1 justify-center items-center')}>
           <Animated.Text
-            style={tailwind.style('text-[17px] font-medium  text-center text-gray-950')}>
+            style={tailwind.style('text-[17px] font-medium  text-center text-gray-950 dark:text-grayDark-950')}>
             {i18n.t('SETTINGS.HEADER_TITLE')}
           </Animated.Text>
         </Animated.View>

--- a/src/screens/settings/SettingsHeader.tsx
+++ b/src/screens/settings/SettingsHeader.tsx
@@ -10,7 +10,9 @@ export const SettingsHeader = () => {
       <Animated.View style={tailwind.style('flex flex-row px-4 pt-2 pb-[12px]')}>
         <Animated.View style={tailwind.style('flex-1 justify-center items-center')}>
           <Animated.Text
-            style={tailwind.style('text-[17px] font-medium  text-center text-gray-950')}>
+            style={tailwind.style(
+              'text-[17px] font-medium  text-center text-gray-950 dark:text-grayDark-950',
+            )}>
             {i18n.t('SETTINGS.HEADER_TITLE')}
           </Animated.Text>
         </Animated.View>

--- a/src/screens/settings/SettingsScreen.tsx
+++ b/src/screens/settings/SettingsScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { StatusBar, Text, Platform, Pressable } from 'react-native';
+import { StatusBar, Text, Platform, Pressable, Appearance } from 'react-native';
 import Animated from 'react-native-reanimated';
 // import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -35,12 +35,14 @@ import {
   NotificationPreferences,
   SwitchAccount,
   SettingsList,
+  ThemeList,
 } from '@/components-next';
 import { UserAvatar } from './components/UserAvatar';
 
 import { LANGUAGES, TAB_BAR_HEIGHT } from '@/constants';
 import { useRefsContext } from '@/context';
 import { ChatwootIcon, NotificationIcon, SwitchIcon, TranslateIcon } from '@/svg-icons';
+import { useTheme } from '@/context';
 import { GenericListType } from '@/types';
 
 import { useHaptic } from '@/utils';
@@ -133,12 +135,14 @@ const SettingsScreen = () => {
   const enableAccountSwitch = accounts.length > 1;
 
   const activeLocale = useSelector(selectLocale);
+  const { theme, changeTheme } = useTheme();
   const {
     userAvailabilityStatusSheetRef,
     languagesModalSheetRef,
     notificationPreferencesSheetRef,
     switchAccountSheetRef,
     debugActionsSheetRef,
+    themeSheetRef,
   } = useRefsContext();
 
   const hapticSelection = useHaptic();
@@ -192,6 +196,13 @@ const SettingsScreen = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeLocale]);
 
+  useEffect(() => {
+    themeSheetRef.current?.dismiss({
+      overshootClamping: true,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [theme]);
+
   const openURL = async () => {
     await WebBrowser.openBrowserAsync(HELP_URL);
   };
@@ -238,6 +249,14 @@ const SettingsScreen = () => {
       onPressListItem: () => languagesModalSheetRef.current?.present(),
     },
     {
+      hasChevron: true,
+      title: i18n.t('SETTINGS.CHANGE_THEME'),
+      icon: <SwitchIcon />,
+      subtitle: i18n.t(`SETTINGS.THEME.${theme.toUpperCase()}`),
+      subtitleType: 'light',
+      onPressListItem: () => themeSheetRef.current?.present(),
+    },
+    {
       hasChevron: enableAccountSwitch,
       title: i18n.t('SETTINGS.SWITCH_ACCOUNT'),
       icon: <SwitchIcon />,
@@ -271,11 +290,11 @@ const SettingsScreen = () => {
   ];
 
   return (
-    <SafeAreaView style={tailwind.style('flex-1 bg-white font-inter-normal-20')}>
+    <SafeAreaView style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50 font-inter-normal-20')}>
       <StatusBar
         translucent
-        backgroundColor={tailwind.color('bg-white')}
-        barStyle={'dark-content'}
+        backgroundColor={tailwind.color('bg-white dark:bg-grayDark-50')}
+        barStyle={theme === 'dark' || (theme === 'system' && Appearance.getColorScheme() === 'dark') ? 'light-content' : 'dark-content'}
       />
       <SettingsHeader />
       <Animated.ScrollView
@@ -290,12 +309,12 @@ const SettingsScreen = () => {
               )}></Animated.View>
           </Animated.View>
           <Animated.View style={tailwind.style('flex flex-col items-center gap-1')}>
-            <Animated.Text style={tailwind.style('text-[22px] font-inter-580-24 text-gray-950')}>
+            <Animated.Text style={tailwind.style('text-[22px] font-inter-580-24 text-gray-950 dark:text-grayDark-950')}>
               {name}
             </Animated.Text>
             <Animated.Text
               style={tailwind.style(
-                'text-[15px] font-inter-420-20 leading-[17.25px] text-gray-900',
+                'text-[15px] font-inter-420-20 leading-[17.25px] text-gray-900 dark:text-grayDark-900',
               )}>
               {email}
             </Animated.Text>
@@ -318,7 +337,7 @@ const SettingsScreen = () => {
         <Pressable
           style={tailwind.style('p-4 items-center')}
           onLongPress={() => debugActionsSheetRef.current?.present()}>
-          <Text style={tailwind.style('text-sm text-gray-700 ')}>
+          <Text style={tailwind.style('text-sm text-gray-700 dark:text-grayDark-700')}>
             {`${chatwootInstance} ${appVersionDetails}`}
           </Text>
         </Pressable>
@@ -357,6 +376,20 @@ const SettingsScreen = () => {
           <BottomSheetHeader headerText={i18n.t('SETTINGS.SET_LANGUAGE')} />
           <LanguageList onChangeLanguage={onChangeLanguage} currentLanguage={activeLocale} />
         </BottomSheetScrollView>
+      </BottomSheetModal>
+      <BottomSheetModal
+        ref={themeSheetRef}
+        backdropComponent={BottomSheetBackdrop}
+        handleIndicatorStyle={tailwind.style('overflow-hidden bg-blackA-A6 w-8 h-1 rounded-[11px]')}
+        enablePanDownToClose
+        animationConfigs={animationConfigs}
+        handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
+        style={tailwind.style('rounded-[26px] overflow-hidden')}
+        snapPoints={[260]}>
+        <BottomSheetWrapper>
+          <BottomSheetHeader headerText={i18n.t('SETTINGS.SET_THEME')} />
+          <ThemeList currentTheme={theme} changeTheme={changeTheme} />
+        </BottomSheetWrapper>
       </BottomSheetModal>
       <BottomSheetModal
         ref={notificationPreferencesSheetRef}

--- a/src/screens/settings/SettingsScreen.tsx
+++ b/src/screens/settings/SettingsScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { StatusBar, Text, Platform, Pressable } from 'react-native';
+import { StatusBar, Text, Platform, Pressable, Appearance } from 'react-native';
 import Animated from 'react-native-reanimated';
 // import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -37,12 +37,14 @@ import {
   NotificationPreferences,
   SwitchAccount,
   SettingsList,
+  ThemeList,
 } from '@/components-next';
 import { UserAvatar } from './components/UserAvatar';
 
 import { LANGUAGES, TAB_BAR_HEIGHT } from '@/constants';
 import { useRefsContext } from '@/context';
 import { ChatwootIcon, NotificationIcon, SwitchIcon, TranslateIcon } from '@/svg-icons';
+import { useTheme } from '@/context';
 import { GenericListType } from '@/types';
 
 import { useHaptic } from '@/utils';
@@ -135,12 +137,14 @@ const SettingsScreen = () => {
   const enableAccountSwitch = accounts.length > 1;
 
   const activeLocale = useSelector(selectLocale);
+  const { theme, changeTheme } = useTheme();
   const {
     userAvailabilityStatusSheetRef,
     languagesModalSheetRef,
     notificationPreferencesSheetRef,
     switchAccountSheetRef,
     debugActionsSheetRef,
+    themeSheetRef,
   } = useRefsContext();
 
   const hapticSelection = useHaptic();
@@ -195,6 +199,13 @@ const SettingsScreen = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeLocale]);
 
+  useEffect(() => {
+    themeSheetRef.current?.dismiss({
+      overshootClamping: true,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [theme]);
+
   const openURL = async () => {
     await WebBrowser.openBrowserAsync(HELP_URL);
   };
@@ -242,6 +253,14 @@ const SettingsScreen = () => {
       onPressListItem: () => languagesModalSheetRef.current?.present(),
     },
     {
+      hasChevron: true,
+      title: i18n.t('SETTINGS.CHANGE_THEME'),
+      icon: <SwitchIcon />,
+      subtitle: i18n.t(`SETTINGS.THEME.${theme.toUpperCase()}`),
+      subtitleType: 'light',
+      onPressListItem: () => themeSheetRef.current?.present(),
+    },
+    {
       hasChevron: enableAccountSwitch,
       title: i18n.t('SETTINGS.SWITCH_ACCOUNT'),
       icon: <SwitchIcon />,
@@ -275,11 +294,16 @@ const SettingsScreen = () => {
   ];
 
   return (
-    <SafeAreaView style={tailwind.style('flex-1 bg-white font-inter-normal-20')}>
+    <SafeAreaView
+      style={tailwind.style('flex-1 bg-white dark:bg-grayDark-50 font-inter-normal-20')}>
       <StatusBar
         translucent
-        backgroundColor={tailwind.color('bg-white')}
-        barStyle={'dark-content'}
+        backgroundColor={tailwind.color('bg-white dark:bg-grayDark-50')}
+        barStyle={
+          theme === 'dark' || (theme === 'system' && Appearance.getColorScheme() === 'dark')
+            ? 'light-content'
+            : 'dark-content'
+        }
       />
       <SettingsHeader />
       <Animated.ScrollView
@@ -294,12 +318,15 @@ const SettingsScreen = () => {
               )}></Animated.View>
           </Animated.View>
           <Animated.View style={tailwind.style('flex flex-col items-center gap-1')}>
-            <Animated.Text style={tailwind.style('text-[22px] font-inter-580-24 text-gray-950')}>
+            <Animated.Text
+              style={tailwind.style(
+                'text-[22px] font-inter-580-24 text-gray-950 dark:text-grayDark-950',
+              )}>
               {name}
             </Animated.Text>
             <Animated.Text
               style={tailwind.style(
-                'text-[15px] font-inter-420-20 leading-[17.25px] text-gray-900',
+                'text-[15px] font-inter-420-20 leading-[17.25px] text-gray-900 dark:text-grayDark-900',
               )}>
               {email}
             </Animated.Text>
@@ -322,7 +349,7 @@ const SettingsScreen = () => {
         <Pressable
           style={tailwind.style('p-4 items-center')}
           onLongPress={() => debugActionsSheetRef.current?.present()}>
-          <Text style={tailwind.style('text-sm text-gray-700 ')}>
+          <Text style={tailwind.style('text-sm text-gray-700 dark:text-grayDark-700')}>
             {`${chatwootInstance} ${appVersionDetails}`}
           </Text>
         </Pressable>
@@ -361,6 +388,20 @@ const SettingsScreen = () => {
           <BottomSheetHeader headerText={i18n.t('SETTINGS.SET_LANGUAGE')} />
           <LanguageList onChangeLanguage={onChangeLanguage} currentLanguage={activeLocale} />
         </BottomSheetScrollView>
+      </BottomSheetModal>
+      <BottomSheetModal
+        ref={themeSheetRef}
+        backdropComponent={BottomSheetBackdrop}
+        handleIndicatorStyle={tailwind.style('overflow-hidden bg-blackA-A6 w-8 h-1 rounded-[11px]')}
+        enablePanDownToClose
+        animationConfigs={animationConfigs}
+        handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
+        style={tailwind.style('rounded-[26px] overflow-hidden')}
+        snapPoints={[260]}>
+        <BottomSheetWrapper>
+          <BottomSheetHeader headerText={i18n.t('SETTINGS.SET_THEME')} />
+          <ThemeList currentTheme={theme} changeTheme={changeTheme} />
+        </BottomSheetWrapper>
       </BottomSheetModal>
       <BottomSheetModal
         ref={notificationPreferencesSheetRef}

--- a/src/screens/settings/components/DebugActions.tsx
+++ b/src/screens/settings/components/DebugActions.tsx
@@ -91,14 +91,14 @@ const DebugActionCell = ({ item, index, isLastItem }: DebugActionCellProps) => {
           <View>
             <Text
               style={tailwind.style(
-                'text-base  text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
+                'text-base  text-gray-950 dark:text-grayDark-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
               )}>
               {item.label}
             </Text>
             <Text
               numberOfLines={2}
               style={tailwind.style(
-                'text-sm text-gray-900 font-inter-420-20 leading-[18px] tracking-[0.16px] italic',
+                'text-sm text-gray-900 dark:text-grayDark-900 font-inter-420-20 leading-[18px] tracking-[0.16px] italic',
               )}>
               {debugValue(item.key)}
             </Text>

--- a/src/screens/settings/components/UserAvatar.tsx
+++ b/src/screens/settings/components/UserAvatar.tsx
@@ -92,7 +92,7 @@ export const UserAvatar: React.FC<Partial<UserAvatarProps>> = props => {
   return (
     <View
       style={[
-        tailwind.style('relative items-center justify-center bg-gray-100 rounded-full h-24 w-24'),
+        tailwind.style('relative items-center justify-center bg-gray-100 dark:bg-grayDark-100 rounded-full h-24 w-24'),
         styleAdapter(style),
       ]}
       {...boxProps}>
@@ -101,7 +101,7 @@ export const UserAvatar: React.FC<Partial<UserAvatarProps>> = props => {
       ) : name ? (
         <Text
           style={[
-            tailwind.style('text-center uppercase text-gray-800 font-inter-medium-24 text-3xl'),
+            tailwind.style('text-center uppercase text-gray-800 dark:text-grayDark-800 font-inter-medium-24 text-3xl'),
           ]}
           adjustsFontSizeToFit
           allowFontScaling={false}>

--- a/src/screens/settings/components/UserAvatar.tsx
+++ b/src/screens/settings/components/UserAvatar.tsx
@@ -92,7 +92,9 @@ export const UserAvatar: React.FC<Partial<UserAvatarProps>> = props => {
   return (
     <View
       style={[
-        tailwind.style('relative items-center justify-center bg-gray-100 rounded-full h-24 w-24'),
+        tailwind.style(
+          'relative items-center justify-center bg-gray-100 dark:bg-grayDark-100 rounded-full h-24 w-24',
+        ),
         styleAdapter(style),
       ]}
       {...boxProps}>
@@ -101,7 +103,9 @@ export const UserAvatar: React.FC<Partial<UserAvatarProps>> = props => {
       ) : name ? (
         <Text
           style={[
-            tailwind.style('text-center uppercase text-gray-800 font-inter-medium-24 text-3xl'),
+            tailwind.style(
+              'text-center uppercase text-gray-800 dark:text-grayDark-800 font-inter-medium-24 text-3xl',
+            ),
           ]}
           adjustsFontSizeToFit
           allowFontScaling={false}>

--- a/src/store/settings/settingsSlice.ts
+++ b/src/store/settings/settingsSlice.ts
@@ -54,6 +54,9 @@ export const settingsSlice = createSlice({
       state.localeValue = action.payload;
       state.uiFlags.isLocaleSet = true;
     },
+    setTheme: (state, action) => {
+      state.theme = action.payload;
+    },
   },
   extraReducers: builder => {
     builder
@@ -99,5 +102,5 @@ export const settingsSlice = createSlice({
       });
   },
 });
-export const { resetSettings, setLocale } = settingsSlice.actions;
+export const { resetSettings, setLocale, setTheme } = settingsSlice.actions;
 export default settingsSlice.reducer;

--- a/src/theme/tailwind.config.ts
+++ b/src/theme/tailwind.config.ts
@@ -19,6 +19,7 @@ const chatwootAppColors = {
 };
 
 export const twConfig = {
+  darkMode: 'class',
   theme: {
     ...defaultTheme,
     extend: {


### PR DESCRIPTION
## Description

Adds comprehensive dark mode support to the Chatwoot mobile app.

This includes system theme detection, a Settings theme picker for Light/Dark/System, persisted theme preference, and dark-mode variants across auth, conversations, chat, inbox, settings, and shared components. The branch is rebased onto current `develop` and no longer changes app version, dependencies, or lockfiles.

The theme provider applies the twrnc color scheme synchronously before rendering children, so switching themes or following system appearance changes rebuilds themed styles in the same render.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Rebased on current `develop` (`v4.7.0`).
- Resolved conflicts while preserving current `develop` behavior for login keyboard handling, image previews, reply-to-message navigation, labels, and package versions.
- Ran focused ESLint on changed TypeScript/TSX files.
- Ran `git diff --check`.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
