### PR TITLE
fix: Remove unnecessary capitalization in ReplyMessage components

### DIFF
--- a/src/screens/chat-screen/components/message-components/ReplyMessageBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/ReplyMessageBubble.tsx
@@ -79,7 +79,7 @@ export const ReplyMessageBubble = (props: ReplyMessageBubbleProps) => {
               {renderAttachmentSection()}
               <Animated.Text
                 style={tailwind.style(
-                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950 capitalize pl-1.5',
+                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950 pl-1.5',
                 )}>
                 {replyMessageItem?.attachments[0].fileType}
               </Animated.Text>
@@ -96,7 +96,7 @@ export const ReplyMessageBubble = (props: ReplyMessageBubbleProps) => {
               <Animated.Text
                 numberOfLines={1}
                 style={tailwind.style(
-                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950 capitalize',
+                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950',
                 )}>
                 {replyMessageItem?.content}
               </Animated.Text>

--- a/src/screens/chat-screen/components/message-components/ReplyMessageCell.tsx
+++ b/src/screens/chat-screen/components/message-components/ReplyMessageCell.tsx
@@ -79,7 +79,7 @@ export const ReplyMessageCell = (props: ReplyMessageCellProps) => {
               {renderAttachmentSection()}
               <Animated.Text
                 style={tailwind.style(
-                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950 capitalize pl-1.5',
+                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950 pl-1.5',
                 )}>
                 {replyMessageItem?.attachments[0].fileType}
               </Animated.Text>
@@ -98,7 +98,7 @@ export const ReplyMessageCell = (props: ReplyMessageCellProps) => {
               <Animated.Text
                 numberOfLines={1}
                 style={tailwind.style(
-                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950 capitalize',
+                  'text-[14px] font-inter-normal-20 leading-[19.6px] tracking-[0.16px] text-gray-950',
                 )}>
                 {replyMessageItem?.content}
               </Animated.Text>

--- a/src/screens/chat-screen/components/reply-box/QuoteReply.tsx
+++ b/src/screens/chat-screen/components/reply-box/QuoteReply.tsx
@@ -154,13 +154,13 @@ export const QuoteReply = () => {
             ) : (
               <Text
                 numberOfLines={1}
-                style={tailwind.style('text-md font-inter-normal-20 tracking-[0.32px] capitalize')}>
+                style={tailwind.style('text-md font-inter-normal-20 tracking-[0.32px]')}>
                 {quoteMessage?.content}
               </Text>
             )
           ) : (
             <Text
-              style={tailwind.style('text-md font-inter-normal-20 tracking-[0.32px] capitalize')}>
+              style={tailwind.style('text-md font-inter-normal-20 tracking-[0.32px]')}>
               {quoteMessage?.attachments?.[0]?.fileType}
             </Text>
           )}


### PR DESCRIPTION
## Description 

Text of 'Replied to' message quote on mobile devices shows the first line of the message with capitalized words, no such behaviour on Web/PWA version.

Relevant issue not found on GitHub.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Removed capitalized styling of reply message quote's text. 

## How Has This Been Tested?

Visual testing on end device.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested in both Android and iOS platform
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
