### PR TITLE
feat: Add the support for contact labels

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -4,7 +4,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
   return {
     name: 'Chatwoot',
     slug: process.env.EXPO_PUBLIC_APP_SLUG || 'chatwoot-mobile',
-    version: '4.3.12',
+    version: '4.3.13',
     orientation: 'portrait',
     icon: './assets/icon.png',
     userInterfaceStyle: 'light',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/mobile-app",
-  "version": "4.3.12",
+  "version": "4.3.13",
   "scripts": {
     "start": "expo start --dev-client",
     "start:production": "expo start --no-dev --minify",

--- a/src/components-next/label-section/LabelActions.tsx
+++ b/src/components-next/label-section/LabelActions.tsx
@@ -1,0 +1,161 @@
+import React, { useState, useEffect } from 'react';
+import { Platform, Pressable, StyleSheet } from 'react-native';
+import Animated from 'react-native-reanimated';
+import { BottomSheetModal, BottomSheetScrollView } from '@gorhom/bottom-sheet';
+
+import { useRefsContext } from '@/context';
+import { LabelTag } from '@/svg-icons';
+import { tailwind } from '@/theme';
+import { Icon, SearchBar } from '@/components-next';
+import { useAppSelector } from '@/hooks';
+import { filterLabels } from '@/store/label/labelSelectors';
+
+import { LabelItem } from '@/components-next/label-section';
+import { LabelStack, LabelBackdrop } from './label-actions';
+
+interface LabelActionsProps {
+  labels: string[];
+  onLabelsUpdate: (updatedLabels: string[]) => Promise<void> | void;
+  sheetRef?: React.RefObject<BottomSheetModal>;
+}
+
+export const LabelActions = (props: LabelActionsProps) => {
+  const { labels, onLabelsUpdate, sheetRef } = props;
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const [selectedLabels, setSelectedLabels] = useState(labels);
+
+  useEffect(() => {
+    setSelectedLabels(labels);
+  }, [labels]);
+
+  const { addLabelSheetRef: contextAddLabelSheetRef } = useRefsContext();
+  const addLabelSheetRef = sheetRef || contextAddLabelSheetRef;
+
+  // Custom backdrop that uses the instance's own ref instead of the shared context ref
+  const backdropComponent = (props: Parameters<typeof LabelBackdrop>[0]) => (
+    <LabelBackdrop {...props} sheetRef={addLabelSheetRef} />
+  );
+
+  const allLabels = useAppSelector(state => filterLabels(state, ''));
+
+  const filteredLabels = useAppSelector(state => filterLabels(state, searchTerm));
+
+  const selectedLabelItems =
+    allLabels && selectedLabels
+      ? allLabels.filter(({ title }) => {
+          return selectedLabels?.includes(title);
+        })
+      : [];
+
+  const handleAddLabelPress = () => {
+    addLabelSheetRef.current?.present();
+  };
+
+  const handleOnSubmitEditing = () => {
+    addLabelSheetRef.current?.close();
+  };
+
+  const handleChangeText = (text: string) => {
+    setSearchTerm(text);
+  };
+
+  const handleChange = (index: number) => {
+    if (index === -1) {
+      setSearchTerm('');
+    }
+  };
+
+  const handleAddOrUpdateLabels = async (label: string) => {
+    setSelectedLabels(prevLabels => {
+      const updatedLabels = prevLabels.includes(label)
+        ? prevLabels.filter(item => item !== label)
+        : [...prevLabels, label];
+
+      onLabelsUpdate(updatedLabels);
+
+      return updatedLabels;
+    });
+  };
+  return (
+    <Animated.View>
+      <Animated.View style={tailwind.style('pl-4')}>
+        <Animated.Text
+          style={tailwind.style(
+            'text-sm font-inter-medium-24 leading-[16px] tracking-[0.32px] text-gray-700',
+          )}>
+          Labels
+        </Animated.Text>
+      </Animated.View>
+      <Animated.View style={tailwind.style('flex flex-row flex-wrap pl-4')}>
+        {selectedLabelItems.map((label, index) => (
+          <LabelItem key={index} index={index} item={label} />
+        ))}
+        <Pressable
+          onPress={handleAddLabelPress}
+          style={({ pressed }) => [
+            styles.labelShadow,
+            tailwind.style(
+              'flex flex-row items-center bg-white px-3 py-[7px] rounded-lg mr-2 mt-3',
+              pressed ? 'bg-blue-100' : '',
+            ),
+          ]}>
+          <Icon icon={<LabelTag />} size={16} />
+          <Animated.Text
+            style={tailwind.style(
+              'text-md font-inter-medium-24 leading-[17px] tracking-[0.24px] pl-1.5 text-blue-800',
+            )}>
+            Add
+          </Animated.Text>
+        </Pressable>
+      </Animated.View>
+      <BottomSheetModal
+        ref={addLabelSheetRef}
+        backdropComponent={backdropComponent}
+        handleIndicatorStyle={tailwind.style('overflow-hidden bg-blackA-A6 w-8 h-1 rounded-[11px]')}
+        handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
+        style={tailwind.style('rounded-[26px] overflow-hidden')}
+        enablePanDownToClose
+        snapPoints={[316]}
+        keyboardBehavior="interactive"
+        keyboardBlurBehavior="restore"
+        onChange={handleChange}
+        enableDynamicSizing={false}
+        detached>
+        <SearchBar
+          isInsideBottomSheet
+          onSubmitEditing={handleOnSubmitEditing}
+          onChangeText={handleChangeText}
+          placeholder="Search labels"
+          returnKeyLabel="done"
+          returnKeyType="done"
+        />
+        <BottomSheetScrollView showsVerticalScrollIndicator={false}>
+          <LabelStack
+            filteredLabels={filteredLabels}
+            selectedLabels={selectedLabels}
+            isStandAloneComponent={allLabels.length > 3}
+            handleLabelPress={handleAddOrUpdateLabels}
+          />
+        </BottomSheetScrollView>
+      </BottomSheetModal>
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  labelShadow:
+    Platform.select({
+      ios: {
+        shadowColor: '#00000040',
+        shadowOffset: { width: 0, height: 0.15 },
+        shadowRadius: 2,
+        shadowOpacity: 0.35,
+        elevation: 2,
+      },
+      android: {
+        elevation: 4,
+        backgroundColor: 'white',
+      },
+    }) || {}, // Add fallback empty object
+});

--- a/src/components-next/label-section/LabelActions.tsx
+++ b/src/components-next/label-section/LabelActions.tsx
@@ -1,0 +1,179 @@
+import React, { useState, useEffect } from 'react';
+import { Platform, Pressable, StyleSheet } from 'react-native';
+import Animated from 'react-native-reanimated';
+import { BottomSheetModal, BottomSheetScrollView } from '@gorhom/bottom-sheet';
+
+import { useRefsContext } from '@/context';
+import { LabelTag } from '@/svg-icons';
+import { tailwind } from '@/theme';
+import { Label } from '@/types';
+import { BottomSheetBackdrop, Icon, SearchBar } from '@/components-next';
+import { useAppSelector } from '@/hooks';
+import { filterLabels } from '@/store/label/labelSelectors';
+
+import { LabelCell, LabelItem } from '@/components-next/label-section';
+
+type LabelStackProps = {
+  filteredLabels: Label[];
+  selectedLabels: string[];
+  handleLabelPress: (label: string) => void;
+  isStandAloneComponent?: boolean;
+};
+const LabelStack = (props: LabelStackProps) => {
+  const { filteredLabels, selectedLabels, isStandAloneComponent = true, handleLabelPress } = props;
+
+  return (
+    <BottomSheetScrollView showsVerticalScrollIndicator={false} style={tailwind.style('my-1 pl-3')}>
+      {filteredLabels.map((value, index) => {
+        return (
+          <LabelCell
+            key={index}
+            {...{ value, index }}
+            handleLabelPress={handleLabelPress}
+            isActive={selectedLabels.includes(value.title)}
+            isLastItem={index === filteredLabels.length - 1 && isStandAloneComponent ? true : false}
+          />
+        );
+      })}
+    </BottomSheetScrollView>
+  );
+};
+
+interface LabelActionsProps {
+  labels: string[];
+  onLabelsUpdate: (updatedLabels: string[]) => Promise<void> | void;
+}
+
+export const LabelActions = (props: LabelActionsProps) => {
+  const { labels, onLabelsUpdate } = props;
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const [selectedLabels, setSelectedLabels] = useState(labels);
+
+  useEffect(() => {
+    setSelectedLabels(labels);
+  }, [labels]);
+
+  const { addLabelSheetRef } = useRefsContext();
+
+  const allLabels = useAppSelector(state => filterLabels(state, ''));
+
+  const filteredLabels = useAppSelector(state => filterLabels(state, searchTerm));
+
+  const selectedLabelItems =
+    allLabels && selectedLabels
+      ? allLabels.filter(({ title }) => {
+          return selectedLabels?.includes(title);
+        })
+      : [];
+
+  const handleAddLabelPress = () => {
+    addLabelSheetRef.current?.present();
+  };
+
+  const handleOnSubmitEditing = () => {
+    addLabelSheetRef.current?.close();
+  };
+
+  const handleChangeText = (text: string) => {
+    setSearchTerm(text);
+  };
+
+  const handleChange = (index: number) => {
+    if (index === -1) {
+      setSearchTerm('');
+    }
+  };
+
+  const handleAddOrUpdateLabels = async (label: string) => {
+    setSelectedLabels(prevLabels => {
+      const updatedLabels = prevLabels.includes(label)
+        ? prevLabels.filter(item => item !== label)
+        : [...prevLabels, label];
+
+      onLabelsUpdate(updatedLabels);
+
+      return updatedLabels;
+    });
+  };
+  return (
+    <Animated.View>
+      <Animated.View style={tailwind.style('pl-4')}>
+        <Animated.Text
+          style={tailwind.style(
+            'text-sm font-inter-medium-24 leading-[16px] tracking-[0.32px] text-gray-700',
+          )}>
+          Labels
+        </Animated.Text>
+      </Animated.View>
+      <Animated.View style={tailwind.style('flex flex-row flex-wrap pl-4')}>
+        {selectedLabelItems.map((label, index) => (
+          <LabelItem key={index} index={index} item={label} />
+        ))}
+        <Pressable
+          onPress={handleAddLabelPress}
+          style={({ pressed }) => [
+            styles.labelShadow,
+            tailwind.style(
+              'flex flex-row items-center bg-white px-3 py-[7px] rounded-lg mr-2 mt-3',
+              pressed ? 'bg-blue-100' : '',
+            ),
+          ]}>
+          <Icon icon={<LabelTag />} size={16} />
+          <Animated.Text
+            style={tailwind.style(
+              'text-md font-inter-medium-24 leading-[17px] tracking-[0.24px] pl-1.5 text-blue-800',
+            )}>
+            Add
+          </Animated.Text>
+        </Pressable>
+      </Animated.View>
+      <BottomSheetModal
+        ref={addLabelSheetRef}
+        backdropComponent={BottomSheetBackdrop}
+        handleIndicatorStyle={tailwind.style('overflow-hidden bg-blackA-A6 w-8 h-1 rounded-[11px]')}
+        handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
+        style={tailwind.style('rounded-[26px] overflow-hidden')}
+        enablePanDownToClose
+        snapPoints={[316]}
+        keyboardBehavior="interactive"
+        keyboardBlurBehavior="restore"
+        onChange={handleChange}>
+        <SearchBar
+          isInsideBottomSheet
+          onSubmitEditing={handleOnSubmitEditing}
+          onChangeText={handleChangeText}
+          placeholder="Search labels"
+          returnKeyLabel="done"
+          returnKeyType="done"
+        />
+        <BottomSheetScrollView showsVerticalScrollIndicator={false}>
+          <LabelStack
+            filteredLabels={filteredLabels}
+            selectedLabels={selectedLabels}
+            isStandAloneComponent={allLabels.length > 3}
+            handleLabelPress={handleAddOrUpdateLabels}
+          />
+          <Animated.View style={tailwind.style('items-start')}></Animated.View>
+        </BottomSheetScrollView>
+      </BottomSheetModal>
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  labelShadow:
+    Platform.select({
+      ios: {
+        shadowColor: '#00000040',
+        shadowOffset: { width: 0, height: 0.15 },
+        shadowRadius: 2,
+        shadowOpacity: 0.35,
+        elevation: 2,
+      },
+      android: {
+        elevation: 4,
+        backgroundColor: 'white',
+      },
+    }) || {}, // Add fallback empty object
+});

--- a/src/components-next/label-section/LabelActions.tsx
+++ b/src/components-next/label-section/LabelActions.tsx
@@ -138,7 +138,9 @@ export const LabelActions = (props: LabelActionsProps) => {
         snapPoints={[316]}
         keyboardBehavior="interactive"
         keyboardBlurBehavior="restore"
-        onChange={handleChange}>
+        onChange={handleChange}
+        enableDynamicSizing={false}
+        detached>
         <SearchBar
           isInsideBottomSheet
           onSubmitEditing={handleOnSubmitEditing}
@@ -154,7 +156,6 @@ export const LabelActions = (props: LabelActionsProps) => {
             isStandAloneComponent={allLabels.length > 3}
             handleLabelPress={handleAddOrUpdateLabels}
           />
-          <Animated.View style={tailwind.style('items-start')}></Animated.View>
         </BottomSheetScrollView>
       </BottomSheetModal>
     </Animated.View>

--- a/src/components-next/label-section/index.ts
+++ b/src/components-next/label-section/index.ts
@@ -1,2 +1,3 @@
 export * from './LabelCell';
 export * from './LabelItem';
+export * from './LabelActions';

--- a/src/components-next/label-section/index.ts
+++ b/src/components-next/label-section/index.ts
@@ -1,3 +1,3 @@
 export * from './LabelCell';
 export * from './LabelItem';
-export * from './LabelActions';
+export * from './label-actions';

--- a/src/components-next/label-section/label-actions/LabelActions.tsx
+++ b/src/components-next/label-section/label-actions/LabelActions.tsx
@@ -1,51 +1,30 @@
 import React, { useState, useEffect } from 'react';
 import { Platform, Pressable, StyleSheet } from 'react-native';
 import Animated from 'react-native-reanimated';
-import { BottomSheetModal, BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import {
+  BottomSheetModal,
+  BottomSheetScrollView,
+  BottomSheetBackgroundProps,
+} from '@gorhom/bottom-sheet';
 
 import { useRefsContext } from '@/context';
 import { LabelTag } from '@/svg-icons';
 import { tailwind } from '@/theme';
-import { Label } from '@/types';
-import { BottomSheetBackdrop, Icon, SearchBar } from '@/components-next';
+import { Icon, SearchBar } from '@/components-next';
 import { useAppSelector } from '@/hooks';
 import { filterLabels } from '@/store/label/labelSelectors';
 
-import { LabelCell, LabelItem } from '@/components-next/label-section';
-
-type LabelStackProps = {
-  filteredLabels: Label[];
-  selectedLabels: string[];
-  handleLabelPress: (label: string) => void;
-  isStandAloneComponent?: boolean;
-};
-const LabelStack = (props: LabelStackProps) => {
-  const { filteredLabels, selectedLabels, isStandAloneComponent = true, handleLabelPress } = props;
-
-  return (
-    <BottomSheetScrollView showsVerticalScrollIndicator={false} style={tailwind.style('my-1 pl-3')}>
-      {filteredLabels.map((value, index) => {
-        return (
-          <LabelCell
-            key={index}
-            {...{ value, index }}
-            handleLabelPress={handleLabelPress}
-            isActive={selectedLabels.includes(value.title)}
-            isLastItem={index === filteredLabels.length - 1 && isStandAloneComponent ? true : false}
-          />
-        );
-      })}
-    </BottomSheetScrollView>
-  );
-};
+import { LabelItem } from '@/components-next/label-section';
+import { LabelStack, LabelBackdrop } from './';
 
 interface LabelActionsProps {
   labels: string[];
   onLabelsUpdate: (updatedLabels: string[]) => Promise<void> | void;
+  sheetRef?: React.RefObject<BottomSheetModal>;
 }
 
 export const LabelActions = (props: LabelActionsProps) => {
-  const { labels, onLabelsUpdate } = props;
+  const { labels, onLabelsUpdate, sheetRef } = props;
   const [searchTerm, setSearchTerm] = useState('');
 
   const [selectedLabels, setSelectedLabels] = useState(labels);
@@ -54,7 +33,13 @@ export const LabelActions = (props: LabelActionsProps) => {
     setSelectedLabels(labels);
   }, [labels]);
 
-  const { addLabelSheetRef } = useRefsContext();
+  const { addLabelSheetRef: contextAddLabelSheetRef } = useRefsContext();
+  const addLabelSheetRef = sheetRef || contextAddLabelSheetRef;
+
+  // Custom backdrop that uses the instance's own ref instead of the shared context ref
+  const backdropComponent = (props: BottomSheetBackgroundProps) => (
+    <LabelBackdrop {...props} sheetRef={addLabelSheetRef} />
+  );
 
   const allLabels = useAppSelector(state => filterLabels(state, ''));
 
@@ -130,7 +115,7 @@ export const LabelActions = (props: LabelActionsProps) => {
       </Animated.View>
       <BottomSheetModal
         ref={addLabelSheetRef}
-        backdropComponent={BottomSheetBackdrop}
+        backdropComponent={backdropComponent}
         handleIndicatorStyle={tailwind.style('overflow-hidden bg-blackA-A6 w-8 h-1 rounded-[11px]')}
         handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
         style={tailwind.style('rounded-[26px] overflow-hidden')}

--- a/src/components-next/label-section/label-actions/LabelActions.tsx
+++ b/src/components-next/label-section/label-actions/LabelActions.tsx
@@ -10,12 +10,14 @@ import {
 import { useRefsContext } from '@/context';
 import { LabelTag } from '@/svg-icons';
 import { tailwind } from '@/theme';
-import { Icon, SearchBar } from '@/components-next';
+import { Icon } from '@/components-next/common/icon';
+import { SearchBar } from '@/components-next/common/search';
 import { useAppSelector } from '@/hooks';
 import { filterLabels } from '@/store/label/labelSelectors';
 
-import { LabelItem } from '@/components-next/label-section';
-import { LabelStack, LabelBackdrop } from './';
+import { LabelItem } from '../LabelItem';
+import { LabelStack } from './LabelStack';
+import { LabelBackdrop } from './LabelBackdrop';
 
 interface LabelActionsProps {
   labels: string[];

--- a/src/components-next/label-section/label-actions/LabelBackdrop.tsx
+++ b/src/components-next/label-section/label-actions/LabelBackdrop.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Pressable } from 'react-native';
+import Animated, { interpolate, useAnimatedStyle } from 'react-native-reanimated';
+import { BottomSheetBackgroundProps, BottomSheetModal } from '@gorhom/bottom-sheet';
+
+import { tailwind } from '@/theme';
+
+interface LabelBackdropProps extends BottomSheetBackgroundProps {
+  sheetRef: React.RefObject<BottomSheetModal>;
+}
+
+export const LabelBackdrop: React.FC<LabelBackdropProps> = props => {
+  const { animatedIndex, style, sheetRef } = props;
+
+  const animatedStyle = useAnimatedStyle(() => {
+    return {
+      opacity: interpolate(animatedIndex.value, [-1, 0], [0, 1]),
+    };
+  });
+
+  const handleBackdropPress = () => {
+    sheetRef.current?.dismiss({ overshootClamping: true });
+  };
+
+  return (
+    <Pressable onPress={handleBackdropPress} style={style}>
+      <Animated.View style={[tailwind.style('bg-blackA-A9'), style, animatedStyle]} />
+    </Pressable>
+  );
+};

--- a/src/components-next/label-section/label-actions/LabelStack.tsx
+++ b/src/components-next/label-section/label-actions/LabelStack.tsx
@@ -3,7 +3,7 @@ import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 
 import { tailwind } from '@/theme';
 import { Label } from '@/types';
-import { LabelCell } from '@/components-next/label-section';
+import { LabelCell } from '../LabelCell';
 
 type LabelStackProps = {
   filteredLabels: Label[];

--- a/src/components-next/label-section/label-actions/LabelStack.tsx
+++ b/src/components-next/label-section/label-actions/LabelStack.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
+
+import { tailwind } from '@/theme';
+import { Label } from '@/types';
+import { LabelCell } from '@/components-next/label-section';
+
+type LabelStackProps = {
+  filteredLabels: Label[];
+  selectedLabels: string[];
+  handleLabelPress: (label: string) => void;
+  isStandAloneComponent?: boolean;
+};
+
+export const LabelStack = (props: LabelStackProps) => {
+  const { filteredLabels, selectedLabels, isStandAloneComponent = true, handleLabelPress } = props;
+
+  return (
+    <BottomSheetScrollView showsVerticalScrollIndicator={false} style={tailwind.style('my-1 pl-3')}>
+      {filteredLabels.map((value, index) => {
+        return (
+          <LabelCell
+            key={index}
+            {...{ value, index }}
+            handleLabelPress={handleLabelPress}
+            isActive={selectedLabels.includes(value.title)}
+            isLastItem={index === filteredLabels.length - 1 && isStandAloneComponent ? true : false}
+          />
+        );
+      })}
+    </BottomSheetScrollView>
+  );
+};

--- a/src/components-next/label-section/label-actions/index.ts
+++ b/src/components-next/label-section/label-actions/index.ts
@@ -1,3 +1,3 @@
-export { LabelStack } from './LabelStack';
-export { LabelBackdrop } from './LabelBackdrop';
-export { LabelActions } from './LabelActions';
+export * from './LabelStack';
+export * from './LabelBackdrop';
+export * from './LabelActions';

--- a/src/components-next/label-section/label-actions/index.ts
+++ b/src/components-next/label-section/label-actions/index.ts
@@ -1,0 +1,3 @@
+export { LabelStack } from './LabelStack';
+export { LabelBackdrop } from './LabelBackdrop';
+export { LabelActions } from './LabelActions';

--- a/src/screens/chat-screen/conversation-actions/components/ConversationLabelActions.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/ConversationLabelActions.tsx
@@ -1,183 +1,28 @@
-import React, { useState } from 'react';
-import { Platform, Pressable, StyleSheet } from 'react-native';
-import Animated from 'react-native-reanimated';
-import { BottomSheetModal, BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import React from 'react';
 
-import { useChatWindowContext, useRefsContext } from '@/context';
-import { LabelTag } from '@/svg-icons';
-import { tailwind } from '@/theme';
-import { Label } from '@/types';
-import { BottomSheetBackdrop, Icon, SearchBar } from '@/components-next';
-import { useAppSelector } from '@/hooks';
-import { filterLabels } from '@/store/label/labelSelectors';
+import { useChatWindowContext } from '@/context';
 import { useAppDispatch } from '@/hooks';
 import { conversationActions } from '@/store/conversation/conversationActions';
 
-import { LabelCell, LabelItem } from '@/components-next/label-section';
+import { LabelActions } from '@/components-next/label-section';
 
-type LabelStackProps = {
-  filteredLabels: Label[];
-  selectedLabels: string[];
-  handleLabelPress: (label: string) => void;
-  isStandAloneComponent?: boolean;
-};
-const LabelStack = (props: LabelStackProps) => {
-  const { filteredLabels, selectedLabels, isStandAloneComponent = true, handleLabelPress } = props;
-
-  return (
-    <BottomSheetScrollView showsVerticalScrollIndicator={false} style={tailwind.style('my-1 pl-3')}>
-      {filteredLabels.map((value, index) => {
-        return (
-          <LabelCell
-            key={index}
-            {...{ value, index }}
-            handleLabelPress={handleLabelPress}
-            isActive={selectedLabels.includes(value.title)}
-            isLastItem={index === filteredLabels.length - 1 && isStandAloneComponent ? true : false}
-          />
-        );
-      })}
-    </BottomSheetScrollView>
-  );
-};
-
-interface LabelSectionProps {
+interface ConversationLabelActionsProps {
   labels: string[];
 }
 
-export const ConversationLabelActions = (props: LabelSectionProps) => {
+export const ConversationLabelActions = (props: ConversationLabelActionsProps) => {
   const { labels } = props;
-  const [searchTerm, setSearchTerm] = useState('');
   const { conversationId } = useChatWindowContext();
   const dispatch = useAppDispatch();
 
-  const [selectedLabels, setSelectedLabels] = useState(labels);
-
-  const { addLabelSheetRef } = useRefsContext();
-
-  const allLabels = useAppSelector(state => filterLabels(state, ''));
-
-  const filteredLabels = useAppSelector(state => filterLabels(state, searchTerm));
-
-  const conversationLabels =
-    allLabels && selectedLabels
-      ? allLabels.filter(({ title }) => {
-          return selectedLabels?.includes(title);
-        })
-      : [];
-
-  const handleAddLabelPress = () => {
-    addLabelSheetRef.current?.present();
+  const handleLabelsUpdate = (updatedLabels: string[]) => {
+    dispatch(
+      conversationActions.addOrUpdateConversationLabels({
+        conversationId: conversationId,
+        labels: updatedLabels,
+      }),
+    );
   };
 
-  const handleOnSubmitEditing = () => {
-    addLabelSheetRef.current?.close();
-  };
-
-  const handleChangeText = (text: string) => {
-    setSearchTerm(text);
-  };
-
-  const handleChange = (index: number) => {
-    if (index === -1) {
-      setSearchTerm('');
-    }
-  };
-
-  const handleAddOrUpdateLabels = async (label: string) => {
-    setSelectedLabels(prevLabels => {
-      const updatedLabels = prevLabels.includes(label)
-        ? prevLabels.filter(item => item !== label)
-        : [...prevLabels, label];
-
-      dispatch(
-        conversationActions.addOrUpdateConversationLabels({
-          conversationId: conversationId,
-          labels: updatedLabels,
-        }),
-      );
-
-      return updatedLabels;
-    });
-  };
-  return (
-    <Animated.View>
-      <Animated.View style={tailwind.style('pl-4')}>
-        <Animated.Text
-          style={tailwind.style(
-            'text-sm font-inter-medium-24 leading-[16px] tracking-[0.32px] text-gray-700',
-          )}>
-          Labels
-        </Animated.Text>
-      </Animated.View>
-      <Animated.View style={tailwind.style('flex flex-row flex-wrap pl-4')}>
-        {conversationLabels.map((label, index) => (
-          <LabelItem key={index} index={index} item={label} />
-        ))}
-        <Pressable
-          onPress={handleAddLabelPress}
-          style={({ pressed }) => [
-            styles.labelShadow,
-            tailwind.style(
-              'flex flex-row items-center bg-white px-3 py-[7px] rounded-lg mr-2 mt-3',
-              pressed ? 'bg-blue-100' : '',
-            ),
-          ]}>
-          <Icon icon={<LabelTag />} size={16} />
-          <Animated.Text
-            style={tailwind.style(
-              'text-md font-inter-medium-24 leading-[17px] tracking-[0.24px] pl-1.5 text-blue-800',
-            )}>
-            Add
-          </Animated.Text>
-        </Pressable>
-      </Animated.View>
-      <BottomSheetModal
-        ref={addLabelSheetRef}
-        backdropComponent={BottomSheetBackdrop}
-        handleIndicatorStyle={tailwind.style('overflow-hidden bg-blackA-A6 w-8 h-1 rounded-[11px]')}
-        handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
-        style={tailwind.style('rounded-[26px] overflow-hidden')}
-        enablePanDownToClose
-        snapPoints={[316]}
-        keyboardBehavior="interactive"
-        keyboardBlurBehavior="restore"
-        onChange={handleChange}>
-        <SearchBar
-          isInsideBottomSheet
-          onSubmitEditing={handleOnSubmitEditing}
-          onChangeText={handleChangeText}
-          placeholder="Search labels"
-          returnKeyLabel="done"
-          returnKeyType="done"
-        />
-        <BottomSheetScrollView showsVerticalScrollIndicator={false}>
-          <LabelStack
-            filteredLabels={filteredLabels}
-            selectedLabels={selectedLabels}
-            isStandAloneComponent={allLabels.length > 3}
-            handleLabelPress={handleAddOrUpdateLabels}
-          />
-          <Animated.View style={tailwind.style('items-start')}></Animated.View>
-        </BottomSheetScrollView>
-      </BottomSheetModal>
-    </Animated.View>
-  );
+  return <LabelActions labels={labels} onLabelsUpdate={handleLabelsUpdate} />;
 };
-
-const styles = StyleSheet.create({
-  labelShadow:
-    Platform.select({
-      ios: {
-        shadowColor: '#00000040',
-        shadowOffset: { width: 0, height: 0.15 },
-        shadowRadius: 2,
-        shadowOpacity: 0.35,
-        elevation: 2,
-      },
-      android: {
-        elevation: 4,
-        backgroundColor: 'white',
-      },
-    }) || {}, // Add fallback empty object
-});

--- a/src/screens/chat-screen/conversation-actions/components/ConversationLabelActions.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/ConversationLabelActions.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useRef } from 'react';
+import { BottomSheetModal } from '@gorhom/bottom-sheet';
 
 import { useChatWindowContext } from '@/context';
 import { useAppDispatch } from '@/hooks';
@@ -14,6 +15,7 @@ export const ConversationLabelActions = (props: ConversationLabelActionsProps) =
   const { labels } = props;
   const { conversationId } = useChatWindowContext();
   const dispatch = useAppDispatch();
+  const conversationLabelSheetRef = useRef<BottomSheetModal>(null);
 
   const handleLabelsUpdate = (updatedLabels: string[]) => {
     dispatch(
@@ -24,5 +26,11 @@ export const ConversationLabelActions = (props: ConversationLabelActionsProps) =
     );
   };
 
-  return <LabelActions labels={labels} onLabelsUpdate={handleLabelsUpdate} />;
+  return (
+    <LabelActions
+      labels={labels}
+      onLabelsUpdate={handleLabelsUpdate}
+      sheetRef={conversationLabelSheetRef}
+    />
+  );
 };

--- a/src/screens/contact-details/ContactDetailsScreen.tsx
+++ b/src/screens/contact-details/ContactDetailsScreen.tsx
@@ -23,6 +23,7 @@ import {
   ContactDetailsScreenHeader,
   ContactBasicActions,
   ContactMetaInformation,
+  ContactLabelActions,
 } from './components';
 import { AttributeList } from '@/components-next';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
@@ -32,6 +33,7 @@ import { useAppDispatch, useAppSelector } from '@/hooks';
 import { contactLabelActions } from '@/store/contact/contactLabelActions';
 import { getContactCustomAttributes } from '@/store/custom-attribute/customAttributeSlice';
 import { selectContactById } from '@/store/contact/contactSelectors';
+import { selectContactLabelsByContactId } from '@/store/contact/contactLabelSlice';
 import i18n from '@/i18n';
 
 type ContactDetailsScreenProps = NativeStackScreenProps<
@@ -157,6 +159,10 @@ const ContactDetailsScreen = (props: ContactDetailsScreenProps) => {
 
   const hasContactCustomAttributes = usedContactCustomAttributes.length > 0;
 
+  const contactLabels = useAppSelector(state =>
+    contactId ? selectContactLabelsByContactId(contactId)(state) : [],
+  );
+
   useEffect(() => {
     if (contactId) {
       dispatch(contactLabelActions.getContactLabels({ contactId }));
@@ -232,6 +238,11 @@ const ContactDetailsScreen = (props: ContactDetailsScreenProps) => {
             <ContactMetaInformation attributes={usedContactCustomAttributes} />
           </Animated.View>
         )}
+        {contactId ? (
+          <Animated.View style={tailwind.style('pt-10')}>
+            <ContactLabelActions labels={contactLabels} contactId={contactId} />
+          </Animated.View>
+        ) : null}
       </Animated.ScrollView>
     </View>
   );

--- a/src/screens/contact-details/ContactDetailsScreen.tsx
+++ b/src/screens/contact-details/ContactDetailsScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { View, Platform } from 'react-native';
 import Animated from 'react-native-reanimated';
+import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import camelCase from 'camelcase';
 
 import { TAB_BAR_HEIGHT } from '@/constants';
@@ -213,38 +214,40 @@ const ContactDetailsScreen = (props: ContactDetailsScreenProps) => {
   const allDetails = [...userDetails, ...socialMediaDetails];
 
   return (
-    <View
-      style={tailwind.style(
-        `flex-1 bg-white pt-6 ${Platform.OS === 'android' ? 'pt-12' : 'pt-6'}`,
-      )}>
-      <ContactDetailsScreenHeader
-        name={name || contactName || ''}
-        thumbnail={thumbnail || contactThumbnail || ''}
-        bio={description || ''}
-      />
-      <Animated.ScrollView
-        showsVerticalScrollIndicator={false}
-        contentContainerStyle={tailwind.style(`pb-[${TAB_BAR_HEIGHT}]`)}>
-        {email || phoneNumber ? (
-          <Animated.View style={tailwind.style('mt-[23px] px-4')}>
-            <ContactBasicActions phoneNumber={phoneNumber || ''} email={email || ''} />
-          </Animated.View>
-        ) : null}
-        <Animated.View style={tailwind.style('pt-10')}>
-          <AttributeList list={allDetails as AttributeListType[]} />
-        </Animated.View>
-        {hasContactCustomAttributes && (
+    <BottomSheetModalProvider>
+      <View
+        style={tailwind.style(
+          `flex-1 bg-white pt-6 ${Platform.OS === 'android' ? 'pt-12' : 'pt-6'}`,
+        )}>
+        <ContactDetailsScreenHeader
+          name={name || contactName || ''}
+          thumbnail={thumbnail || contactThumbnail || ''}
+          bio={description || ''}
+        />
+        <Animated.ScrollView
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={tailwind.style(`pb-[${TAB_BAR_HEIGHT}]`)}>
+          {email || phoneNumber ? (
+            <Animated.View style={tailwind.style('mt-[23px] px-4')}>
+              <ContactBasicActions phoneNumber={phoneNumber || ''} email={email || ''} />
+            </Animated.View>
+          ) : null}
           <Animated.View style={tailwind.style('pt-10')}>
-            <ContactMetaInformation attributes={usedContactCustomAttributes} />
+            <AttributeList list={allDetails as AttributeListType[]} />
           </Animated.View>
-        )}
-        {contactId ? (
-          <Animated.View style={tailwind.style('pt-10')}>
-            <ContactLabelActions labels={contactLabels} contactId={contactId} />
-          </Animated.View>
-        ) : null}
-      </Animated.ScrollView>
-    </View>
+          {hasContactCustomAttributes && (
+            <Animated.View style={tailwind.style('pt-10')}>
+              <ContactMetaInformation attributes={usedContactCustomAttributes} />
+            </Animated.View>
+          )}
+          {contactId ? (
+            <Animated.View style={tailwind.style('pt-10')}>
+              <ContactLabelActions labels={contactLabels} contactId={contactId} />
+            </Animated.View>
+          ) : null}
+        </Animated.ScrollView>
+      </View>
+    </BottomSheetModalProvider>
   );
 };
 

--- a/src/screens/contact-details/components/ContactLabelActions.tsx
+++ b/src/screens/contact-details/components/ContactLabelActions.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useRef } from 'react';
+import { BottomSheetModal } from '@gorhom/bottom-sheet';
 
 import { useAppDispatch } from '@/hooks';
 import { contactLabelActions } from '@/store/contact/contactLabelActions';
@@ -13,6 +14,7 @@ interface ContactLabelActionsProps {
 export const ContactLabelActions = (props: ContactLabelActionsProps) => {
   const { labels, contactId } = props;
   const dispatch = useAppDispatch();
+  const contactLabelSheetRef = useRef<BottomSheetModal>(null);
 
   const handleLabelsUpdate = (updatedLabels: string[]) => {
     dispatch(
@@ -23,6 +25,12 @@ export const ContactLabelActions = (props: ContactLabelActionsProps) => {
     );
   };
 
-  return <LabelActions labels={labels} onLabelsUpdate={handleLabelsUpdate} />;
+  return (
+    <LabelActions
+      labels={labels}
+      onLabelsUpdate={handleLabelsUpdate}
+      sheetRef={contactLabelSheetRef}
+    />
+  );
 };
 

--- a/src/screens/contact-details/components/ContactLabelActions.tsx
+++ b/src/screens/contact-details/components/ContactLabelActions.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import { useAppDispatch } from '@/hooks';
+import { contactLabelActions } from '@/store/contact/contactLabelActions';
+
+import { LabelActions } from '@/components-next/label-section';
+
+interface ContactLabelActionsProps {
+  labels: string[];
+  contactId: number;
+}
+
+export const ContactLabelActions = (props: ContactLabelActionsProps) => {
+  const { labels, contactId } = props;
+  const dispatch = useAppDispatch();
+
+  const handleLabelsUpdate = (updatedLabels: string[]) => {
+    dispatch(
+      contactLabelActions.updateContactLabels({
+        contactId: contactId,
+        labels: updatedLabels,
+      }),
+    );
+  };
+
+  return <LabelActions labels={labels} onLabelsUpdate={handleLabelsUpdate} />;
+};
+

--- a/src/screens/contact-details/components/index.ts
+++ b/src/screens/contact-details/components/index.ts
@@ -1,3 +1,4 @@
 export * from './ContactDetailsScreenHeader';
 export * from './ContactBasicActions';
 export * from './ContactMetaInformation';
+export * from './ContactLabelActions';

--- a/src/store/contact/contactService.ts
+++ b/src/store/contact/contactService.ts
@@ -19,7 +19,7 @@ export class ContactService {
     payload: UpdateContactLabelsPayload,
   ): Promise<ContactLabelsAPIResponse> {
     const { contactId, labels } = payload;
-    const response = await apiService.put<ContactLabelsAPIResponse>(
+    const response = await apiService.post<ContactLabelsAPIResponse>(
       `contacts/${contactId}/labels`,
       { labels },
     );


### PR DESCRIPTION
## Description 
Add the support for Contact labels (#876)

## Changes:
- Extract common label management logic into generic LabelActions component
  - Make LabelActions reusable by accepting labels and onLabelsUpdate callback prop
  - Remove conversation-specific logic (bulkAction, selectedIds) from component
  - Add detached prop to BottomSheetModal to render at root level (iOS formSheet fix)
  - Add enableDynamicSizing={false} for consistent rendering
  - Ref handling:
    - Add optional sheetRef prop to allow multiple instances without ref conflicts (Each instance (ConversationLabelActions, ContactLabelActions) uses its own ref)
    - Create custom LabelBackdrop component for instance-specific ref handling (Ensures backdrop dismisses the correct modal instance)
  - Organize LabelActions into label-actions folder structure
    - Split LabelStack and LabelBackdrop into separate component files
 
- Refactor ConversationLabelActions to use shared LabelActions component
- Create ContactLabelActions wrapper for contact label management
- ContactDetailsScreen:
  - Integrate ContactLabelActions into ContactDetailsScreen
  - Add BottomSheetModalProvider wrapper in ContactDetailsScreen for formSheet context (iOS formSheet creates separate presentation context requiring its own provider)
- Fix contact labels API method from PUT to POST to match API spec

## Updated UI
<img src="https://github.com/user-attachments/assets/d7571428-47a3-493f-ac86-ce39dca90114" width="300" />

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [x] I have tested in both Android and iOS platforms
- [x] My changes generate no new warnings
