### PR TITLE
fix: ignore stale conversation updates

### DIFF
--- a/src/store/conversation/conversationSlice.ts
+++ b/src/store/conversation/conversationSlice.ts
@@ -58,11 +58,14 @@ const shouldPreserveLocalStatus = (
   incomingConversation: Conversation,
 ) => {
   const localStatusUpdatedAt = existingConversation?.localStatusUpdatedAt;
+  const existingUpdatedAt = existingConversation?.updatedAt;
   const incomingUpdatedAt = incomingConversation.updatedAt;
 
   return (
     typeof localStatusUpdatedAt === 'number' &&
+    typeof existingUpdatedAt === 'number' &&
     typeof incomingUpdatedAt === 'number' &&
+    localStatusUpdatedAt === existingUpdatedAt &&
     incomingUpdatedAt <= localStatusUpdatedAt &&
     existingConversation?.status !== incomingConversation.status
   );
@@ -73,7 +76,10 @@ const preserveLocalStatus = (
   incomingConversation: Conversation,
 ) => {
   if (!shouldPreserveLocalStatus(existingConversation, incomingConversation)) {
-    return incomingConversation;
+    return {
+      ...incomingConversation,
+      localStatusUpdatedAt: undefined,
+    };
   }
 
   return {

--- a/src/store/conversation/conversationSlice.ts
+++ b/src/store/conversation/conversationSlice.ts
@@ -76,7 +76,8 @@ const shouldPreserveLocalStatus = (
 ) => {
   return (
     shouldKeepLocalStatusMarker(existingConversation, incomingConversation) &&
-    existingConversation?.status !== incomingConversation.status
+    existingConversation?.status !== incomingConversation.status &&
+    existingConversation?.localStatusPreviousStatus === incomingConversation.status
   );
 };
 
@@ -88,6 +89,7 @@ const preserveLocalStatus = (
     return {
       ...incomingConversation,
       localStatusUpdatedAt: undefined,
+      localStatusPreviousStatus: undefined,
     };
   }
 
@@ -95,6 +97,7 @@ const preserveLocalStatus = (
     return {
       ...incomingConversation,
       localStatusUpdatedAt: existingConversation?.localStatusUpdatedAt,
+      localStatusPreviousStatus: existingConversation?.localStatusPreviousStatus,
     };
   }
 
@@ -103,6 +106,7 @@ const preserveLocalStatus = (
     status: existingConversation.status,
     snoozedUntil: existingConversation.snoozedUntil,
     localStatusUpdatedAt: existingConversation.localStatusUpdatedAt,
+    localStatusPreviousStatus: existingConversation.localStatusPreviousStatus,
   };
 };
 
@@ -267,6 +271,7 @@ const conversationSlice = createSlice({
         if (!conversation) {
           return;
         }
+        conversation.localStatusPreviousStatus = conversation.status;
         conversation.status = currentStatus;
         conversation.snoozedUntil = snoozedUntil;
         conversation.localStatusUpdatedAt = conversation.updatedAt;

--- a/src/store/conversation/conversationSlice.ts
+++ b/src/store/conversation/conversationSlice.ts
@@ -39,6 +39,51 @@ const initialState = conversationAdapter.getInitialState<ConversationState>({
   isChangingConversationStatus: false,
 });
 
+const isOutdatedConversationUpdate = (
+  existingConversation: Conversation | undefined,
+  incomingConversation: Conversation,
+) => {
+  const existingUpdatedAt = existingConversation?.updatedAt;
+  const incomingUpdatedAt = incomingConversation.updatedAt;
+
+  return (
+    typeof existingUpdatedAt === 'number' &&
+    typeof incomingUpdatedAt === 'number' &&
+    incomingUpdatedAt < existingUpdatedAt
+  );
+};
+
+const shouldPreserveLocalStatus = (
+  existingConversation: Conversation | undefined,
+  incomingConversation: Conversation,
+) => {
+  const localStatusUpdatedAt = existingConversation?.localStatusUpdatedAt;
+  const incomingUpdatedAt = incomingConversation.updatedAt;
+
+  return (
+    typeof localStatusUpdatedAt === 'number' &&
+    typeof incomingUpdatedAt === 'number' &&
+    incomingUpdatedAt <= localStatusUpdatedAt &&
+    existingConversation?.status !== incomingConversation.status
+  );
+};
+
+const preserveLocalStatus = (
+  existingConversation: Conversation | undefined,
+  incomingConversation: Conversation,
+) => {
+  if (!shouldPreserveLocalStatus(existingConversation, incomingConversation)) {
+    return incomingConversation;
+  }
+
+  return {
+    ...incomingConversation,
+    status: existingConversation.status,
+    snoozedUntil: existingConversation.snoozedUntil,
+    localStatusUpdatedAt: existingConversation.localStatusUpdatedAt,
+  };
+};
+
 const conversationSlice = createSlice({
   name: 'conversation',
   initialState,
@@ -52,7 +97,15 @@ const conversationSlice = createSlice({
       const conversation = action.payload as Conversation;
       const conversationIds = conversationAdapter.getSelectors().selectIds(state);
       if (conversationIds.includes(conversation.id)) {
-        const { messages, ...conversationAttributes } = conversation;
+        const existingConversation = state.entities[conversation.id];
+        if (isOutdatedConversationUpdate(existingConversation, conversation)) {
+          return;
+        }
+
+        const { messages, ...conversationAttributes } = preserveLocalStatus(
+          existingConversation,
+          conversation,
+        );
         conversationAdapter.updateOne(state, {
           id: conversation.id,
           changes: conversationAttributes,
@@ -108,7 +161,16 @@ const conversationSlice = createSlice({
       })
       .addCase(conversationActions.fetchConversations.fulfilled, (state, { payload }) => {
         const { conversations, meta } = payload;
-        conversationAdapter.upsertMany(state, conversations);
+        const conversationsToUpsert = conversations.filter(
+          conversation =>
+            !isOutdatedConversationUpdate(state.entities[conversation.id], conversation),
+        );
+        conversationAdapter.upsertMany(
+          state,
+          conversationsToUpsert.map(conversation =>
+            preserveLocalStatus(state.entities[conversation.id], conversation),
+          ),
+        );
         state.isLoadingConversations = false;
         state.isAllConversationsFetched = conversations.length < 20 || false;
         state.meta = meta;
@@ -122,7 +184,15 @@ const conversationSlice = createSlice({
       })
       .addCase(conversationActions.fetchConversation.fulfilled, (state, { payload }) => {
         const { conversation } = payload;
-        conversationAdapter.upsertOne(state, conversation);
+        if (isOutdatedConversationUpdate(state.entities[conversation.id], conversation)) {
+          state.isConversationFetching = false;
+          return;
+        }
+
+        conversationAdapter.upsertOne(
+          state,
+          preserveLocalStatus(state.entities[conversation.id], conversation),
+        );
         state.isConversationFetching = false;
         state.isAllMessagesFetched = false;
       })
@@ -177,6 +247,7 @@ const conversationSlice = createSlice({
         }
         conversation.status = currentStatus;
         conversation.snoozedUntil = snoozedUntil;
+        conversation.localStatusUpdatedAt = conversation.updatedAt;
         state.isChangingConversationStatus = false;
       })
       .addCase(conversationActions.toggleConversationStatus.rejected, state => {
@@ -228,7 +299,8 @@ const conversationSlice = createSlice({
         const messageIndex = conversation.messages.findIndex(m => m.id === messageId);
         if (messageIndex !== -1) {
           const message = conversation.messages[messageIndex];
-          const existing = message.contentAttributes ?? ({} as NonNullable<Message['contentAttributes']>);
+          const existing =
+            message.contentAttributes ?? ({} as NonNullable<Message['contentAttributes']>);
           conversation.messages[messageIndex] = {
             ...message,
             contentAttributes: {

--- a/src/store/conversation/conversationSlice.ts
+++ b/src/store/conversation/conversationSlice.ts
@@ -53,7 +53,7 @@ const isOutdatedConversationUpdate = (
   );
 };
 
-const shouldPreserveLocalStatus = (
+const shouldKeepLocalStatusMarker = (
   existingConversation: Conversation | undefined,
   incomingConversation: Conversation,
 ) => {
@@ -66,7 +66,16 @@ const shouldPreserveLocalStatus = (
     typeof existingUpdatedAt === 'number' &&
     typeof incomingUpdatedAt === 'number' &&
     localStatusUpdatedAt === existingUpdatedAt &&
-    incomingUpdatedAt <= localStatusUpdatedAt &&
+    incomingUpdatedAt <= localStatusUpdatedAt
+  );
+};
+
+const shouldPreserveLocalStatus = (
+  existingConversation: Conversation | undefined,
+  incomingConversation: Conversation,
+) => {
+  return (
+    shouldKeepLocalStatusMarker(existingConversation, incomingConversation) &&
     existingConversation?.status !== incomingConversation.status
   );
 };
@@ -75,10 +84,17 @@ const preserveLocalStatus = (
   existingConversation: Conversation | undefined,
   incomingConversation: Conversation,
 ) => {
-  if (!shouldPreserveLocalStatus(existingConversation, incomingConversation)) {
+  if (!shouldKeepLocalStatusMarker(existingConversation, incomingConversation)) {
     return {
       ...incomingConversation,
       localStatusUpdatedAt: undefined,
+    };
+  }
+
+  if (!shouldPreserveLocalStatus(existingConversation, incomingConversation)) {
+    return {
+      ...incomingConversation,
+      localStatusUpdatedAt: existingConversation?.localStatusUpdatedAt,
     };
   }
 

--- a/src/store/conversation/specs/conversationSlice.spec.ts
+++ b/src/store/conversation/specs/conversationSlice.spec.ts
@@ -63,6 +63,57 @@ describe('conversation reducer', () => {
     expect(state.entities[conversation.id]?.priority).toBe('high');
   });
 
+  it('keeps the status guard after same-second server confirmation', () => {
+    const initialConversation = {
+      ...conversation,
+      status: 'open' as const,
+      updatedAt: 100,
+    };
+
+    const serverConfirmation = {
+      ...conversation,
+      status: 'resolved' as const,
+      updatedAt: 100,
+      labels: ['confirmed'],
+    };
+
+    const staleConversation = {
+      ...conversation,
+      status: 'open' as const,
+      updatedAt: 100,
+      labels: ['stale'],
+    };
+
+    let state = conversationReducer(undefined, addConversation(initialConversation));
+    state = conversationReducer(
+      state,
+      conversationActions.toggleConversationStatus.fulfilled(
+        {
+          conversationId: conversation.id,
+          currentStatus: 'resolved',
+          snoozedUntil: null,
+        },
+        'request-id',
+        {
+          conversationId: conversation.id,
+          payload: { status: 'resolved', snoozed_until: null },
+        },
+      ),
+    );
+
+    state = conversationReducer(state, updateConversation(serverConfirmation));
+
+    expect(state.entities[conversation.id]?.status).toBe('resolved');
+    expect(state.entities[conversation.id]?.localStatusUpdatedAt).toBe(100);
+    expect(state.entities[conversation.id]?.labels).toEqual(['confirmed']);
+
+    state = conversationReducer(state, updateConversation(staleConversation));
+
+    expect(state.entities[conversation.id]?.status).toBe('resolved');
+    expect(state.entities[conversation.id]?.localStatusUpdatedAt).toBe(100);
+    expect(state.entities[conversation.id]?.labels).toEqual(['stale']);
+  });
+
   it('accepts newer server status updates after a local status toggle', () => {
     const initialConversation = {
       ...conversation,

--- a/src/store/conversation/specs/conversationSlice.spec.ts
+++ b/src/store/conversation/specs/conversationSlice.spec.ts
@@ -96,6 +96,29 @@ describe('conversation reducer', () => {
 
     expect(state.entities[conversation.id]?.status).toBe('open');
     expect(state.entities[conversation.id]?.updatedAt).toBe(201);
+    expect(state.entities[conversation.id]?.localStatusUpdatedAt).toBeUndefined();
+  });
+
+  it('does not let client-clock local markers block server status updates', () => {
+    const initialConversation = {
+      ...conversation,
+      status: 'resolved' as const,
+      updatedAt: 100,
+      localStatusUpdatedAt: Date.now(),
+    };
+
+    const serverConversation = {
+      ...conversation,
+      status: 'open' as const,
+      updatedAt: 101,
+    };
+
+    let state = conversationReducer(undefined, addConversation(initialConversation));
+    state = conversationReducer(state, updateConversation(serverConversation));
+
+    expect(state.entities[conversation.id]?.status).toBe('open');
+    expect(state.entities[conversation.id]?.updatedAt).toBe(101);
+    expect(state.entities[conversation.id]?.localStatusUpdatedAt).toBeUndefined();
   });
 
   it('ignores outdated conversations from list fetches', () => {

--- a/src/store/conversation/specs/conversationSlice.spec.ts
+++ b/src/store/conversation/specs/conversationSlice.spec.ts
@@ -105,13 +105,53 @@ describe('conversation reducer', () => {
 
     expect(state.entities[conversation.id]?.status).toBe('resolved');
     expect(state.entities[conversation.id]?.localStatusUpdatedAt).toBe(100);
+    expect(state.entities[conversation.id]?.localStatusPreviousStatus).toBe('open');
     expect(state.entities[conversation.id]?.labels).toEqual(['confirmed']);
 
     state = conversationReducer(state, updateConversation(staleConversation));
 
     expect(state.entities[conversation.id]?.status).toBe('resolved');
     expect(state.entities[conversation.id]?.localStatusUpdatedAt).toBe(100);
+    expect(state.entities[conversation.id]?.localStatusPreviousStatus).toBe('open');
     expect(state.entities[conversation.id]?.labels).toEqual(['stale']);
+  });
+
+  it('accepts equal-timestamp status updates that are not stale pre-toggle echoes', () => {
+    const initialConversation = {
+      ...conversation,
+      status: 'open' as const,
+      updatedAt: 100,
+    };
+
+    const serverConversation = {
+      ...conversation,
+      status: 'pending' as const,
+      updatedAt: 100,
+    };
+
+    let state = conversationReducer(undefined, addConversation(initialConversation));
+    state = conversationReducer(
+      state,
+      conversationActions.toggleConversationStatus.fulfilled(
+        {
+          conversationId: conversation.id,
+          currentStatus: 'resolved',
+          snoozedUntil: null,
+        },
+        'request-id',
+        {
+          conversationId: conversation.id,
+          payload: { status: 'resolved', snoozed_until: null },
+        },
+      ),
+    );
+
+    state = conversationReducer(state, updateConversation(serverConversation));
+
+    expect(state.entities[conversation.id]?.status).toBe('pending');
+    expect(state.entities[conversation.id]?.updatedAt).toBe(100);
+    expect(state.entities[conversation.id]?.localStatusUpdatedAt).toBe(100);
+    expect(state.entities[conversation.id]?.localStatusPreviousStatus).toBe('open');
   });
 
   it('accepts newer server status updates after a local status toggle', () => {
@@ -148,6 +188,7 @@ describe('conversation reducer', () => {
     expect(state.entities[conversation.id]?.status).toBe('open');
     expect(state.entities[conversation.id]?.updatedAt).toBe(201);
     expect(state.entities[conversation.id]?.localStatusUpdatedAt).toBeUndefined();
+    expect(state.entities[conversation.id]?.localStatusPreviousStatus).toBeUndefined();
   });
 
   it('does not let client-clock local markers block server status updates', () => {
@@ -170,6 +211,7 @@ describe('conversation reducer', () => {
     expect(state.entities[conversation.id]?.status).toBe('open');
     expect(state.entities[conversation.id]?.updatedAt).toBe(101);
     expect(state.entities[conversation.id]?.localStatusUpdatedAt).toBeUndefined();
+    expect(state.entities[conversation.id]?.localStatusPreviousStatus).toBeUndefined();
   });
 
   it('ignores outdated conversations from list fetches', () => {

--- a/src/store/conversation/specs/conversationSlice.spec.ts
+++ b/src/store/conversation/specs/conversationSlice.spec.ts
@@ -1,0 +1,139 @@
+import conversationReducer, { addConversation, updateConversation } from '../conversationSlice';
+import { conversation } from './conversationMockData';
+import { conversationActions } from '../conversationActions';
+
+describe('conversation reducer', () => {
+  it('ignores outdated conversation updates', () => {
+    const initialConversation = {
+      ...conversation,
+      status: 'resolved' as const,
+      updatedAt: 200,
+    };
+
+    const outdatedConversation = {
+      ...conversation,
+      status: 'open' as const,
+      updatedAt: 100,
+    };
+
+    let state = conversationReducer(undefined, addConversation(initialConversation));
+    state = conversationReducer(state, updateConversation(outdatedConversation));
+
+    expect(state.entities[conversation.id]?.status).toBe('resolved');
+    expect(state.entities[conversation.id]?.updatedAt).toBe(200);
+  });
+
+  it('keeps resolved status while merging same-second updates after status toggle', () => {
+    const initialConversation = {
+      ...conversation,
+      status: 'open' as const,
+      updatedAt: 100,
+    };
+
+    const staleConversation = {
+      ...conversation,
+      status: 'open' as const,
+      updatedAt: 100,
+      labels: ['billing'],
+      priority: 'high' as const,
+    };
+
+    let state = conversationReducer(undefined, addConversation(initialConversation));
+    state = conversationReducer(
+      state,
+      conversationActions.toggleConversationStatus.fulfilled(
+        {
+          conversationId: conversation.id,
+          currentStatus: 'resolved',
+          snoozedUntil: null,
+        },
+        'request-id',
+        {
+          conversationId: conversation.id,
+          payload: { status: 'resolved', snoozed_until: null },
+        },
+      ),
+    );
+    state = conversationReducer(state, updateConversation(staleConversation));
+
+    expect(state.entities[conversation.id]?.status).toBe('resolved');
+    expect(state.entities[conversation.id]?.updatedAt).toBe(100);
+    expect(state.entities[conversation.id]?.localStatusUpdatedAt).toBe(100);
+    expect(state.entities[conversation.id]?.labels).toEqual(['billing']);
+    expect(state.entities[conversation.id]?.priority).toBe('high');
+  });
+
+  it('accepts newer server status updates after a local status toggle', () => {
+    const initialConversation = {
+      ...conversation,
+      status: 'open' as const,
+      updatedAt: 100,
+    };
+
+    const newerConversation = {
+      ...conversation,
+      status: 'open' as const,
+      updatedAt: 201,
+    };
+
+    let state = conversationReducer(undefined, addConversation(initialConversation));
+    state = conversationReducer(
+      state,
+      conversationActions.toggleConversationStatus.fulfilled(
+        {
+          conversationId: conversation.id,
+          currentStatus: 'resolved',
+          snoozedUntil: null,
+        },
+        'request-id',
+        {
+          conversationId: conversation.id,
+          payload: { status: 'resolved', snoozed_until: null },
+        },
+      ),
+    );
+    state = conversationReducer(state, updateConversation(newerConversation));
+
+    expect(state.entities[conversation.id]?.status).toBe('open');
+    expect(state.entities[conversation.id]?.updatedAt).toBe(201);
+  });
+
+  it('ignores outdated conversations from list fetches', () => {
+    const initialConversation = {
+      ...conversation,
+      status: 'resolved' as const,
+      updatedAt: 200,
+    };
+
+    const staleConversation = {
+      ...conversation,
+      status: 'open' as const,
+      updatedAt: 100,
+    };
+
+    let state = conversationReducer(undefined, addConversation(initialConversation));
+    state = conversationReducer(
+      state,
+      conversationActions.fetchConversations.fulfilled(
+        {
+          conversations: [staleConversation],
+          meta: {
+            mineCount: 1,
+            unassignedCount: 1,
+            allCount: 1,
+          },
+        },
+        'request-id',
+        {
+          status: 'open',
+          assigneeType: 'all',
+          page: 1,
+          sortBy: 'latest',
+        },
+      ),
+    );
+
+    expect(state.entities[conversation.id]?.status).toBe('resolved');
+    expect(state.entities[conversation.id]?.updatedAt).toBe(200);
+  });
+});

--- a/src/types/Conversation.ts
+++ b/src/types/Conversation.ts
@@ -39,6 +39,7 @@ export interface Conversation {
   timestamp: UnixTimestamp;
   updatedAt?: UnixTimestamp;
   localStatusUpdatedAt?: UnixTimestamp;
+  localStatusPreviousStatus?: ConversationStatus;
 
   slaPolicyId: number | null;
 

--- a/src/types/Conversation.ts
+++ b/src/types/Conversation.ts
@@ -37,6 +37,8 @@ export interface Conversation {
 
   // Deprecated
   timestamp: UnixTimestamp;
+  updatedAt?: UnixTimestamp;
+  localStatusUpdatedAt?: UnixTimestamp;
 
   slaPolicyId: number | null;
 


### PR DESCRIPTION
## Summary
- ignore older conversation payloads when realtime or fetch responses arrive out of order
- mark successful local status changes with an updated timestamp so stale `open` payloads cannot immediately undo a resolved state
- add reducer coverage for stale action cable-style updates and stale list fetches

Closes #1064

## Tests
- pnpm install --frozen-lockfile
- pnpm test src/store/conversation/specs/conversationSlice.spec.ts --runInBand
- pnpm exec eslint src/store/conversation/conversationSlice.ts src/store/conversation/specs/conversationSlice.spec.ts src/types/Conversation.ts
- git diff --check

## Notes
- Full `pnpm lint` is still blocked by unrelated existing lint/prettier issues outside this change.
- Full `pnpm exec tsc --noEmit` is still blocked by unrelated existing repo-wide type errors outside this change.