### PR TITLE
feat: Add translate option to message long-press menu

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -238,8 +238,13 @@
     "LONG_PRESS_ACTIONS": {
       "COPY": "Copy",
       "REPLY": "Reply",
-      "DELETE_MESSAGE": "Delete message"
+      "DELETE_MESSAGE": "Delete message",
+      "TRANSLATE": "Translate"
     },
+    "TRANSLATE_SUCCESS": "Message translated",
+    "TRANSLATE_ERROR": "Failed to translate message",
+    "VIEW_ORIGINAL": "View original",
+    "VIEW_TRANSLATED": "View translated",
     "EMAIL_HEADER": {
       "FROM": "From",
       "TO": "To",

--- a/src/screens/chat-screen/components/message-components/TextBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/TextBubble.tsx
@@ -20,9 +20,10 @@ export const TextBubble = (props: TextBubbleProps) => {
   const { private: isPrivate, content, contentAttributes, sender } = messageItem;
 
   const translations = contentAttributes?.translations;
+  const activeLocale = i18n.locale?.split('_')[0] || 'en';
   const translatedText =
-    translations && Object.keys(translations).length > 0
-      ? Object.values(translations)[0]
+    translations
+      ? (translations[activeLocale] || Object.values(translations)[0] || null)
       : null;
   const hasTranslations = !!translatedText;
 

--- a/src/screens/chat-screen/components/message-components/TextBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/TextBubble.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { useState, useCallback } from 'react';
+import { Pressable } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { tailwind } from '@/theme';
 import { Message } from '@/types';
 import { MarkdownBubble } from './MarkdownBubble';
 import { EmailMeta } from './EmailMeta';
+import i18n from '@/i18n';
+import { MESSAGE_VARIANTS } from '@/constants';
 
 export type TextBubbleProps = {
   item: Message;
@@ -16,18 +19,54 @@ export const TextBubble = (props: TextBubbleProps) => {
 
   const { private: isPrivate, content, contentAttributes, sender } = messageItem;
 
+  const translations = contentAttributes?.translations;
+  const translatedText =
+    translations && Object.keys(translations).length > 0
+      ? Object.values(translations)[0]
+      : null;
+  const hasTranslations = !!translatedText;
+
+  const [showOriginal, setShowOriginal] = useState(false);
+
+  const toggleTranslation = useCallback(() => {
+    setShowOriginal(prev => !prev);
+  }, []);
+
+  const displayContent =
+    hasTranslations && !showOriginal ? translatedText : (content || '');
+
+  const toggleTextColor =
+    variant === MESSAGE_VARIANTS.USER ? 'text-blue-200' : 'text-blue-700';
+
+  const renderContent = () => (
+    <React.Fragment>
+      <MarkdownBubble messageContent={displayContent} variant={variant} />
+      {hasTranslations && (
+        <Pressable onPress={toggleTranslation} hitSlop={4}>
+          <Animated.Text
+            style={tailwind.style(
+              'text-xs font-inter-420-20 tracking-[0.32px] pt-1',
+              toggleTextColor,
+            )}>
+            {showOriginal
+              ? i18n.t('CONVERSATION.VIEW_TRANSLATED')
+              : i18n.t('CONVERSATION.VIEW_ORIGINAL')}
+          </Animated.Text>
+        </Pressable>
+      )}
+    </React.Fragment>
+  );
+
   return (
     <React.Fragment>
       {contentAttributes && <EmailMeta {...{ contentAttributes, sender }} />}
       {isPrivate ? (
         <Animated.View style={tailwind.style('flex flex-row')}>
           <Animated.View style={tailwind.style('w-[3px] bg-amber-700 h-auto rounded-[4px]')} />
-          <Animated.View style={tailwind.style('pl-2.5')}>
-            <MarkdownBubble messageContent={content} variant={variant} />
-          </Animated.View>
+          <Animated.View style={tailwind.style('pl-2.5')}>{renderContent()}</Animated.View>
         </Animated.View>
       ) : (
-        <MarkdownBubble messageContent={content} variant={variant} />
+        renderContent()
       )}
     </React.Fragment>
   );

--- a/src/screens/chat-screen/components/message-item/Message.tsx
+++ b/src/screens/chat-screen/components/message-item/Message.tsx
@@ -32,7 +32,7 @@ import {
 } from '@/constants';
 import i18n from '@/i18n';
 import Clipboard from '@react-native-clipboard/clipboard';
-import { CopyIcon, Trash } from '@/svg-icons';
+import { CopyIcon, Trash, TranslateIcon } from '@/svg-icons';
 import { MenuOption, MessageMenu } from '../message-menu';
 import { tailwind } from '@/theme';
 import { Dimensions, View } from 'react-native';
@@ -275,6 +275,19 @@ export const MessageComponent = (props: MessageComponentProps) => {
     showToast({ message: i18n.t('CONVERSATION.DELETE_MESSAGE_SUCCESS') });
   };
 
+  const handleTranslateMessage = async (messageId: number) => {
+    hapticSelection?.();
+    const targetLanguage = i18n.locale?.split('_')[0] || 'en';
+    try {
+      await dispatch(
+        conversationActions.translateMessage({ conversationId, messageId, targetLanguage }),
+      ).unwrap();
+      showToast({ message: i18n.t('CONVERSATION.TRANSLATE_SUCCESS') });
+    } catch {
+      showToast({ message: i18n.t('CONVERSATION.TRANSLATE_ERROR') });
+    }
+  };
+
   const getMenuOptions = (message: Message): MenuOption[] => {
     const { messageType, content, attachments } = message;
     const hasText = !!content;
@@ -293,6 +306,16 @@ export const MessageComponent = (props: MessageComponentProps) => {
         handleOnPressMenuOption: () => handleCopyMessage(content),
         destructive: false,
       });
+
+      const hasTranslation = !!message.contentAttributes?.translations;
+      if (!hasTranslation) {
+        menuOptions.push({
+          title: i18n.t('CONVERSATION.LONG_PRESS_ACTIONS.TRANSLATE'),
+          icon: <TranslateIcon />,
+          handleOnPressMenuOption: () => handleTranslateMessage(message.id),
+          destructive: false,
+        });
+      }
     }
 
     if (hasAttachments || hasText) {

--- a/src/screens/chat-screen/components/message-item/Message.tsx
+++ b/src/screens/chat-screen/components/message-item/Message.tsx
@@ -307,8 +307,9 @@ export const MessageComponent = (props: MessageComponentProps) => {
         destructive: false,
       });
 
-      const hasTranslation = !!message.contentAttributes?.translations;
-      if (!hasTranslation) {
+      const targetLanguage = i18n.locale?.split('_')[0] || 'en';
+      const hasTranslationForLocale = !!message.contentAttributes?.translations?.[targetLanguage];
+      if (!hasTranslationForLocale) {
         menuOptions.push({
           title: i18n.t('CONVERSATION.LONG_PRESS_ACTIONS.TRANSLATE'),
           icon: <TranslateIcon />,

--- a/src/store/conversation/conversationActions.ts
+++ b/src/store/conversation/conversationActions.ts
@@ -25,6 +25,8 @@ import type {
   SendMessageAPIResponse,
   SendMessagePayload,
   TogglePriorityPayload,
+  TranslateMessagePayload,
+  TranslateMessageAPIResponse,
 } from './conversationTypes';
 import { AxiosError } from 'axios';
 import { MESSAGE_STATUS } from '@/constants';
@@ -254,4 +256,24 @@ export const conversationActions = {
       return await ConversationService.togglePriority(payload);
     },
   ),
+  translateMessage: createAsyncThunk<
+    TranslateMessageAPIResponse & { conversationId: number; messageId: number; targetLanguage: string },
+    TranslateMessagePayload
+  >('conversations/translateMessage', async (payload, { rejectWithValue }) => {
+    try {
+      const response = await ConversationService.translateMessage(payload);
+      return {
+        ...response,
+        conversationId: payload.conversationId,
+        messageId: payload.messageId,
+        targetLanguage: payload.targetLanguage,
+      };
+    } catch (error) {
+      const { response } = error as AxiosError<ApiErrorResponse>;
+      if (!response) {
+        throw error;
+      }
+      return rejectWithValue(response.data);
+    }
+  }),
 };

--- a/src/store/conversation/conversationService.ts
+++ b/src/store/conversation/conversationService.ts
@@ -29,6 +29,8 @@ import type {
   MarkMessageReadOrUnreadResponse,
   ToggleConversationStatusAPIResponse,
   TogglePriorityPayload,
+  TranslateMessagePayload,
+  TranslateMessageAPIResponse,
 } from './conversationTypes';
 
 import {
@@ -217,5 +219,16 @@ export class ConversationService {
   static async togglePriority(payload: TogglePriorityPayload): Promise<void> {
     const { conversationId, priority } = payload;
     await apiService.post(`conversations/${conversationId}/toggle_priority`, { priority });
+  }
+
+  static async translateMessage(
+    payload: TranslateMessagePayload,
+  ): Promise<TranslateMessageAPIResponse> {
+    const { conversationId, messageId, targetLanguage } = payload;
+    const response = await apiService.post<TranslateMessageAPIResponse>(
+      `conversations/${conversationId}/messages/${messageId}/translate`,
+      { target_language: targetLanguage },
+    );
+    return response.data;
   }
 }

--- a/src/store/conversation/conversationSlice.ts
+++ b/src/store/conversation/conversationSlice.ts
@@ -225,14 +225,18 @@ const conversationSlice = createSlice({
         if (!conversation) {
           return;
         }
-        const message = conversation.messages.find(m => m.id === messageId);
-        if (message) {
+        const messageIndex = conversation.messages.findIndex(m => m.id === messageId);
+        if (messageIndex !== -1) {
+          const message = conversation.messages[messageIndex];
           const existing = message.contentAttributes ?? ({} as NonNullable<Message['contentAttributes']>);
-          message.contentAttributes = {
-            ...existing,
-            translations: {
-              ...existing.translations,
-              [targetLanguage]: content,
+          conversation.messages[messageIndex] = {
+            ...message,
+            contentAttributes: {
+              ...existing,
+              translations: {
+                ...existing.translations,
+                [targetLanguage]: content,
+              },
             },
           };
         }

--- a/src/store/conversation/conversationSlice.ts
+++ b/src/store/conversation/conversationSlice.ts
@@ -215,6 +215,27 @@ const conversationSlice = createSlice({
         }
         conversation.unreadCount = unreadCount;
         conversation.agentLastSeenAt = agentLastSeenAt;
+      })
+      .addCase(conversationActions.translateMessage.fulfilled, (state, action) => {
+        const { conversationId, messageId, targetLanguage, content } = action.payload;
+        if (!content) {
+          return;
+        }
+        const conversation = state.entities[conversationId];
+        if (!conversation) {
+          return;
+        }
+        const message = conversation.messages.find(m => m.id === messageId);
+        if (message) {
+          const existing = message.contentAttributes ?? ({} as NonNullable<Message['contentAttributes']>);
+          message.contentAttributes = {
+            ...existing,
+            translations: {
+              ...existing.translations,
+              [targetLanguage]: content,
+            },
+          };
+        }
       });
   },
 });

--- a/src/store/conversation/conversationTypes.ts
+++ b/src/store/conversation/conversationTypes.ts
@@ -239,3 +239,13 @@ export interface TogglePriorityPayload {
   conversationId: number;
   priority: ConversationPriority;
 }
+
+export interface TranslateMessagePayload {
+  conversationId: number;
+  messageId: number;
+  targetLanguage: string;
+}
+
+export interface TranslateMessageAPIResponse {
+  content: string;
+}

--- a/src/types/Message.ts
+++ b/src/types/Message.ts
@@ -63,6 +63,7 @@ export type MessageContentAttributes = {
   imageType: string;
   contentType: ContentType;
   isUnsupported: boolean;
+  translations?: Record<string, string>;
 };
 
 export interface Message {


### PR DESCRIPTION
##Description

Integrate with Chatwoot's existing translate API to allow agents to translate messages directly from the mobile app. Adds translate menu option, Redux action/service layer, and inline translation toggle on TextBubble to switch between original and translated content.

Fixes [https://linear.app/chatwoot/issue/CW-1891/support-translate-option-in-the-mobile-message-menu](https://linear.app/chatwoot/issue/CW-1891/support-translate-option-in-the-mobile-message-menu)

https://github.com/user-attachments/assets/4839e53c-6ab4-4b4a-87b0-edb604f7c30c

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have tested in both Android and iOS platform
- [x] My changes generate no new warnings