### PR TITLE
fix: Scroll login form above keyboard using KeyboardAwareScrollView

### DIFF
--- a/src/screens/auth/LoginScreen.tsx
+++ b/src/screens/auth/LoginScreen.tsx
@@ -8,6 +8,7 @@ import {
   useBottomSheetSpringConfigs,
 } from '@gorhom/bottom-sheet';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
 
 import { EMAIL_REGEX } from '@/constants';
 import { EyeIcon, EyeSlash, LockIcon } from '@/svg-icons';
@@ -145,9 +146,11 @@ const LoginScreen = () => {
         barStyle={'dark-content'}
       />
       <View style={tailwind.style('flex-1 bg-white')}>
-        <Animated.ScrollView
+        <KeyboardAwareScrollView
           showsVerticalScrollIndicator={false}
-          contentContainerStyle={tailwind.style('px-6 pt-24')}>
+          keyboardShouldPersistTaps="handled"
+          bottomOffset={24}
+          contentContainerStyle={tailwind.style('px-6 pt-24 pb-8')}>
           <Image
             // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
             source={require('@/assets/images/logo.png')}
@@ -296,7 +299,7 @@ const LoginScreen = () => {
               {i18n.t('LOGIN.CHANGE_LANGUAGE')}
             </Animated.Text>
           </Pressable>
-        </Animated.ScrollView>
+        </KeyboardAwareScrollView>
       </View>
       <BottomSheetModal
         ref={languagesModalSheetRef}


### PR DESCRIPTION
## Description 

On the login screen, focusing the email or password field brought up the keyboard, which covered the lower part of the form. The screen did not scroll, so the obscured fields and actions were unreachable.

### Cause

The form was rendered inside a plain Animated.ScrollView, which has no awareness of the keyboard and does not scroll the focused input into view.

### Fix

Replaced Animated.ScrollView with KeyboardAwareScrollView from react-native-keyboard-controller (already a project dependency, with KeyboardProvider mounted at the navigation root). It automatically scrolls the focused input above the keyboard.

| Before | After |
| :---: | :---: |
| <video src="https://github.com/user-attachments/assets/caad0ef5-dafc-41da-94a1-a8d2beae6cf9" width="300" controls></video> | <video src="https://github.com/user-attachments/assets/3feb4640-d1be-49ec-af10-9c5c5540a812" width="300" controls></video> |

Fixes [CW-7206](https://linear.app/chatwoot/issue/CW-7206/body-scroll-issue-when-keyboard-opens)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
