### PR TITLE
Search(2): Improve message fetching for search navigation

### DIFF
--- a/src/store/conversation/conversationService.ts
+++ b/src/store/conversation/conversationService.ts
@@ -75,14 +75,20 @@ export class ConversationService {
   }
 
   static async fetchPreviousMessages(payload: MessagesPayload): Promise<MessagesResponse> {
-    const { conversationId, beforeId } = payload;
+    const { conversationId, beforeId, afterId } = payload;
+
+    const params: Record<string, number> = {};
+    if (beforeId) {
+      params.before = beforeId;
+    }
+    if (afterId) {
+      params.after = afterId;
+    }
 
     const response = await apiService.get<MessagesAPIResponse>(
       `conversations/${conversationId}/messages`,
       {
-        params: {
-          before: beforeId,
-        },
+        params,
       },
     );
     const { meta, payload: messages } = response.data;

--- a/src/store/conversation/conversationSlice.ts
+++ b/src/store/conversation/conversationSlice.ts
@@ -139,17 +139,25 @@ const conversationSlice = createSlice({
           return;
         }
         const conversation = state.entities[conversationId];
-        conversation.messages.unshift(...messages);
+        const { afterId } = action.meta.arg;
+        if (afterId) {
+          const existingMessageIds = new Set(conversation.messages.map(message => message.id));
+          const incomingMessages = messages.filter(message => !existingMessageIds.has(message.id));
+          conversation.messages.push(...incomingMessages);
+          conversation.messages.sort((a, b) => a.createdAt - b.createdAt);
+        } else {
+          conversation.messages.unshift(...messages);
+        }
         conversation.meta = {
           ...conversation.meta,
           ...responseMeta,
         };
         state.isLoadingMessages = false;
-        // Only update isAllMessagesFetched for "before" requests (pagination of older messages)
-        // Skip for "after" requests or when both are present (search navigation)
-        const { afterId } = action.meta.arg;
-        if (!afterId) {
-        state.isAllMessagesFetched = messages.length < 20 || false;
+        // Any request with "after" should re-enable older pagination fetches.
+        if (afterId) {
+          state.isAllMessagesFetched = false;
+        } else {
+          state.isAllMessagesFetched = messages.length < 20 || false;
         }
       })
       .addCase(conversationActions.fetchPreviousMessages.rejected, state => {

--- a/src/store/conversation/conversationSlice.ts
+++ b/src/store/conversation/conversationSlice.ts
@@ -133,8 +133,8 @@ const conversationSlice = createSlice({
       .addCase(conversationActions.fetchPreviousMessages.pending, state => {
         state.isLoadingMessages = true;
       })
-      .addCase(conversationActions.fetchPreviousMessages.fulfilled, (state, { payload }) => {
-        const { messages, conversationId, meta } = payload;
+      .addCase(conversationActions.fetchPreviousMessages.fulfilled, (state, action) => {
+        const { messages, conversationId, meta: responseMeta } = action.payload;
         if (!state.entities[conversationId]) {
           return;
         }
@@ -142,10 +142,15 @@ const conversationSlice = createSlice({
         conversation.messages.unshift(...messages);
         conversation.meta = {
           ...conversation.meta,
-          ...meta,
+          ...responseMeta,
         };
         state.isLoadingMessages = false;
+        // Only update isAllMessagesFetched for "before" requests (pagination of older messages)
+        // Skip for "after" requests or when both are present (search navigation)
+        const { afterId } = action.meta.arg;
+        if (!afterId) {
         state.isAllMessagesFetched = messages.length < 20 || false;
+        }
       })
       .addCase(conversationActions.fetchPreviousMessages.rejected, state => {
         state.isLoadingMessages = false;

--- a/src/store/conversation/conversationTypes.ts
+++ b/src/store/conversation/conversationTypes.ts
@@ -72,6 +72,7 @@ export interface ApiErrorResponse {
 export interface MessagesPayload {
   conversationId: number;
   beforeId?: number | null;
+  afterId?: number | null;
 }
 
 export interface MessagesResponse {


### PR DESCRIPTION
- Handle fetchPreviousMessages merges by request type:
beforeId requests prepend older messages (existing pagination behavior),
afterId requests append newer messages, dedupe by id, and sort by createdAt to preserve chronological order.
- Fix stale pagination state by resetting isAllMessagesFetched to false for any request that includes afterId.
- Keep isAllMessagesFetched completion logic tied to older-message pagination (beforeId path) so onEndReached can continue loading history correctly.
- Improve search navigation window loading (afterId/beforeId) without breaking conversation last-message ordering or blocking subsequent pagination.