### PR TITLE
fix(i18n): Translate hardcoded strings + re-memoize on locale change

### DIFF
--- a/src/components-next/sheet-components/AvailabilityStatusList.tsx
+++ b/src/components-next/sheet-components/AvailabilityStatusList.tsx
@@ -7,6 +7,7 @@ import { tailwind } from '@/theme';
 import { AvailabilityStatus, AvailabilityStatusListItemType } from '@/types';
 import { useHaptic } from '@/utils';
 import { Icon } from '@/components-next/common/icon';
+import i18n from '@/i18n';
 
 type StatusCellProps = {
   item: AvailabilityStatusListItemType;
@@ -42,9 +43,9 @@ const StatusCell = ({
           )}>
           <Text
             style={tailwind.style(
-              'text-base capitalize text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
+              'text-base text-gray-950 font-inter-420-20 leading-[21px] tracking-[0.16px]',
             )}>
-            {item.status}
+            {i18n.t(item.titleKey)}
           </Text>
           {isSelected && <Icon icon={<TickIcon />} size={20} />}
         </Animated.View>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -20,9 +20,21 @@ export const userStatusList = [
 ];
 
 export const AVAILABILITY_STATUS_LIST = [
-  { statusColor: 'bg-green-800', status: 'online' },
-  { statusColor: 'bg-yellow-800', status: 'busy' },
-  { statusColor: 'bg-gray-800', status: 'offline' },
+  {
+    statusColor: 'bg-green-800',
+    status: 'online',
+    titleKey: 'SETTINGS.AVAILABILITY_STATUS.ONLINE',
+  },
+  {
+    statusColor: 'bg-yellow-800',
+    status: 'busy',
+    titleKey: 'SETTINGS.AVAILABILITY_STATUS.BUSY',
+  },
+  {
+    statusColor: 'bg-gray-800',
+    status: 'offline',
+    titleKey: 'SETTINGS.AVAILABILITY_STATUS.OFFLINE',
+  },
 ];
 
 export const AUDIO_FORMATS = {
@@ -34,58 +46,6 @@ export const AUDIO_FORMATS = {
 };
 
 export const MAXIMUM_FILE_UPLOAD_SIZE = 20;
-
-export const CONVERSATION_STATUSES = [
-  {
-    key: 'open',
-    name: 'Open',
-  },
-  {
-    key: 'resolved',
-    name: 'Resolved',
-  },
-  {
-    key: 'pending',
-    name: 'Pending',
-  },
-  {
-    key: 'snoozed',
-    name: 'Snoozed',
-  },
-  {
-    key: 'all',
-    name: 'All',
-  },
-];
-export const SORT_TYPES = [
-  {
-    key: 'latest',
-    name: 'Latest',
-  },
-  {
-    key: 'sort_on_created_at',
-    name: 'Created At',
-  },
-  {
-    key: 'sort_on_priority',
-    name: 'Priority',
-  },
-];
-
-export const ASSIGNEE_TYPES = [
-  {
-    key: 'mine',
-    name: 'Mine',
-  },
-  {
-    key: 'unassigned',
-    name: 'Unassigned',
-  },
-  {
-    key: 'all',
-    name: 'All',
-  },
-];
 
 export const CONVERSATION_STATUS = {
   OPEN: 'open',

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -4,7 +4,8 @@
     "ERROR": "Error",
     "ERROR_TITLE": "Unexpected error occurred",
     "REPORT_MESSAGE": "We have reported this to our team ! Please close the app and start again!",
-    "CLOSE": "Close"
+    "CLOSE": "Close",
+    "BACK": "Back"
   },
   "FOOTER": {
     "HOME": "Home",
@@ -174,6 +175,11 @@
     "SNOOZE_UNTIL_TOMORROW": "Until tomorrow",
     "SNOOZE_UNTIL_NEXT_WEEK": "Until next week",
     "SNOOZE": "Snooze conversation",
+    "REPLYING_TO": "Replying to %{name}",
+    "LOCATION_SEE_ON_MAP": "See on map",
+    "IS_TYPING": "%{name} is typing",
+    "ARE_TYPING_PAIR": "%{first} and %{second} are typing",
+    "OTHERS_ARE_TYPING": "%{name} and %{count} others are typing",
     "CHANGE_PRIORITY": "Change priority",
     "MESSAGES": "Messages",
     "UNDEFINED_VARIABLES_TITLE": "Undefined variables",
@@ -254,6 +260,16 @@
       "EXPAND": "Expand email"
     },
     "ACTIONS": {
+      "MENU_TITLE": "Conversation Actions",
+      "SHARE_CONVERSATION": "Share conversation",
+      "SELECT_ACTION": "Select action",
+      "NONE": "None",
+      "STATUS": {
+        "OPEN": "Open",
+        "PENDING": "Pending",
+        "SNOOZE": "Snooze",
+        "RESOLVE": "Resolve"
+      },
       "ASSIGNEE": {
         "EMPTY": "Unassigned",
         "ASSIGN": "Assign",
@@ -302,7 +318,12 @@
     "LOGOUT": "Logout",
     "SUBMIT": "Submit",
     "SET_LANGUAGE": "Set Language",
-    "DEBUG_ACTIONS": "Debug Actions"
+    "DEBUG_ACTIONS": "Debug Actions",
+    "AVAILABILITY_STATUS": {
+      "ONLINE": "Online",
+      "BUSY": "Busy",
+      "OFFLINE": "Offline"
+    }
   },
   "NOTIFICATION": {
     "HEADER_TITLE": "Notifications",
@@ -372,7 +393,10 @@
   },
   "CONTACT_DETAILS": {
     "TITLE": "Contact Details",
+    "LOCATION": "Location",
+    "PHONE": "Phone",
     "EMAIL": "Email",
+    "COMPANY": "Company",
     "PHONE_NUMBER": "Phone Number",
     "CALL": "Call",
     "CONTACT_ATTRIBUTES": "Contact Attributes",
@@ -380,6 +404,7 @@
   },
   "CONVERSATION_PARTICIPANTS": {
     "TITLE": "Participants",
+    "PARTICIPANT_COUNT_TEXT": "%{count} participants",
     "TOTAL_PARTICIPANTS_TEXT": "%{count} people are participating.",
     "TOTAL_PARTICIPANT_TEXT": "%{count} person is participating.",
     "NO_PARTICIPANTS_TEXT": "No one is participating!.",

--- a/src/i18n/pt_BR.json
+++ b/src/i18n/pt_BR.json
@@ -4,7 +4,8 @@
     "ERROR": "Erro",
     "ERROR_TITLE": "Ocorreu um erro inesperado",
     "REPORT_MESSAGE": "Já relatamos isso para nossa equipe! Por favor, feche o aplicativo e comece novamente!",
-    "CLOSE": "Fechar"
+    "CLOSE": "Fechar",
+    "BACK": "Voltar"
   },
   "FOOTER": {
     "HOME": "Principal",
@@ -152,6 +153,11 @@
     "SNOOZE_UNTIL_TOMORROW": "Até amanhã",
     "SNOOZE_UNTIL_NEXT_WEEK": "Até a próxima semana",
     "SNOOZE": "Adiar conversa",
+    "REPLYING_TO": "Respondendo a %{name}",
+    "LOCATION_SEE_ON_MAP": "Ver no mapa",
+    "IS_TYPING": "%{name} está digitando",
+    "ARE_TYPING_PAIR": "%{first} e %{second} estão digitando",
+    "OTHERS_ARE_TYPING": "%{name} e mais %{count} estão digitando",
     "CHANGE_PRIORITY": "Alterar prioridade",
     "MESSAGES": "Mensagens",
     "UNDEFINED_VARIABLES_TITLE": "Variáveis não definidas",
@@ -227,6 +233,16 @@
       "EXPAND": "Expandir e-mail"
     },
     "ACTIONS": {
+      "MENU_TITLE": "Ações da conversa",
+      "SHARE_CONVERSATION": "Compartilhar conversa",
+      "SELECT_ACTION": "Selecionar ação",
+      "NONE": "Nenhum",
+      "STATUS": {
+        "OPEN": "Abrir",
+        "PENDING": "Pendente",
+        "SNOOZE": "Adiar",
+        "RESOLVE": "Resolver"
+      },
       "ASSIGNEE": {
         "EMPTY": "Não atribuídas",
         "ASSIGN": "Atribuir",
@@ -274,7 +290,12 @@
     "LOGOUT": "Sair",
     "SUBMIT": "Enviar",
     "SET_LANGUAGE": "Configurar Idioma",
-    "DEBUG_ACTIONS": "Ações de Depuração"
+    "DEBUG_ACTIONS": "Ações de Depuração",
+    "AVAILABILITY_STATUS": {
+      "ONLINE": "Online",
+      "BUSY": "Ocupado",
+      "OFFLINE": "Offline"
+    }
   },
   "NOTIFICATION": {
     "HEADER_TITLE": "Notificações",
@@ -344,7 +365,10 @@
   },
   "CONTACT_DETAILS": {
     "TITLE": "Detalhes do contato",
+    "LOCATION": "Localização",
+    "PHONE": "Telefone",
     "EMAIL": "e-mail",
+    "COMPANY": "Empresa",
     "PHONE_NUMBER": "Número de Telefone",
     "CALL": "Chamada",
     "CONTACT_ATTRIBUTES": "Atributos do contato",
@@ -352,6 +376,7 @@
   },
   "CONVERSATION_PARTICIPANTS": {
     "TITLE": "Participantes",
+    "PARTICIPANT_COUNT_TEXT": "%{count} participantes",
     "TOTAL_PARTICIPANTS_TEXT": "%{count} pessoas estão participando.",
     "TOTAL_PARTICIPANT_TEXT": "%{count} pessoa está participando.",
     "NO_PARTICIPANTS_TEXT": "Ninguém está participando!",

--- a/src/navigation/stack/AuthStack.tsx
+++ b/src/navigation/stack/AuthStack.tsx
@@ -5,6 +5,7 @@ import ConfigInstallationURL from '@/screens/auth/ConfigURLScreen';
 import Login from '@/screens/auth/LoginScreen';
 import ForgotPassword from '@/screens/auth/ForgotPassword';
 import MFAScreen from '@/screens/auth/MFAScreen';
+import i18n from '@/i18n';
 
 export type AuthStackParamList = {
   Login: undefined;
@@ -28,7 +29,7 @@ export const AuthStack = () => {
       <Stack.Screen
         options={{
           headerShown: true,
-          headerBackTitle: 'Back',
+          headerBackTitle: i18n.t('COMMON.BACK'),
           headerBackVisible: true,
           headerShadowVisible: false,
           title: '',
@@ -39,7 +40,7 @@ export const AuthStack = () => {
       <Stack.Screen
         options={{
           headerShown: true,
-          headerBackTitle: 'Back',
+          headerBackTitle: i18n.t('COMMON.BACK'),
           headerBackVisible: true,
           headerShadowVisible: false,
           title: '',
@@ -50,7 +51,7 @@ export const AuthStack = () => {
       <Stack.Screen
         options={{
           headerShown: true,
-          headerBackTitle: 'Back',
+          headerBackTitle: i18n.t('COMMON.BACK'),
           headerBackVisible: true,
           headerShadowVisible: false,
           title: '',

--- a/src/screens/chat-screen/components/chat-header/ChatHeaderContainer.tsx
+++ b/src/screens/chat-screen/components/chat-header/ChatHeaderContainer.tsx
@@ -16,6 +16,7 @@ import { evaluateSLAStatus } from '@chatwoot/utils';
 import { resetSentMessage } from '@/store/conversation/sendMessageSlice';
 import { selectAllDashboardApps } from '@/store/dashboard-app/dashboardAppSlice';
 import { selectUser } from '@/store/auth/authSelectors';
+import { selectLocale } from '@/store/settings/settingsSelectors';
 
 type ChatScreenHeaderProps = {
   name: string;
@@ -32,6 +33,7 @@ export const ChatHeaderContainer = (props: ChatScreenHeaderProps) => {
   const conversation = useAppSelector(state => selectConversationById(state, conversationId));
   const currentUser = useAppSelector(selectUser);
   const dashboardApps = useAppSelector(selectAllDashboardApps);
+  const locale = useAppSelector(selectLocale);
 
   const appliedSla = conversation?.appliedSla;
 
@@ -142,14 +144,15 @@ export const ChatHeaderContainer = (props: ChatScreenHeaderProps) => {
     return [
       pagerViewIndex === 0
         ? {
-            title: 'Conversation Actions',
+            title: i18n.t('CONVERSATION.ACTIONS.MENU_TITLE'),
             onSelect: handleNavigation,
           }
         : undefined,
       ...dashboardRoutes,
     ].filter((item): item is DashboardList => item !== undefined);
+    // `locale` is included so the i18n.t() title above re-evaluates on locale switch.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pagerViewIndex]);
+  }, [pagerViewIndex, locale]);
 
   const sLAStatusText = () => {
     const upperCaseType = slaStatus?.type?.toUpperCase(); // FRT, NRT, or RT

--- a/src/screens/chat-screen/components/chat-header/DropdownMenu.tsx
+++ b/src/screens/chat-screen/components/chat-header/DropdownMenu.tsx
@@ -11,6 +11,7 @@ import * as DropdownMenu from 'zeego/dropdown-menu';
 
 import { BottomSheetHeader, BottomSheetWrapper } from '@/components-next';
 import { tailwind } from '@/theme';
+import i18n from '@/i18n';
 
 export type DashboardList = {
   title: string;
@@ -125,7 +126,7 @@ export const ChatDropdownMenu = (props: PropsWithChildren<ChatDropdownMenuProps>
           enablePanDownToClose
           snapPoints={[dropdownMenuList.length * 44 + 4 + 37]}>
           <BottomSheetWrapper>
-            <BottomSheetHeader headerText="Select action" />
+            <BottomSheetHeader headerText={i18n.t('CONVERSATION.ACTIONS.SELECT_ACTION')} />
             <Animated.View style={tailwind.style('py-1 pl-3')}>
               {dropdownMenuList?.map((option, index) => {
                 const handleOnOptionSelect = () => {

--- a/src/screens/chat-screen/components/message-components/LocationBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/LocationBubble.tsx
@@ -8,6 +8,7 @@ import { Icon } from '@/components-next/common';
 import { MESSAGE_VARIANTS } from '@/constants';
 import { MapIcon } from '@/svg-icons';
 import { openURL } from '@/utils/urlUtils';
+import i18n from '@/i18n';
 
 type LocationBubbleProps = {
   latitude: number | 0;
@@ -32,7 +33,7 @@ export const LocationBubble: React.FC<LocationBubbleProps> = props => {
           variant === MESSAGE_VARIANTS.USER ? 'text-white' : '',
           variant === MESSAGE_VARIANTS.AGENT ? 'text-gray-950' : '',
         )}>
-        See on map
+        {i18n.t('CONVERSATION.LOCATION_SEE_ON_MAP')}
       </Text>
     </Animated.View>
   );

--- a/src/screens/chat-screen/components/message-components/LocationCell.tsx
+++ b/src/screens/chat-screen/components/message-components/LocationCell.tsx
@@ -11,6 +11,7 @@ import { MESSAGE_STATUS, MESSAGE_TYPES, TEXT_MAX_WIDTH } from '@/constants';
 import { DeliveryStatus } from './DeliveryStatus';
 import { MapIcon } from '@/svg-icons';
 import { openURL } from '@/utils/urlUtils';
+import i18n from '@/i18n';
 
 type LocationCellProps = {
   shouldRenderAvatar: boolean;
@@ -95,7 +96,7 @@ export const LocationCell: React.FC<LocationCellProps> = props => {
                   isIncoming ? 'text-white' : '',
                   isOutgoing ? 'text-gray-950' : '',
                 )}>
-                See on map
+                {i18n.t('CONVERSATION.LOCATION_SEE_ON_MAP')}
               </Text>
             </Animated.View>
 

--- a/src/screens/chat-screen/components/message-components/ReplyMessageBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/ReplyMessageBubble.tsx
@@ -10,6 +10,7 @@ import { isMarkdown } from '@/utils';
 import { Icon } from '@/components-next';
 import { MarkdownBubble } from './MarkdownBubble';
 import { MESSAGE_VARIANTS, TEXT_MAX_WIDTH } from '@/constants';
+import i18n from '@/i18n';
 
 type ReplyMessageBubbleProps = {
   replyMessage: Message;
@@ -70,7 +71,7 @@ export const ReplyMessageBubble = (props: ReplyMessageBubbleProps) => {
             style={tailwind.style(
               'text-cxs font-inter-420-20 leading-[14.95px] tracking-[0.32px] text-blackA-A11',
             )}>
-            Replying to {replyMessageItem?.sender?.name}
+            {i18n.t('CONVERSATION.REPLYING_TO', { name: replyMessageItem?.sender?.name ?? '' })}
           </Animated.Text>
           {hasAttachments ? (
             <Animated.View style={tailwind.style('py-[3px] flex flex-row items-center')}>

--- a/src/screens/chat-screen/components/message-components/ReplyMessageCell.tsx
+++ b/src/screens/chat-screen/components/message-components/ReplyMessageCell.tsx
@@ -10,6 +10,7 @@ import { isMarkdown } from '@/utils';
 import { Icon } from '@/components-next';
 import { MarkdownDisplay } from './MarkdownDisplay';
 import { TEXT_MAX_WIDTH } from '@/constants';
+import i18n from '@/i18n';
 
 type ReplyMessageCellProps = {
   replyMessage: Message;
@@ -70,7 +71,7 @@ export const ReplyMessageCell = (props: ReplyMessageCellProps) => {
             style={tailwind.style(
               'text-cxs font-inter-420-20 leading-[14.95px] tracking-[0.32px] text-blackA-A11',
             )}>
-            Replying to {replyMessageItem?.sender?.name}
+            {i18n.t('CONVERSATION.REPLYING_TO', { name: replyMessageItem?.sender?.name ?? '' })}
           </Animated.Text>
           {hasAttachments ? (
             <Animated.View style={tailwind.style('py-[3px] flex flex-row items-center')}>

--- a/src/screens/chat-screen/components/reply-box/QuoteReply.tsx
+++ b/src/screens/chat-screen/components/reply-box/QuoteReply.tsx
@@ -16,6 +16,7 @@ import { selectQuoteMessage, setQuoteMessage } from '@/store/conversation/sendMe
 
 import { VideoPlayer } from '../message-components';
 import { Message } from '@/types';
+import i18n from '@/i18n';
 
 const AudioIcon = () => {
   return (
@@ -132,7 +133,7 @@ export const QuoteReply = () => {
             style={tailwind.style(
               'text-cxs tracking-[0.32px] leading-[15px] font-inter-420-20 text-blackA-A11',
             )}>
-            Replying to {quoteMessage?.sender?.name}
+            {i18n.t('CONVERSATION.REPLYING_TO', { name: quoteMessage?.sender?.name ?? '' })}
           </Animated.Text>
         </Animated.View>
         <Animated.View style={tailwind.style('pt-0.5')}>
@@ -159,8 +160,7 @@ export const QuoteReply = () => {
               </Text>
             )
           ) : (
-            <Text
-              style={tailwind.style('text-md font-inter-normal-20 tracking-[0.32px]')}>
+            <Text style={tailwind.style('text-md font-inter-normal-20 tracking-[0.32px]')}>
               {quoteMessage?.attachments?.[0]?.fileType}
             </Text>
           )}

--- a/src/screens/chat-screen/components/reply-box/ReplyBoxContainer.tsx
+++ b/src/screens/chat-screen/components/reply-box/ReplyBoxContainer.tsx
@@ -54,6 +54,7 @@ import { SendMessagePayload } from '@/store/conversation/conversationTypes';
 import { TypingIndicator } from './TypingIndicator';
 import { getTypingUsersText } from '@/utils';
 import { selectTypingUsersByConversationId } from '@/store/conversation/conversationTypingSlice';
+import { selectLocale } from '@/store/settings/settingsSelectors';
 import { Agent, CannedResponse, Conversation } from '@/types';
 import AnalyticsHelper from '@/utils/analyticsUtils';
 import { showToast } from '@/utils/toastUtils';
@@ -161,7 +162,16 @@ const BottomSheetContent = () => {
   const [copilotFollowUpText, setCopilotFollowUpText] = useState('');
 
   const typingUsers = useAppSelector(selectTypingUsersByConversationId(conversationId));
-  const typingText = useMemo(() => getTypingUsersText({ users: typingUsers }), [typingUsers]);
+  // `locale` is an extra dependency for the typingText memo: getTypingUsersText
+  // reads i18n.locale via i18n.t, so the memoized string would stay in the
+  // previous language until `typingUsers` changes. ESLint can't infer that
+  // side effect, hence the disable.
+  const locale = useAppSelector(selectLocale);
+  const typingText = useMemo(
+    () => getTypingUsersText({ users: typingUsers }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [typingUsers, locale],
+  );
 
   const attachmentsLength = useMemo(() => attachedFiles.length, [attachedFiles.length]);
 

--- a/src/screens/chat-screen/conversation-actions/ConversationActions.tsx
+++ b/src/screens/chat-screen/conversation-actions/ConversationActions.tsx
@@ -15,7 +15,6 @@ import {
 } from './components';
 import { TAB_BAR_HEIGHT } from '@/constants';
 import { tailwind } from '@/theme';
-import i18n from '@/i18n';
 import { ConversationStatus } from '@/types';
 import { useChatWindowContext } from '@/context';
 import { useAppDispatch, useAppSelector } from '@/hooks';

--- a/src/screens/chat-screen/conversation-actions/ConversationActions.tsx
+++ b/src/screens/chat-screen/conversation-actions/ConversationActions.tsx
@@ -5,6 +5,7 @@ import Animated from 'react-native-reanimated';
 import { BottomSheetModal, useBottomSheetSpringConfigs } from '@gorhom/bottom-sheet';
 
 import { BottomSheetBackdrop, Button } from '@/components-next';
+import i18n from '@/i18n';
 import {
   ConversationBasicActions,
   ConversationLabelActions,
@@ -153,7 +154,11 @@ export const ConversationActions = () => {
           {conversation && <ConversationMetaInformation conversation={conversation} />}
         </Animated.View>
         <Animated.View style={tailwind.style('px-4 pt-10')}>
-          <Button variant="secondary" handlePress={onShareConversation} text="Share conversation" />
+          <Button
+            variant="secondary"
+            handlePress={onShareConversation}
+            text={i18n.t('CONVERSATION.ACTIONS.SHARE_CONVERSATION')}
+          />
         </Animated.View>
       </ScrollView>
       <BottomSheetModal

--- a/src/screens/chat-screen/conversation-actions/components/AddParticipantList.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/AddParticipantList.tsx
@@ -52,7 +52,7 @@ const ParticipantOverflowCell = ({ count }: { count: number }) => {
             style={tailwind.style(
               'text-base font-inter-420-20 leading-[22px] tracking-[0.16px] text-gray-950',
             )}>
-            {count} participants
+            {i18n.t('CONVERSATION_PARTICIPANTS.PARTICIPANT_COUNT_TEXT', { count })}
           </Animated.Text>
         </Animated.View>
       </Animated.View>

--- a/src/screens/chat-screen/conversation-actions/components/ConversationBasicActions.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/ConversationBasicActions.tsx
@@ -12,17 +12,16 @@ import { OpenIcon, ResolvedFilledIcon, PendingFilledIcon, SnoozedFilledIcon } fr
 import { tailwind } from '@/theme';
 import { useHaptic, useScaleAnimation } from '@/utils';
 import { ConversationStatus } from '@/types';
+import i18n from '@/i18n';
 
 import { ConversationActionType } from '../ConversationActions';
-
-type ConversationStateType = 'open' | 'pending' | 'snooze' | 'resolve';
 
 type ConversationActionOptionsType = {
   backgroundActionColor: string;
   backgroundActionPressedColor: string;
   borderActionColor: string;
   actionIcon: React.JSX.Element;
-  actionText: ConversationStateType;
+  titleKey: string;
   actionStatus: ConversationStatus | 'open';
 };
 
@@ -35,7 +34,7 @@ const conversationActionOptions: ConversationActionOptionsType[] = [
     backgroundActionPressedColor: 'bg-gray-200',
     borderActionColor: 'bg-gray-700',
     actionIcon: <OpenIcon stroke={tailwind.color('text-gray-700') as string} />,
-    actionText: 'open',
+    titleKey: 'CONVERSATION.ACTIONS.STATUS.OPEN',
     actionStatus: 'open',
   },
   {
@@ -43,7 +42,7 @@ const conversationActionOptions: ConversationActionOptionsType[] = [
     backgroundActionPressedColor: 'bg-amber-200',
     borderActionColor: 'bg-amber-700',
     actionIcon: <PendingFilledIcon />,
-    actionText: 'pending',
+    titleKey: 'CONVERSATION.ACTIONS.STATUS.PENDING',
     actionStatus: 'pending',
   },
   {
@@ -51,7 +50,7 @@ const conversationActionOptions: ConversationActionOptionsType[] = [
     backgroundActionPressedColor: 'bg-indigo-200',
     borderActionColor: 'bg-indigo-700',
     actionIcon: <SnoozedFilledIcon />,
-    actionText: 'snooze',
+    titleKey: 'CONVERSATION.ACTIONS.STATUS.SNOOZE',
     actionStatus: 'snoozed',
   },
   {
@@ -59,7 +58,7 @@ const conversationActionOptions: ConversationActionOptionsType[] = [
     backgroundActionPressedColor: 'bg-green-200',
     borderActionColor: 'bg-green-700',
     actionIcon: <ResolvedFilledIcon />,
-    actionText: 'resolve',
+    titleKey: 'CONVERSATION.ACTIONS.STATUS.RESOLVE',
     actionStatus: 'resolved',
   },
 ];
@@ -91,13 +90,7 @@ const ConversationActionOption = (props: ConversationActionOptionProps) => {
     } else {
       actionActive.value = withSpring(0);
     }
-  }, [
-    actionActive,
-    conversationAction.actionStatus,
-    conversationAction.actionText,
-    status,
-    isMuted,
-  ]);
+  }, [actionActive, conversationAction.actionStatus, conversationAction.titleKey, status, isMuted]);
 
   const actionBorderColor = tailwind.color(conversationAction.borderActionColor) as string;
 
@@ -134,9 +127,9 @@ const ConversationActionOption = (props: ConversationActionOptionProps) => {
         <Icon icon={conversationAction.actionIcon} size={32} />
         <Animated.Text
           style={tailwind.style(
-            'text-md font-inter-normal-20 leading-[17px] tracking-[0.32px] text-center pt-5 capitalize text-gray-950 ',
+            'text-md font-inter-normal-20 leading-[17px] tracking-[0.32px] text-center pt-5 text-gray-950 ',
           )}>
-          {conversationAction.actionText}
+          {i18n.t(conversationAction.titleKey)}
         </Animated.Text>
       </Pressable>
     </Animated.View>

--- a/src/screens/contact-details/ContactDetailsScreen.tsx
+++ b/src/screens/contact-details/ContactDetailsScreen.tsx
@@ -191,32 +191,31 @@ const ContactDetailsScreen = (props: ContactDetailsScreenProps) => {
       type: 'link',
     }));
 
-  const fullLocation =
-    location || [city, country].filter(Boolean).join(', ') || null;
+  const fullLocation = location || [city, country].filter(Boolean).join(', ') || null;
 
   const userDetails: GenericListType[] = [
     {
       icon: <LocationIcon />,
       subtitle: fullLocation || i18n.t('CONTACT_DETAILS.VALUE_UNAVAILABLE'),
-      title: 'Location',
+      title: i18n.t('CONTACT_DETAILS.LOCATION'),
       subtitleType: 'dark',
     },
     {
       icon: <CallIcon />,
       subtitle: phoneNumber || i18n.t('CONTACT_DETAILS.VALUE_UNAVAILABLE'),
-      title: 'Phone',
+      title: i18n.t('CONTACT_DETAILS.PHONE'),
       subtitleType: 'dark',
     },
     {
       icon: <EmailIcon />,
       subtitle: email || i18n.t('CONTACT_DETAILS.VALUE_UNAVAILABLE'),
-      title: 'Email',
+      title: i18n.t('CONTACT_DETAILS.EMAIL'),
       subtitleType: 'dark',
     },
     {
       icon: <CompanyIcon />,
       subtitle: companyName || i18n.t('CONTACT_DETAILS.VALUE_UNAVAILABLE'),
-      title: 'Company',
+      title: i18n.t('CONTACT_DETAILS.COMPANY'),
       subtitleType: 'dark',
     },
   ];

--- a/src/screens/conversations/components/conversation-item/ConversationItemContainer.tsx
+++ b/src/screens/conversations/components/conversation-item/ConversationItemContainer.tsx
@@ -19,6 +19,7 @@ import { selectContactById } from '@/store/contact/contactSelectors';
 import { selectTypingUsersByConversationId } from '@/store/conversation/conversationTypingSlice';
 import { conversationActions } from '@/store/conversation/conversationActions';
 import { selectAllLabels } from '@/store/label/labelSelectors';
+import { selectLocale } from '@/store/settings/settingsSelectors';
 
 import { isContactTyping, getLastMessage, getTypingUsersText } from '@/utils';
 import { Icon, Swipeable } from '@/components-next/common';
@@ -96,11 +97,20 @@ export const ConversationItemContainer = memo((props: ConversationItemContainerP
   const typingUsers = useAppSelector(selectTypingUsersByConversationId(id));
   const selected = useAppSelector(selectSelected);
   const currentState = useAppSelector(selectCurrentState);
+  // `locale` is an extra dependency for the typingText memo below: the
+  // function reads `i18n.locale` via i18n.t, so the memoized value would
+  // otherwise stay in the previous language until `typingUsers` changes.
+  // ESLint can't infer that side effect, hence the disable.
+  const locale = useAppSelector(selectLocale);
 
   const { availabilityStatus, name: contactName, thumbnail: contactThumbnail } = contact || {};
   const isSelected = useMemo(() => id in selected, [selected, id]);
   const isTyping = useMemo(() => isContactTyping(typingUsers, contactId), [typingUsers, contactId]);
-  const typingText = useMemo(() => getTypingUsersText({ users: typingUsers }), [typingUsers]);
+  const typingText = useMemo(
+    () => getTypingUsersText({ users: typingUsers }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [typingUsers, locale],
+  );
 
   const lastMessage = getLastMessage(conversationItem);
 

--- a/src/screens/conversations/components/conversation-item/ConversationItemContainer.tsx
+++ b/src/screens/conversations/components/conversation-item/ConversationItemContainer.tsx
@@ -161,7 +161,7 @@ export const ConversationItemContainer = memo((props: ConversationItemContainerP
     },
     additionalAttributes,
     allLabels,
-    typingText: typingText as string | undefined,
+    typingText,
   };
 
   return (

--- a/src/store/assignable-agent/assignableAgentSelectors.ts
+++ b/src/store/assignable-agent/assignableAgentSelectors.ts
@@ -1,6 +1,8 @@
 import type { RootState } from '@/store';
 
 import { createSelector } from '@reduxjs/toolkit';
+import i18n from '@/i18n';
+import { selectLocale } from '@/store/settings/settingsSelectors';
 
 export const selectAssignableAgentsState = (state: RootState) => state.assignableAgents;
 
@@ -17,16 +19,19 @@ export const selectAssignableAgents = createSelector(
 export const selectAssignableAgentsByInboxId = createSelector(
   [
     selectAssignableAgents,
+    // Forces re-memoization when the user switches locale so the synthetic
+    // "None" entry below is re-evaluated with the current i18n.t value.
+    selectLocale,
     (_state: RootState, inboxIds: number | number[]) =>
       Array.isArray(inboxIds) ? inboxIds : [inboxIds],
     (_state: RootState, _inboxIds: number | number[], searchTerm: string) => searchTerm,
   ],
-  (state, inboxIds, searchTerm) => {
+  (state, _locale, inboxIds, searchTerm) => {
     const agents = inboxIds.flatMap(id => state[id] || []);
     const agentsList = [
       {
         confirmed: true,
-        name: 'None',
+        name: i18n.t('CONVERSATION.ACTIONS.NONE'),
         id: 0,
         role: 'agent',
         accountId: 0,

--- a/src/store/assignable-agent/specs/assignableAgentSelectors.spec.ts
+++ b/src/store/assignable-agent/specs/assignableAgentSelectors.spec.ts
@@ -1,8 +1,15 @@
+import i18n from '@/i18n';
 import { selectAssignableAgentsByInboxId } from '../assignableAgentSelectors';
 import { RootState } from '@/store';
 import { agent } from './assignableAgentMockData';
 
 describe('inboxAgentSelectors', () => {
+  // Lock the locale so the literal `name: 'None'` assertions below are stable
+  // and act as a canary for the en.json key path.
+  beforeAll(() => {
+    i18n.locale = 'en';
+  });
+
   const state = {
     assignableAgents: {
       records: {
@@ -11,6 +18,7 @@ describe('inboxAgentSelectors', () => {
       },
       uiFlags: { isLoading: false },
     },
+    settings: { localeValue: 'en' },
   } as Partial<RootState> as RootState;
 
   it('selects all inbox agents for single inbox', () => {

--- a/src/store/team/teamSelectors.ts
+++ b/src/store/team/teamSelectors.ts
@@ -1,6 +1,8 @@
 import type { RootState } from '@/store';
 import { teamAdapter } from './teamSlice';
 import { createSelector } from '@reduxjs/toolkit';
+import i18n from '@/i18n';
+import { selectLocale } from '@/store/settings/settingsSelectors';
 
 export const selectTeamsState = (state: RootState) => state.teams;
 
@@ -9,12 +11,17 @@ export const selectLoading = createSelector([selectTeamsState], state => state.i
 export const { selectAll: selectAllTeams } = teamAdapter.getSelectors<RootState>(selectTeamsState);
 
 export const filterTeams = createSelector(
-  [selectAllTeams, (state: RootState, searchTerm: string) => searchTerm],
-  (teams, searchTerm) => {
+  [
+    selectAllTeams,
+    // Forces re-memoization on locale change — see selectAssignableAgentsByInboxId.
+    selectLocale,
+    (_state: RootState, searchTerm: string) => searchTerm,
+  ],
+  (teams, _locale, searchTerm) => {
     const teamsList = [
       {
         id: '0',
-        name: 'None',
+        name: i18n.t('CONVERSATION.ACTIONS.NONE'),
         description: null,
         allowAutoAssign: false,
         accountId: 0,

--- a/src/types/common/AvailabilityStatus.ts
+++ b/src/types/common/AvailabilityStatus.ts
@@ -3,6 +3,7 @@ export type AvailabilityStatus = 'online' | 'offline' | 'busy' | 'typing';
 export type AvailabilityStatusListItemType = {
   status: AvailabilityStatus;
   statusColor: string;
+  titleKey: string;
 };
 
 export type PresenceUpdateData = {

--- a/src/utils/typingUtils.ts
+++ b/src/utils/typingUtils.ts
@@ -1,33 +1,28 @@
 import { TypingUser } from '@/types';
+import i18n from '@/i18n';
 
 export const isContactTyping = (typingUsers: TypingUser[], userId: number) => {
   return typingUsers.some(user => user.id === userId && user.type === 'contact');
 };
 
-export const getTypingUsersText = ({ users }: { users: TypingUser[] }) => {
-  if (!users) {
-    return '';
-  }
-  const isAnyoneTyping = users.length !== 0;
-  if (isAnyoneTyping) {
-    const count = users.length;
-    if (count === 1) {
-      const [user] = users;
-      return `${user.name.toString().replace(/^./, str => str.toUpperCase())} is typing`;
-    }
+const capitalize = (name: string) => name.toString().replace(/^./, str => str.toUpperCase());
 
-    if (count === 2) {
-      const [first, second] = users;
-      return `${first.name.toString().replace(/^./, str => str.toUpperCase())} and ${second.name
-        .toString()
-        .replace(/^./, str => str.toUpperCase())} are typing`;
-    }
-
-    const [user] = users;
-    const rest = users.length - 1;
-    return `${user.name
-      .toString()
-      .replace(/^./, str => str.toUpperCase())} and ${rest} others are typing`;
+export const getTypingUsersText = ({ users }: { users: TypingUser[] }): string | undefined => {
+  const count = users?.length ?? 0;
+  if (count === 0) {
+    return undefined;
   }
-  return false;
+  if (count === 1) {
+    return i18n.t('CONVERSATION.IS_TYPING', { name: capitalize(users[0].name) });
+  }
+  if (count === 2) {
+    return i18n.t('CONVERSATION.ARE_TYPING_PAIR', {
+      first: capitalize(users[0].name),
+      second: capitalize(users[1].name),
+    });
+  }
+  return i18n.t('CONVERSATION.OTHERS_ARE_TYPING', {
+    name: capitalize(users[0].name),
+    count: count - 1,
+  });
 };


### PR DESCRIPTION
## Summary

- Routes ~25 hardcoded English strings through `i18n.t()` across chat header, contact details, conversation actions, reply box, status buttons, typing indicator, and auth navigation. Adds 21 new keys to `en.json` and `pt_BR.json`.
- Fixes a memoization bug: `i18n.t()` calls inside `createSelector` / `useMemo` cache strings at the locale of first compute, so labels stay in the previous language after a runtime locale switch until inputs change. Adds `selectLocale` as an input to two selectors (`assignableAgentSelectors`, `teamSelectors`) and adds `locale` to the deps on three `useMemo`s (`ConversationItemContainer`, `ReplyBoxContainer`, `ChatHeaderContainer`). The typing-indicator `useMemo` fix was flagged by Codex; the rest were caught in the same audit.
- `typingUtils.ts` rewritten to use `i18n.t` with `%{name}` / `%{first}` / `%{second}` / `%{count}` interpolation; return type tightened from `string | '' | false` to `string | undefined` (eliminates a stale cast at `ConversationItemContainer.tsx:164`).
- `ConversationBasicActions` and `AvailabilityStatusList` refactored to the `id + titleKey` pattern already used in `CommandOptionsMenu`. Drops the dead `ConversationStateType` literal and the now-redundant `capitalize` Tailwind class on the status buttons (translated values are already correctly cased).
- Dead-code removal: `CONVERSATION_STATUSES`, `SORT_TYPES`, `ASSIGNEE_TYPES` deleted from `constants/index.ts` — verified zero imports across `src/`. The filter UI uses `CONVERSATION.FILTERS.STATUS.OPTIONS.*` keys directly.

No existing translations modified. If `pt_BR.json` additions step on the Crowdin workflow, happy to drop that hunk.

## Test plan

- [ ] Switch app language at runtime → typing indicator updates immediately (was stale until typing events resumed)
- [ ] Open assignee / team picker → "None" row in the new locale (was stale)
- [ ] Open chat header dropdown → "Conversation Actions" item in the new locale (was stale)
- [ ] `Settings → Set availability` → Online / Busy / Offline in selected locale
- [ ] Chat with a quoted reply → "Replying to {name}" in selected locale
- [ ] Chat with a location message → "See on map" in selected locale
- [ ] `Contact details` → Location / Phone / Email / Company in selected locale
- [ ] Conversation actions sheet → status buttons (Open / Pending / Snooze / Resolve) + "Share conversation" in selected locale
- [ ] Auth flow back button → "Back" in selected locale
- [ ] `pnpm test` — `typingUtils.spec` (3/3) and `assignableAgentSelectors.spec` (2/2) pass

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactor (non-breaking change which improves code quality)