### PR TITLE
feat: Add Instagram and Tiktok delivery status indicators

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -135,6 +135,7 @@ export const INBOX_TYPES = {
   LINE: 'Channel::Line',
   SMS: 'Channel::Sms',
   INSTAGRAM: 'Channel::Instagram',
+  TIKTOK: 'Channel::Tiktok',
 };
 
 export const INBOX_FEATURES = {

--- a/src/screens/chat-screen/components/message-components/DeliveryStatus.tsx
+++ b/src/screens/chat-screen/components/message-components/DeliveryStatus.tsx
@@ -56,6 +56,8 @@ export const DeliveryStatus = (props: DeliveryStatusProps) => {
   const shouldShowStatusIndicator =
     (messageType === MESSAGE_TYPES.OUTGOING || isTemplate) && !isPrivate;
   const isALineChannel = channel === INBOX_TYPES.LINE;
+  const isAnInstagramChannel = channel === INBOX_TYPES.INSTAGRAM;
+  const isATiktokChannel = channel === INBOX_TYPES.TIKTOK;
 
   const animationConfigs = useBottomSheetSpringConfigs({
     mass: 1,
@@ -77,7 +79,9 @@ export const DeliveryStatus = (props: DeliveryStatusProps) => {
       isATwilioChannel ||
       isAFacebookChannel ||
       isATelegramChannel ||
-      isASmsInbox
+      isASmsInbox ||
+      isAnInstagramChannel ||
+      isATiktokChannel
     ) {
       return sourceId && isSent;
     }
@@ -93,7 +97,7 @@ export const DeliveryStatus = (props: DeliveryStatusProps) => {
     if (!shouldShowStatusIndicator) {
       return false;
     }
-    if (isAWhatsappChannel || isATwilioChannel || isAFacebookChannel || isASmsInbox) {
+    if (isAWhatsappChannel || isATwilioChannel || isAFacebookChannel || isASmsInbox || isAnInstagramChannel || isATiktokChannel) {
       return sourceId && isDelivered;
     }
 
@@ -117,7 +121,7 @@ export const DeliveryStatus = (props: DeliveryStatusProps) => {
       return isRead;
     }
 
-    if (isAWhatsappChannel || isATwilioChannel || isAFacebookChannel) {
+    if (isAWhatsappChannel || isATwilioChannel || isAFacebookChannel || isAnInstagramChannel || isATiktokChannel) {
       return sourceId && isRead;
     }
 

--- a/src/types/common/Channel.ts
+++ b/src/types/common/Channel.ts
@@ -9,6 +9,8 @@ export type Channel =
   | 'Channel::FacebookPage'
   | 'Channel::Email'
   | 'Channel::Api'
+  | 'Channel::Instagram'
+  | 'Channel::Tiktok'
   | 'Channel::All';
 
 export type AllChannels = Channel | 'All';
@@ -30,6 +32,8 @@ export const InboxTypes = {
   TELEGRAM: 'Channel::Telegram',
   LINE: 'Channel::Line',
   SMS: 'Channel::Sms',
+  INSTAGRAM: 'Channel::Instagram',
+  TIKTOK: 'Channel::Tiktok',
 };
 
 export const getRandomChannel = () => {


### PR DESCRIPTION
## Description 

Instagram and Tiktok channels were missing from mobile's delivery status logic. All three indicators (sent, delivered, read) had no handling for them. So messages on these channels showed no ticks at all.                                                
                                                                                                                                 
The web app (MessageMeta.vue) already handles both channels with sourceId && status checks. This PR adds the same handling to mobile's DeliveryStatus.tsx.                                          
                                                                                                                                 
Changes:
  - Added TIKTOK: 'Channel::Tiktok' to INBOX_TYPES constants                                                                     
  - Added Instagram and Tiktok to showSentIndicator, showDeliveredIndicator, and showReadIndicator

## Type of change

- [x] New feature (non-breaking change which adds functionality)