### PR TITLE
feat: Scroll to and highlight quoted message on tap

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -4,7 +4,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
   return {
     name: 'Chatwoot',
     slug: process.env.EXPO_PUBLIC_APP_SLUG || 'chatwoot-mobile',
-    version: '4.4.0',
+    version: '4.4.1',
     orientation: 'portrait',
     icon: './assets/icon.png',
     userInterfaceStyle: 'light',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/mobile-app",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "packageManager": "pnpm@10.11.0",
   "scripts": {
     "start": "expo start --dev-client",

--- a/src/context/useChatWindowContext.tsx
+++ b/src/context/useChatWindowContext.tsx
@@ -19,6 +19,9 @@ interface ChatWindowContextType {
   setPagerViewIndex: React.Dispatch<React.SetStateAction<number>>;
   conversationId: number;
   messageId?: number;
+
+  scrollToMessageId?: number;
+  setScrollToMessageId: React.Dispatch<React.SetStateAction<number | undefined>>;
 }
 
 const ChatWindowContext = React.createContext<ChatWindowContextType | undefined>(undefined);
@@ -41,6 +44,7 @@ const ChatWindowProvider: React.FC<
   const [isTextInputFocused, setIsTextInputFocused] = useState(false);
   const [isVoiceRecorderOpen, setIsVoiceRecorderOpen] = useState(false);
   const [pagerViewIndex, setPagerViewIndex] = useState(0);
+  const [scrollToMessageId, setScrollToMessageId] = useState<number | undefined>(undefined);
 
   const textInputRef = useRef<TextInputProps>(null);
 
@@ -60,6 +64,8 @@ const ChatWindowProvider: React.FC<
         setPagerViewIndex,
         conversationId,
         messageId,
+        scrollToMessageId,
+        setScrollToMessageId,
       }}>
       {children}
     </ChatWindowContext.Provider>

--- a/src/screens/chat-screen/components/message-components/ReplyMessageBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/ReplyMessageBubble.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 import { Pressable } from 'react-native';
 import Animated from 'react-native-reanimated';
 
-import { useRefsContext } from '@/context';
+import { useChatWindowContext } from '@/context';
 import { AttachFileIcon, CameraIcon, VideoCall, VoiceNote } from '@/svg-icons';
 import { tailwind } from '@/theme';
 import { Message } from '@/types';
