### PR TITLE
fix: Wire up zh_CN and zh_TW for maximum Chinese translation coverage

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -188,7 +188,8 @@ export const LANGUAGES = {
   tr: 'Turkish',
   uk: 'Ukrainian',
   vi: 'Vietnamese',
-  zh: 'Chinese',
+  zh_CN: 'Chinese (Simplified)',
+  zh_TW: 'Chinese (Traditional)',
 };
 
 export const URL_REGEX = {

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -32,7 +32,8 @@ import ta from './ta.json';
 import tr from './tr.json';
 import uk from './uk.json';
 import vi from './vi.json';
-import zh from './zh.json';
+import zh_CN from './zh_CN.json';
+import zh_TW from './zh_TW.json';
 
 i18n.locale = 'en';
 i18n.fallbacks = true;
@@ -69,7 +70,9 @@ i18n.translations = {
   tr,
   uk,
   vi,
-  zh,
+  zh_CN,
+  zh_TW,
+  zh: zh_CN,
 };
 
 export default i18n;

--- a/src/store/settings/settingsSelectors.ts
+++ b/src/store/settings/settingsSelectors.ts
@@ -8,7 +8,9 @@ export const selectInstallationUrl = createSelector(
   settings => settings.installationUrl,
 );
 
-export const selectLocale = createSelector(selectSettings, settings => settings.localeValue);
+export const selectLocale = createSelector(selectSettings, settings =>
+  settings.localeValue === 'zh' ? 'zh_CN' : settings.localeValue,
+);
 
 export const selectIsLocaleSet = createSelector(
   selectSettings,


### PR DESCRIPTION
## Description 
Chinese was listed in the language dropdown but most of the app remained in English after switching. 

### Root cause:
  `src/i18n/index.js` was importing `zh.json` which has only 140/359 keys (~38% coverage) . Anything added in recent years  fell back to English. The repo already had `zh_CN.json` and `zh_TW.json` with ~87% coverage but they were never wired up.

  This PR:
  - Replaces the `zh.json` import with `zh_CN.json` (Simplified) and `zh_TW.json` (Traditional).
  - Surfaces both as separate dropdown entries — `Chinese (Simplified)` and `Chinese (Traditional)` , mirroring the existing
  `pt` / `pt_BR` pattern.
  - Migrates legacy users with persisted `'zh'` locale to `'zh_CN'` via `selectLocale`, and keeps a `zh: zh_CN` alias in
  `i18n.translations` so they get a working translation even before the selector normalizes.

  Coverage jumps from ~38% → ~87% for Chinese users.

Fixes [chinese-translation-incomplete-in-mobile-app](https://linear.app/chatwoot/issue/CW-7182/chinese-translation-incomplete-in-mobile-app)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
