### PR TITLE
fix: Show correct delivery status ticks for API channel messages

### DIFF
--- a/src/screens/chat-screen/components/message-components/DeliveryStatus.tsx
+++ b/src/screens/chat-screen/components/message-components/DeliveryStatus.tsx
@@ -81,6 +81,10 @@ export const DeliveryStatus = (props: DeliveryStatusProps) => {
     ) {
       return sourceId && isSent;
     }
+    // API inbox messages use real sent/delivered/read status values from the external system.
+    if (isAPIChannel) {
+      return isSent;
+    }
     // There is no source id for the line channel
     if (isALineChannel) {
       return true;
@@ -97,8 +101,12 @@ export const DeliveryStatus = (props: DeliveryStatusProps) => {
       return sourceId && isDelivered;
     }
 
-    // We will consider messages as delivered for web widget inbox and API inbox if they are sent
-    if (isAWebWidgetChannel || isAPIChannel) {
+    // API inbox messages use real delivered status from the external system.
+    if (isAPIChannel) {
+      return isDelivered;
+    }
+    // All messages marked as delivered for the web widget inbox once they are sent.
+    if (isAWebWidgetChannel) {
       return isSent;
     }
 


### PR DESCRIPTION
## Description 

Messages sent through API channel inboxes were not showing any delivery ticks on mobile, while the same messages showed double ticks correctly on web.    

The issue was that mobile treated API channel the same as WebWidget, which doesn't receive real delivery updates. API channels do get real status callbacks from the provider, so they need to use actual status values : sent, delivered, read. Just like the web already does. 

The mobile code grouped API channel with WebWidget and treated "sent" as "delivered" for both. But as the web codebase  documents in [MessageMeta.vue](https://github.com/chatwoot/chatwoot/blob/develop/app/javascript/dashboard/components-next/message/MessageMeta.vue):                                                                                                  
                                                                                                                                 
  - "API inbox messages use real sent/delivered/read status values from the external system" (API channels get actual delivery callbacks from the provider)
  - "All messages marked as delivered for the web widget inbox once they are sent" (WebWidget has no delivery tracking, so it fakes delivered on sent )                                                                                                  
   
The web has separated these two cases, but mobile's logic as mentioned in comment: "We will consider messages as delivered for web widget inbox and API inbox if they are sent".
                                                                                                                                 
This PR syncs mobile's DeliveryStatus.tsx to match the web's approach.

Fixes [https://linear.app/chatwoot/issue/PLA-112/message-delivery-status-is-not-showing-for-api-channel](https://linear.app/chatwoot/issue/PLA-112/message-delivery-status-is-not-showing-for-api-channel)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have tested in both Android and iOS platform
- [x] My changes generate no new warnings