@@ -24,7 +24,7 @@ const variantBaseMap = {
 export const ReplyMessageBubble = (props: ReplyMessageBubbleProps) => {
   const replyMessageItem = props.replyMessage as Message;
 
-  const { messageListRef } = useRefsContext();
+  const { setScrollToMessageId } = useChatWindowContext();
 
   const hasAttachments = useMemo(
     () => replyMessageItem?.attachments?.length > 0,
@@ -47,13 +47,11 @@ export const ReplyMessageBubble = (props: ReplyMessageBubbleProps) => {
   };
 
   const handleScrollToMessage = useCallback(() => {
-    messageListRef.current?.scrollToItem({
-      item: replyMessageItem,
-      animated: true,
-      viewPosition: 0.5,
-    });
+    if (replyMessageItem?.id) {
+      setScrollToMessageId(replyMessageItem.id);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [replyMessageItem?.id]);
 
   return (
     <Pressable

--- a/src/screens/chat-screen/components/message-components/ReplyMessageCell.tsx
+++ b/src/screens/chat-screen/components/message-components/ReplyMessageCell.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 import { Pressable } from 'react-native';
 import Animated from 'react-native-reanimated';
 
-import { useRefsContext } from '@/context';
+import { useChatWindowContext } from '@/context';
 import { AttachFileIcon, CameraIcon, VideoCall, VoiceNote } from '@/svg-icons';
 import { tailwind } from '@/theme';
 import { Message } from '@/types';
@@ -22,7 +22,7 @@ export const ReplyMessageCell = (props: ReplyMessageCellProps) => {
 
   const { isIncoming, isOutgoing } = props;
 
-  const { messageListRef } = useRefsContext();
+  const { setScrollToMessageId } = useChatWindowContext();
 
   const hasAttachments = useMemo(
     () => replyMessageItem?.attachments?.length > 0,
@@ -45,13 +45,11 @@ export const ReplyMessageCell = (props: ReplyMessageCellProps) => {
   };
 
   const handleScrollToMessage = useCallback(() => {
-    messageListRef.current?.scrollToItem({
-      item: replyMessageItem,
-      animated: true,
-      viewPosition: 0.5,
-    });
+    if (replyMessageItem?.id) {
+      setScrollToMessageId(replyMessageItem.id);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [replyMessageItem?.id]);
 
   return (
     <Pressable

--- a/src/screens/chat-screen/components/message-item/Message.tsx
+++ b/src/screens/chat-screen/components/message-item/Message.tsx
@@ -114,7 +114,6 @@ const MessageWrapper = ({
 }: MessageWrapperProps) => {
   const { zoomStyle, highlightStyle } = useTargetMessageAnimation({
     isTargetMessage,
-    messageId: item.id,
     isListPositioned,
   });
 

--- a/src/screens/chat-screen/components/message-item/useTargetMessageAnimation.ts
+++ b/src/screens/chat-screen/components/message-item/useTargetMessageAnimation.ts
@@ -26,19 +26,24 @@ export function useTargetMessageAnimation({
   const highlightOpacity = useSharedValue(0);
   const { messageId: contextMessageId, scrollToMessageId } = useChatWindowContext();
   const lastAnimatedTriggerRef = useRef<number | undefined>(undefined);
+  const prevScrollToMessageIdRef = useRef<number | undefined>(undefined);
 
   // Combine both triggers into one — scrollToMessageId takes priority
   const activeTriggerId = scrollToMessageId ?? contextMessageId;
   // For quote taps, skip the isListPositioned check since the list is already visible
   const isQuoteTap = scrollToMessageId !== undefined;
 
-  // Reset animation guard when scrollToMessageId is cleared,
-  // so tapping the same quote again can re-trigger the animation
+  // When scrollToMessageId transitions from a value to undefined (i.e. quote scroll
+  // finished), restore the guard to contextMessageId so the search target doesn't
+  // re-animate, while ensuring a repeat quote tap can still trigger.
   useEffect(() => {
-    if (scrollToMessageId === undefined) {
-      lastAnimatedTriggerRef.current = undefined;
+    const wasSet = prevScrollToMessageIdRef.current !== undefined;
+    prevScrollToMessageIdRef.current = scrollToMessageId;
+
+    if (wasSet && scrollToMessageId === undefined) {
+      lastAnimatedTriggerRef.current = contextMessageId;
     }
-  }, [scrollToMessageId]);
+  }, [scrollToMessageId, contextMessageId]);
 
   useEffect(() => {
     if (!isTargetMessage || activeTriggerId === undefined || (!isListPositioned && !isQuoteTap)) {

--- a/src/screens/chat-screen/components/message-item/useTargetMessageAnimation.ts
+++ b/src/screens/chat-screen/components/message-item/useTargetMessageAnimation.ts
@@ -11,41 +11,49 @@ import { useChatWindowContext } from '@/context';
 
 interface UseTargetMessageAnimationParams {
   isTargetMessage: boolean;
-  messageId: number;
   isListPositioned: boolean;
 }
 
 /**
- * Hook to handle zoom and highlight animation for target messages when navigating from search.
- * Animation triggers only after the list is positioned and visible, avoiding the race
- * condition where a fixed delay could fire while the list is still hidden.
+ * Hook to handle zoom and highlight animation for target messages.
+ * Triggers from both search navigation (contextMessageId) and quote tap (scrollToMessageId).
  */
 export function useTargetMessageAnimation({
   isTargetMessage,
-  messageId,
   isListPositioned,
 }: UseTargetMessageAnimationParams) {
   const messageScale = useSharedValue(1);
   const highlightOpacity = useSharedValue(0);
-  const { messageId: contextMessageId } = useChatWindowContext();
-  const lastAnimatedContextMessageIdRef = useRef<number | undefined>(undefined);
+  const { messageId: contextMessageId, scrollToMessageId } = useChatWindowContext();
+  const lastAnimatedTriggerRef = useRef<number | undefined>(undefined);
+
+  // Combine both triggers into one — scrollToMessageId takes priority
+  const activeTriggerId = scrollToMessageId ?? contextMessageId;
+  // For quote taps, skip the isListPositioned check since the list is already visible
+  const isQuoteTap = scrollToMessageId !== undefined;
+
+  // Reset animation guard when scrollToMessageId is cleared,
+  // so tapping the same quote again can re-trigger the animation
+  useEffect(() => {
+    if (scrollToMessageId === undefined) {
+      lastAnimatedTriggerRef.current = undefined;
+    }
+  }, [scrollToMessageId]);
 
   useEffect(() => {
-    if (!isTargetMessage || contextMessageId === undefined || !isListPositioned) {
+    if (!isTargetMessage || activeTriggerId === undefined || (!isListPositioned && !isQuoteTap)) {
       messageScale.value = 1;
       highlightOpacity.value = 0;
       return;
     }
 
-    // Only animate once per contextMessageId to avoid re-triggering on re-renders
-    if (lastAnimatedContextMessageIdRef.current === contextMessageId) return;
-    lastAnimatedContextMessageIdRef.current = contextMessageId;
+    // Only animate once per trigger to avoid re-triggering on re-renders
+    if (lastAnimatedTriggerRef.current === activeTriggerId) return;
+    lastAnimatedTriggerRef.current = activeTriggerId;
 
     messageScale.value = 1;
     highlightOpacity.value = 0;
 
-    // Short delay after list is visible to let the user register the message position
-    // before the highlight draws their attention
     messageScale.value = withDelay(
       150,
       withSequence(
@@ -63,7 +71,7 @@ export function useTargetMessageAnimation({
         withTiming(0, { duration: 300 }),
       ),
     );
-  }, [isTargetMessage, messageId, contextMessageId, isListPositioned, messageScale, highlightOpacity]);
+  }, [isTargetMessage, activeTriggerId, isListPositioned, isQuoteTap, messageScale, highlightOpacity]);
 
   const zoomStyle = useAnimatedStyle(() => {
     return {

--- a/src/screens/chat-screen/components/message-list/MessagesListContainer.tsx
+++ b/src/screens/chat-screen/components/message-list/MessagesListContainer.tsx
@@ -72,7 +72,8 @@ const PlatformSpecificKeyboardWrapperComponent =
 
 export const MessagesListContainer = () => {
   const [appState, setAppState] = useState(AppState.currentState);
-  const { conversationId, messageId } = useChatWindowContext();
+  const { conversationId, messageId, scrollToMessageId, setScrollToMessageId } =
+    useChatWindowContext();
   const dispatch = useAppDispatch();
   const [isFlashListReady, setFlashListReady] = React.useState(false);
   const [isListVisible, setIsListVisible] = useState(!messageId);
@@ -250,6 +251,37 @@ export const MessagesListContainer = () => {
     onPositioned: useCallback(() => setIsListVisible(true), []),
   });
 
+  // Handle scroll-to-message when tapping a quoted message reply
+  useEffect(() => {
+    if (!scrollToMessageId) return;
+
+    const targetIndex = messagesWithGrouping.findIndex(
+      item => !('date' in item) && 'id' in item && item.id === scrollToMessageId,
+    );
+
+    if (targetIndex >= 0) {
+      try {
+        messageListRef.current?.scrollToIndex({
+          index: targetIndex,
+          animated: true,
+          viewPosition: 0.5,
+        });
+      } catch {
+        // scrollToIndex can throw if index is out of range during layout changes
+      }
+    }
+
+    // Clear after a delay to allow the highlight animation to complete
+    const timer = setTimeout(() => {
+      setScrollToMessageId(undefined);
+    }, 1500);
+
+    return () => clearTimeout(timer);
+  }, [scrollToMessageId, messagesWithGrouping, messageListRef, setScrollToMessageId]);
+
+  // The active target message ID — either from search navigation or quote tap
+  const activeTargetMessageId = scrollToMessageId || messageId;
+
   // Show loader when navigating to a message from search until messages are loaded
   // (prevents list from rendering at wrong position)
   if (messageId && messagesWithGrouping.length === 0 && isLoadingMessages) {
@@ -274,7 +306,7 @@ export const MessagesListContainer = () => {
           onEndReached={onEndReached}
           isEmailInbox={isEmailInbox}
           currentUserId={userId as number}
-          targetMessageId={messageId}
+          targetMessageId={activeTargetMessageId}
           initialScrollIndex={
             targetMessageIndex !== undefined && targetMessageIndex >= 0
               ? targetMessageIndex


### PR DESCRIPTION
## Description                                                                                                                     
                                                                                                                                 
  - Tapping a quoted message preview in a reply bubble now scrolls to the original message and plays a zoom + highlight animation
  - Reuses the existing search navigation animation by extending `ChatWindowContext` with `scrollToMessageId` state              
  - Simplified `useTargetMessageAnimation` to use a single trigger path for both search navigation and quote taps

Fixes [https://linear.app/chatwoot/issue/CW-3890/scroll-to-message-when-click-on-reply-message](https://linear.app/chatwoot/issue/CW-3890/scroll-to-message-when-click-on-reply-message)

https://github.com/user-attachments/assets/f09f16a5-b55b-433d-b98e-39f6ed193b74


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have tested in both Android and iOS platform
- [x] My changes generate no new warnings