### PR TITLE
fix: Resolve ENOENT race condition in OGG temp file cleanup on iOS

### DIFF
--- a/src/utils/audioConverter.ios.ts
+++ b/src/utils/audioConverter.ios.ts
@@ -32,8 +32,10 @@ export const convertOggToWav = async (oggUrl: string): Promise<string | Error> =
     );
 
     // Clean up the temporary OGG file
-    if (await RNFS.exists(tempOggPath)) {
+    try {
       await RNFS.unlink(tempOggPath);
+    } catch {
+      // File may already be cleaned up
     }
 
     // Verify output file exists


### PR DESCRIPTION
Fixes [https://linear.app/chatwoot/issue/CW-6688/error-enoent-no-such-file-or-directory-open](https://linear.app/chatwoot/issue/CW-6688/error-enoent-no-such-file-or-directory-open)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
