### PR TITLE
fix: Render contact details and dashboard screens on Android by using modal presentation

### DIFF
--- a/src/navigation/tabs/AppTabs.tsx
+++ b/src/navigation/tabs/AppTabs.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
+import { Platform } from 'react-native';
 import { BottomTabBarProps, createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
@@ -189,7 +190,7 @@ export const AppTabs = () => {
         />
         <Stack.Screen
           options={{
-            presentation: 'formSheet',
+            presentation: Platform.OS === 'ios' ? 'formSheet' : 'modal',
             animation: 'slide_from_bottom',
           }}
           name="ContactDetails"
@@ -197,7 +198,7 @@ export const AppTabs = () => {
         />
         <Stack.Screen
           options={{
-            presentation: 'formSheet',
+            presentation: Platform.OS === 'ios' ? 'formSheet' : 'modal',
             animation: 'slide_from_bottom',
           }}
           name="Dashboard"


### PR DESCRIPTION
## Description 
After the Expo 53 / RN 0.79 upgrade ([PR 1063](https://github.com/chatwoot/chatwoot-mobile-app/pull/1063)) bumped react-native-screens to 4.x, the ContactDetails and Dashboard screens stopped showing up on Android. They were loaded and tappable (tapping where the phone/email should be still copied them), but nothing was drawn on screen until the app was closed and reopened.
 
### Cause
Both screens used presentation: 'formSheet'. In react-native-screens 4.0 the Android formSheet was rewritten into a real native bottom sheet, and it expects a specific child layout (a ScrollView with at most ~2 subviews). Our screens don't match that shape. They wrap a header plus a ScrollView / WebView. So the new implementation mislaid out the content and never painted it. iOS was unaffected because it uses the OS's own native formSheet, which has no such requirement.

### Fix
Keep formSheet on iOS and use the standard modal style on Android for both screens, which avoids the new native-sheet implementation entirely.

Verified on Android (both screens now show up right away) and iOS (unchanged).

Fixes #1073 ([CW-7252](https://linear.app/chatwoot/issue/CW-7252/android-app-contact-details-screen-is-invisible-after-tapping-customer))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
