### PR TITLE
fix: Stabilize assign and add participant bottom sheet sizing and remove loader flash

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,6 +181,19 @@
     "patchedDependencies": {
       "ffmpeg-kit-react-native@6.0.2": "patches/ffmpeg-kit-react-native.patch"
     },
-    "overrides": {}
+    "overrides": {
+      "form-data": "^4.0.4",
+      "node-forge": "^1.3.2",
+      "glob": "^10.5.0",
+      "markdown-it": "^12.3.2",
+      "js-yaml": "^4.1.1",
+      "storybook": "8.6.17",
+      "@expo/cli>minimatch": "3.1.4",
+      "@expo/metro-config>minimatch": "3.1.4",
+      "@expo/fingerprint>minimatch": "3.1.4",
+      "@typescript-eslint/typescript-estree>minimatch": "9.0.7",
+      "glob>minimatch": "9.0.7",
+      "tar": "7.5.11"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -181,19 +181,6 @@
     "patchedDependencies": {
       "ffmpeg-kit-react-native@6.0.2": "patches/ffmpeg-kit-react-native.patch"
     },
-    "overrides": {
-      "form-data": "^4.0.4",
-      "node-forge": "^1.3.2",
-      "glob": "^10.5.0",
-      "markdown-it": "^12.3.2",
-      "js-yaml": "^4.1.1",
-      "storybook": "8.6.17",
-      "@expo/cli>minimatch": "3.1.4",
-      "@expo/metro-config>minimatch": "3.1.4",
-      "@expo/fingerprint>minimatch": "3.1.4",
-      "@typescript-eslint/typescript-estree>minimatch": "9.0.7",
-      "glob>minimatch": "9.0.7",
-      "tar": "7.5.11"
-    }
+    "overrides": {}
   }
 }

--- a/src/navigation/tabs/ActionBottomSheet.tsx
+++ b/src/navigation/tabs/ActionBottomSheet.tsx
@@ -32,7 +32,7 @@ const ActionBottomSheet = () => {
   const actionSnapPoints = useMemo(() => {
     switch (currentActionState) {
       case 'Assign':
-        return ['50%'];
+        return [400];
       case 'Status':
         return [250];
       case 'Label':
@@ -40,7 +40,7 @@ const ActionBottomSheet = () => {
       case 'Priority':
         return [300];
       case 'TeamAssign':
-        return ['50%'];
+        return [400];
       default:
         return [250];
     }
@@ -59,6 +59,7 @@ const ActionBottomSheet = () => {
       style={tailwind.style('rounded-[26px] overflow-hidden')}
       animationConfigs={animationConfigs}
       enablePanDownToClose
+      enableDynamicSizing={false}
       snapPoints={actionSnapPoints}
       onDismiss={handleOnDismiss}>
       {currentActionState === 'Assign' ? <UpdateAssignee /> : null}

--- a/src/screens/chat-screen/conversation-actions/ConversationActions.tsx
+++ b/src/screens/chat-screen/conversation-actions/ConversationActions.tsx
@@ -164,7 +164,8 @@ export const ConversationActions = () => {
         style={tailwind.style('rounded-[26px] overflow-hidden')}
         animationConfigs={animationConfigs}
         enablePanDownToClose
-        snapPoints={['50%']}>
+        enableDynamicSizing={false}
+        snapPoints={[400]}>
         <UpdateParticipant activeConversationParticipants={conversationParticipants} />
       </BottomSheetModal>
     </Animated.View>

--- a/src/screens/chat-screen/conversation-actions/components/UpdateParticipant.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/UpdateParticipant.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { ActivityIndicator, Pressable } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
@@ -9,7 +9,6 @@ import { Agent } from '@/types';
 import { Avatar, Icon, SearchBar } from '@/components-next';
 import { TickIcon } from '@/svg-icons';
 
-import { assignableAgentActions } from '@/store/assignable-agent/assignableAgentActions';
 import { useAppDispatch, useAppSelector } from '@/hooks';
 import { selectAssignableParticipantsByInboxId } from '@/store/assignable-agent/assignableAgentSelectors';
 import { selectSelectedConversation } from '@/store/conversation/conversationSelectedSlice';
@@ -97,7 +96,7 @@ const ParticipantStack = ({
 
   return (
     <BottomSheetScrollView showsVerticalScrollIndicator={false} style={tailwind.style('my-1 pl-3')}>
-      {isFetching ? (
+      {isFetching && allAgents.length === 0 ? (
         <ActivityIndicator />
       ) : (
         updatedAgents.map((value, index) => {
@@ -123,15 +122,12 @@ type UpdateParticipantProps = {
 
 export const UpdateParticipant = (props: UpdateParticipantProps) => {
   const { activeConversationParticipants } = props;
-  const dispatch = useAppDispatch();
   const { updateParticipantSheetRef } = useRefsContext();
   const [searchTerm, setSearchTerm] = useState('');
 
   const selectedConversation = useAppSelector(selectSelectedConversation);
 
   const inboxId = selectedConversation?.inboxId;
-
-  const inboxIds = inboxId ? [inboxId] : [];
 
   const selectAgents = useAppSelector(selectAssignableParticipantsByInboxId);
   const allAgents = inboxId ? selectAgents(inboxId, searchTerm) : [];
@@ -142,11 +138,6 @@ export const UpdateParticipant = (props: UpdateParticipantProps) => {
   const handleBlur = () => {
     updateParticipantSheetRef.current?.dismiss({ overshootClamping: true });
   };
-
-  useEffect(() => {
-    dispatch(assignableAgentActions.fetchAgents({ inboxIds }));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const handleChangeText = (text: string) => {
     setSearchTerm(text);

--- a/src/screens/conversations/components/conversation-actions/UpdateAssignee.tsx
+++ b/src/screens/conversations/components/conversation-actions/UpdateAssignee.tsx
@@ -84,6 +84,10 @@ export const UpdateAssignee = () => {
 
   const isFetching = useAppSelector(isAssignableAgentFetching);
 
+  const hasAgentRecords = useAppSelector(state =>
+    inboxIds.some(id => (state.assignableAgents.records[id]?.length ?? 0) > 0),
+  );
+
   const handleFocus = () => {
     actionsModalSheetRef.current?.expand();
   };
@@ -136,7 +140,7 @@ export const UpdateAssignee = () => {
       <BottomSheetScrollView
         showsVerticalScrollIndicator={false}
         style={tailwind.style('my-1 pl-3')}>
-        {isFetching ? (
+        {isFetching && !hasAgentRecords ? (
           <ActivityIndicator />
         ) : (
           <>


### PR DESCRIPTION
## Description 

- Replace ['50%'] snapPoints with fixed [400] and disable enableDynamicSizing on the participants/assign/team sheets so they open at a stable height instead of measuring small via BottomSheetScrollView and growing on scroll. 
- Suppress the loading spinner flash in UpdateAssignee and UpdateParticipant when assignable agents are already cached, by guarding the ActivityIndicator on actual record presence rather than the global isLoading flag. 
- Drop the redundant fetchAgents useEffect in UpdateParticipant since ChatScreen already prefetches assignable agents on mount. 

Fixes [Bug in the popovers](https://linear.app/chatwoot/issue/CW-6863/bug-in-the-popovers)

| Before | After |
| :---: | :---: |
| <video src="https://github.com/user-attachments/assets/3837ba18-3d29-41f0-ad65-22fe1dda522d" width="300" controls></video> | <video src="https://github.com/user-attachments/assets/90669bf3-81a3-4831-8b74-53af1376c66a" width="300" controls></video> |

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
