### PR TITLE
chore: Fix dependabot alerts with pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,6 +187,9 @@
       "markdown-it": "^12.3.2",
       "js-yaml": "^4.1.1",
       "storybook": "8.6.17",
+      "@expo/cli>minimatch": "3.1.4",
+      "@expo/metro-config>minimatch": "3.1.4",
+      "@expo/fingerprint>minimatch": "3.1.4",
       "@typescript-eslint/typescript-estree>minimatch": "9.0.7",
       "glob>minimatch": "9.0.7",
       "tar": "7.5.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ overrides:
   markdown-it: ^12.3.2
   js-yaml: ^4.1.1
   storybook: 8.6.17
+  '@expo/cli>minimatch': 3.1.4
+  '@expo/metro-config>minimatch': 3.1.4
+  '@expo/fingerprint>minimatch': 3.1.4
   '@typescript-eslint/typescript-estree>minimatch': 9.0.7
   glob>minimatch: 9.0.7
   tar: 7.5.10
@@ -5249,8 +5252,8 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+  minimatch@3.1.4:
+    resolution: {integrity: sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==}
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
@@ -8364,7 +8367,7 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
       lodash.debounce: 4.0.8
-      minimatch: 3.1.2
+      minimatch: 3.1.4
       node-forge: 1.3.3
       npm-package-arg: 11.0.3
       ora: 3.4.0
@@ -8470,7 +8473,7 @@ snapshots:
       debug: 4.4.0
       find-up: 5.0.0
       getenv: 1.0.0
-      minimatch: 3.1.2
+      minimatch: 3.1.4
       p-limit: 3.1.0
       resolve-from: 5.0.0
       semver: 7.7.1
@@ -8518,7 +8521,7 @@ snapshots:
       glob: 10.5.0
       jsc-safe-url: 0.2.4
       lightningcss: 1.27.0
-      minimatch: 3.1.2
+      minimatch: 3.1.4
       postcss: 8.4.49
       resolve-from: 5.0.0
     transitivePeerDependencies:
@@ -13248,7 +13251,7 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
-  minimatch@3.1.2:
+  minimatch@3.1.4:
     dependencies:
       brace-expansion: 1.1.12
 


### PR DESCRIPTION
This PR fixes current Dependabot alerts in the mobile app without introducing top-level major dependency upgrades.
