### PR TITLE
fix: iPhone screenshots and large images fail to upload silently

### DIFF
--- a/src/screens/chat-screen/components/message-components/CommandOptionsMenu.tsx
+++ b/src/screens/chat-screen/components/message-components/CommandOptionsMenu.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+ import React from 'react';
 import { Alert, Linking, Platform, Pressable, Text } from 'react-native';
 import {
   pick,
@@ -22,6 +22,7 @@ import { MAXIMUM_FILE_UPLOAD_SIZE } from '@/constants';
 import i18n from '@/i18n';
 import { showToast } from '@/utils/toastUtils';
 import { findFileSize } from '@/utils/fileUtils';
+import { compressImageIfNeeded } from '@/utils/imageCompressionUtils';
 
 export const handleOpenPhotosLibrary = async dispatch => {
   const pickedAssets = await launchImageLibrary({
@@ -173,9 +174,13 @@ const ADD_MENU_OPTIONS = [
 ];
 
 export const validateFileAndSetAttachments = async (dispatch, attachment) => {
-  const { fileSize } = attachment;
+  // Compress images before the size check.
+  // This fixes the bug where iPhone screenshots / HEIC photos
+  // hit the upload limit even though they could fit after compression.
+  const processed = await compressImageIfNeeded(attachment);
+  const { fileSize } = processed;
   if (findFileSize(fileSize) <= MAXIMUM_FILE_UPLOAD_SIZE) {
-    dispatch(updateAttachments([attachment]));
+    dispatch(updateAttachments([processed]));
   } else {
     showToast({ message: i18n.t('CONVERSATION.FILE_SIZE_LIMIT') });
   }

--- a/src/utils/imageCompressionUtils.ts
+++ b/src/utils/imageCompressionUtils.ts
@@ -1,0 +1,141 @@
+import { ImageManipulator, SaveFormat } from 'expo-image-manipulator';
+import { Asset } from 'react-native-image-picker';
+import * as FileSystem from 'expo-file-system';
+
+/**
+ * Threshold above which images get compressed (in MB).
+ * Anything under this is sent as-is to preserve quality
+ * (e.g. small screenshots, receipts where detail matters).
+ */
+const COMPRESSION_THRESHOLD_MB = 1.5;
+
+/**
+ * Max dimension (longest side) after compression.
+ */
+const MAX_DIMENSION = 1920;
+
+/**
+ * JPEG quality after recompression (0..1).
+ */
+const COMPRESSION_QUALITY = 0.8;
+
+const HEIC_MIME = ['image/heic', 'image/heif'];
+
+const isImageAsset = (asset: Asset): boolean => {
+  if (!asset.type) {
+    // Fall back to URI/filename extension if type missing
+    const probe = (asset.fileName || asset.uri || '').toLowerCase();
+    return /\.(png|jpe?g|gif|webp|heic|heif|bmp)(\?|$)/.test(probe);
+  }
+  return asset.type.startsWith('image/');
+};
+
+const isHeic = (asset: Asset): boolean => {
+  if (asset.type && HEIC_MIME.includes(asset.type.toLowerCase())) return true;
+  const probe = (asset.fileName || asset.uri || '').toLowerCase();
+  return /\.(heic|heif)(\?|$)/.test(probe);
+};
+
+const extensionFromType = (type?: string | null): string => {
+  if (!type) return 'jpg';
+  const t = type.toLowerCase();
+  if (t.includes('png')) return 'png';
+  if (t.includes('gif')) return 'gif';
+  if (t.includes('webp')) return 'webp';
+  if (t.includes('heic') || t.includes('heif')) return 'heic';
+  if (t.includes('jpeg') || t.includes('jpg')) return 'jpg';
+  return 'jpg';
+};
+
+const typeFromExtension = (ext: string): string => {
+  const e = ext.toLowerCase();
+  if (e === 'png') return 'image/png';
+  if (e === 'gif') return 'image/gif';
+  if (e === 'webp') return 'image/webp';
+  if (e === 'heic' || e === 'heif') return 'image/heic';
+  return 'image/jpeg';
+};
+
+/**
+ * Ensure the asset has a valid fileName with an extension that matches
+ * its MIME type. The iOS image picker sometimes returns null fileName
+ * (especially for screenshots and iCloud-stored photos), which causes
+ * the multipart upload to be rejected by the Chatwoot backend.
+ */
+export const normalizeAssetFilename = (asset: Asset): Asset => {
+  const ext = extensionFromType(asset.type);
+  const inferredType = asset.type || typeFromExtension(ext);
+
+  // Build a guaranteed-non-empty filename
+  let name = asset.fileName?.trim();
+  if (!name) {
+    // No filename at all — generate one from timestamp
+    name = `attachment_${Date.now()}.${ext}`;
+  } else if (!/\.[a-z0-9]{2,5}$/i.test(name)) {
+    // Has a name but no extension — append the correct one
+    name = `${name}.${ext}`;
+  }
+
+  return {
+    ...asset,
+    fileName: name,
+    type: inferredType,
+  };
+};
+
+/**
+ * Compress an image asset if needed, and always normalize its filename
+ * and MIME type for safe multipart upload.
+ *
+ * Returns the (possibly modified) asset. Never throws — falls back to
+ * the normalized original on any error so the user can still try to send.
+ */
+export const compressImageIfNeeded = async (asset: Asset): Promise<Asset> => {
+  // Always normalize, even when no compression is needed.
+  // This is what fixes the "queda en rojo" bug for small PNG screenshots.
+  const normalized = normalizeAssetFilename(asset);
+
+  try {
+    if (!normalized.uri) return normalized;
+    if (!isImageAsset(normalized)) return normalized;
+
+    const sizeMB = (normalized.fileSize ?? 0) / (1024 * 1024);
+    const needsCompression = sizeMB > COMPRESSION_THRESHOLD_MB || isHeic(normalized);
+    if (!needsCompression) return normalized;
+
+    const context = ImageManipulator.manipulate(normalized.uri);
+    context.resize({ width: MAX_DIMENSION });
+    const image = await context.renderAsync();
+    const result = await image.saveAsync({
+      compress: COMPRESSION_QUALITY,
+      format: SaveFormat.JPEG,
+    });
+
+    let newSize = normalized.fileSize ?? 0;
+    try {
+      const info = await FileSystem.getInfoAsync(result.uri, { size: true });
+      if (info.exists && 'size' in info && typeof info.size === 'number') {
+        newSize = info.size;
+      }
+    } catch {
+      // keep prior size estimate
+    }
+
+    const baseName = (normalized.fileName || `attachment_${Date.now()}`).replace(
+      /\.(heic|heif|png|webp|gif|bmp|jpe?g)$/i,
+      '',
+    );
+
+    return {
+      ...normalized,
+      uri: result.uri,
+      type: 'image/jpeg',
+      fileName: `${baseName}.jpg`,
+      fileSize: newSize,
+      width: result.width,
+      height: result.height,
+    };
+  } catch {
+    return normalized;
+  }
+};


### PR DESCRIPTION
## Description

On the iOS app, attempting to send certain images results in the attachment getting stuck in a "red" / failed state with no clear error shown to the user. Investigation revealed two related root causes:

### 1. `fileName` is sometimes null/undefined from `react-native-image-picker`

For iOS screenshots and assets stored in iCloud (not downloaded locally), `react-native-image-picker` can return an `Asset` with `fileName: null` or without a file extension. In `buildCreatePayload` (`src/utils/messageUtils.ts`), this gets passed directly into the multipart `FormData`:

    payload.append('attachments[]', {
      uri: file.uri,
      name: file.fileName,   // null/undefined here breaks the upload
      type: file.type,
    });

The Chatwoot backend rejects multipart parts without a valid filename, but on the mobile client this surfaces only as a failed (red) attachment, with no actionable error.

### 2. No client-side image compression

`launchImageLibrary` is called with `quality: 1`, and `validateFileAndSetAttachments` hard-fails any file above `MAXIMUM_FILE_UPLOAD_SIZE` (20 MB) without attempting to compress. HEIC photos and long iPhone screenshots routinely exceed this limit even though they would fit comfortably after standard recompression.

### Fix

This PR adds `src/utils/imageCompressionUtils.ts` with two responsibilities:

1. **`normalizeAssetFilename`** — ensures every image asset has a non-empty `fileName` with an extension consistent with its MIME type. Generates `attachment_{timestamp}.{ext}` when the picker returns null. Runs for every image, regardless of whether compression is needed. **This is the actual fix for the "red attachment" bug.**

2. **`compressImageIfNeeded`** — when the image is over 1.5 MB or is HEIC/HEIF, resizes it to a max dimension of 1920px and re-saves as JPEG at quality 0.8 using `expo-image-manipulator`. HEIC/HEIF are always converted for broader compatibility with the backend and downstream channels.

`validateFileAndSetAttachments` in `CommandOptionsMenu.tsx` now awaits `compressImageIfNeeded(attachment)` before the size check, so large images get a chance to fit under the limit instead of failing outright.

The implementation is defensive: if compression or filesystem inspection fails for any reason, the (normalized) original asset is returned, so the size check downstream still applies and behavior never regresses to worse than current.

### New dependencies

- `expo-image-manipulator`
- `expo-file-system` (likely already transitively available; importing explicitly for the `getInfoAsync` size lookup)

Both are first-party Expo packages and align with the existing Expo stack.

Fixes # (no existing issue — opening this PR directly based on user reports)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested on iOS (iPhone) with the following scenarios:

1. Sending a screenshot stored in iCloud (cloud icon visible, not downloaded locally) — previously failed with red attachment, now uploads correctly.
2. Sending a small PNG screenshot (~1 MB) — previously failed silently due to null `fileName`, now uploads correctly with a generated filename.
3. Sending a HEIC photo from the camera roll — now converts to JPEG and uploads correctly.
4. Sending a large screenshot (>5 MB) — now compressed under the threshold and uploads correctly.
5. Sending non-image attachments (PDF, DOCX) — unchanged behavior, no regression.

Android testing pending — the change is platform-agnostic and uses Expo APIs, so behavior should be equivalent, but ideally a maintainer with an Android device can confirm.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested in both Android and iOS platform
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

## Out of scope

A separate, more complex bug was identified during investigation: in `mention-input.tsx`, the cursor jumps and emojis get corrupted (rendered as `?` glyphs) when editing text that contains emojis with surrogate pairs or modifiers (skin tone, ZWJ). The root cause is that `parseValue`/`diffChars` operate on UTF-16 code units rather than grapheme clusters. That fix touches the mention/diff pipeline and is being filed as a separate issue.

