### PR TITLE
fix: keep outgoing email replies readable

### DIFF
--- a/src/screens/chat-screen/components/message-components/Email.tsx
+++ b/src/screens/chat-screen/components/message-components/Email.tsx
@@ -46,20 +46,6 @@ export const Email = (props: EmailProps) => {
 
   const isMessageFailed = status === MESSAGE_STATUS.FAILED;
   const FormattedEmail = text.replace('height:100%;', '');
-  const readableOutgoingEmailStyle = isOutgoing
-    ? `
-        html, body {
-          background: #ffffff !important;
-          color: #111827 !important;
-        }
-        body, p, div, span, td, th, li {
-          color: #111827 !important;
-        }
-        a {
-          color: #2563eb !important;
-        }
-      `
-    : '';
 
   const windowWidth = Dimensions.get('window').width;
   const WIDTH = windowWidth - 52; // 52 is the sum of the left and right padding (12 + 12) and avatar width (24) and gap between avatar and message (4)
@@ -91,7 +77,6 @@ export const Email = (props: EmailProps) => {
           font-family: system,-apple-system,".SFNSText-Regular","San Francisco",Roboto,"Segoe UI","Helvetica Neue","Lucida Grande",sans-serif;
           font-size: 14px;
         } 
-        ${readableOutgoingEmailStyle}
         img{
           max-width: 100% !important;
         }

--- a/src/screens/chat-screen/components/message-components/Email.tsx
+++ b/src/screens/chat-screen/components/message-components/Email.tsx
@@ -46,6 +46,20 @@ export const Email = (props: EmailProps) => {
 
   const isMessageFailed = status === MESSAGE_STATUS.FAILED;
   const FormattedEmail = text.replace('height:100%;', '');
+  const readableOutgoingEmailStyle = isOutgoing
+    ? `
+        html, body {
+          background: #ffffff !important;
+          color: #111827 !important;
+        }
+        body, p, div, span, td, th, li {
+          color: #111827 !important;
+        }
+        a {
+          color: #2563eb !important;
+        }
+      `
+    : '';
 
   const windowWidth = Dimensions.get('window').width;
   const WIDTH = windowWidth - 52; // 52 is the sum of the left and right padding (12 + 12) and avatar width (24) and gap between avatar and message (4)
@@ -77,6 +91,7 @@ export const Email = (props: EmailProps) => {
           font-family: system,-apple-system,".SFNSText-Regular","San Francisco",Roboto,"Segoe UI","Helvetica Neue","Lucida Grande",sans-serif;
           font-size: 14px;
         } 
+        ${readableOutgoingEmailStyle}
         img{
           max-width: 100% !important;
         }

--- a/src/screens/chat-screen/components/message-components/EmailBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/EmailBubble.tsx
@@ -38,20 +38,26 @@ export const EmailBubble = (props: EmailBubbleProps) => {
   const isOutgoing = messageType === MESSAGE_TYPES.OUTGOING;
 
   const FormattedEmail = emailMessageContent().replace('height:100%;', '');
-  const readableOutgoingEmailStyle = isOutgoing
-    ? `
+
+  const baseStyle = `
+        * {
+          font-family: system,-apple-system,".SFNSText-Regular","San Francisco",Roboto,"Segoe UI","Helvetica Neue","Lucida Grande",sans-serif;
+          font-size: 16px;
+        }
+        img{
+          max-width: 100% !important;
+        }
+      `;
+  const outgoingReadableStyle = `
+        :root {
+          color-scheme: light;
+        }
         html, body {
-          background: #ffffff !important;
-          color: #111827 !important;
+          background: #ffffff;
+          color: #111827;
         }
-        body, p, div, span, td, th, li {
-          color: #111827 !important;
-        }
-        a {
-          color: #2563eb !important;
-        }
-      `
-    : '';
+      `;
+  const emailCustomStyle = isOutgoing ? `${outgoingReadableStyle}${baseStyle}` : baseStyle;
 
   return (
     <React.Fragment>
@@ -64,16 +70,8 @@ export const EmailBubble = (props: EmailBubbleProps) => {
             <AutoHeightWebView
               style={{ width: '100%', minHeight: 1, minWidth: '100%' }}
               scrollEnabled={false}
-              customStyle={`
-        * {
-          font-family: system,-apple-system,".SFNSText-Regular","San Francisco",Roboto,"Segoe UI","Helvetica Neue","Lucida Grande",sans-serif;
-          font-size: 16px;
-        } 
-        ${readableOutgoingEmailStyle}
-        img{
-          max-width: 100% !important;
-        }
-      `}
+              forceDarkOn={false}
+              customStyle={emailCustomStyle}
               source={{
                 html: FormattedEmail,
               }}

--- a/src/screens/chat-screen/components/message-components/EmailBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/EmailBubble.tsx
@@ -38,6 +38,20 @@ export const EmailBubble = (props: EmailBubbleProps) => {
   const isOutgoing = messageType === MESSAGE_TYPES.OUTGOING;
 
   const FormattedEmail = emailMessageContent().replace('height:100%;', '');
+  const readableOutgoingEmailStyle = isOutgoing
+    ? `
+        html, body {
+          background: #ffffff !important;
+          color: #111827 !important;
+        }
+        body, p, div, span, td, th, li {
+          color: #111827 !important;
+        }
+        a {
+          color: #2563eb !important;
+        }
+      `
+    : '';
 
   return (
     <React.Fragment>
@@ -55,6 +69,7 @@ export const EmailBubble = (props: EmailBubbleProps) => {
           font-family: system,-apple-system,".SFNSText-Regular","San Francisco",Roboto,"Segoe UI","Helvetica Neue","Lucida Grande",sans-serif;
           font-size: 16px;
         } 
+        ${readableOutgoingEmailStyle}
         img{
           max-width: 100% !important;
         }

--- a/src/screens/chat-screen/components/message-components/MarkdownBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/MarkdownBubble.tsx
@@ -18,6 +18,7 @@ const variantTextMap = {
   [MESSAGE_VARIANTS.TEMPLATE]: 'text-gray-950',
   [MESSAGE_VARIANTS.ERROR]: 'text-white',
   [MESSAGE_VARIANTS.PRIVATE]: 'text-amber-950 font-inter-medium-24',
+  [MESSAGE_VARIANTS.EMAIL]: 'text-gray-950',
 };
 
 export const MarkdownBubble = (props: MarkdownBubbleProps) => {


### PR DESCRIPTION
## Summary
- force outgoing email WebView bodies to use readable dark text on a white background
- keep outgoing email links readable with a blue link color
- add the email markdown bubble variant to the dark text color map

Closes #1076

## Tests
- pnpm exec eslint src/screens/chat-screen/components/message-components/Email.tsx src/screens/chat-screen/components/message-components/EmailBubble.tsx src/screens/chat-screen/components/message-components/MarkdownBubble.tsx
- git diff --check

## Notes
- Full `pnpm lint` and `pnpm exec tsc --noEmit` are currently blocked by unrelated existing failures on develop, including unresolved modules and pre-existing Prettier/type errors outside this change.