### PR TITLE
feat(i18n): Add Hebrew language support

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -168,6 +168,7 @@ export const LANGUAGES = {
   fa: 'Farsi',
   fi: 'Finnish',
   fr: 'French',
+  he: 'Hebrew',
   hu: 'Hungarian',
   it: 'Italian',
   ja: 'Japanese',

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -12,6 +12,7 @@ import es from './es.json';
 import fa from './fa.json';
 import fi from './fi.json';
 import fr from './fr.json';
+import he from './he.json';
 import hu from './hu.json';
 import id from './id.json';
 import it from './it.json';
@@ -48,6 +49,7 @@ i18n.translations = {
   fa,
   fi,
   fr,
+  he,
   hu,
   id,
   it,


### PR DESCRIPTION
## Summary
- Added Hebrew (`he`) to the `LANGUAGES` constant in `src/constants/index.ts` so it appears in the language picker
- The `he.json` translation file already existed but was not registered as a selectable language

## Test plan
- [ ] Verify Hebrew appears in the language picker on the Settings screen
- [ ] Select Hebrew and confirm the app switches to Hebrew translations
- [ ] Verify RTL layout renders correctly with Hebrew selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)