### PR TITLE
fix: preserve emoji input while typing

### DIFF
--- a/src/screens/chat-screen/components/reply-box/mentions-input/components/mention-input.tsx
+++ b/src/screens/chat-screen/components/reply-box/mentions-input/components/mention-input.tsx
@@ -28,6 +28,7 @@ const MentionInput = React.forwardRef<TextInput, MentionInputProps>(
     const [selection, setSelection] = useState({ start: 0, end: 0 });
 
     const { plainText, parts } = useMemo(() => parseValue(value, partTypes), [value, partTypes]);
+    const hasStyledParts = parts.some(part => part.partType != null);
 
     const handleSelectionChange = (
       event: NativeSyntheticEvent<TextInputSelectionChangeEventData>,
@@ -122,21 +123,24 @@ const MentionInput = React.forwardRef<TextInput, MentionInputProps>(
           multiline
           {...textInputProps}
           ref={handleTextInputRef}
+          value={hasStyledParts ? undefined : plainText}
           onChangeText={onChangeInput}
           onSelectionChange={handleSelectionChange}>
-          <Text>
-            {parts.map(({ text, partType, data }, index) =>
-              partType ? (
-                <Text
-                  key={`${index}-${data?.trigger ?? 'pattern'}`}
-                  style={partType.textStyle ?? defaultMentionTextStyle}>
-                  {text}
-                </Text>
-              ) : (
-                <Text key={index}>{text}</Text>
-              ),
-            )}
-          </Text>
+          {hasStyledParts ? (
+            <Text>
+              {parts.map(({ text, partType, data }, index) =>
+                partType ? (
+                  <Text
+                    key={`${index}-${data?.trigger ?? 'pattern'}`}
+                    style={partType.textStyle ?? defaultMentionTextStyle}>
+                    {text}
+                  </Text>
+                ) : (
+                  <Text key={index}>{text}</Text>
+                ),
+              )}
+            </Text>
+          ) : null}
         </TextInput>
 
         {(

--- a/src/screens/chat-screen/components/reply-box/mentions-input/utils/specs/utils.spec.ts
+++ b/src/screens/chat-screen/components/reply-box/mentions-input/utils/specs/utils.spec.ts
@@ -1,0 +1,12 @@
+import { generateValueFromPartsAndChangedText, parseValue } from '../utils';
+
+describe('mentions input utils', () => {
+  it('preserves emoji when text is typed after it', () => {
+    const emoji = '\u{1F60A}';
+    const { plainText, parts } = parseValue(emoji, []);
+
+    expect(generateValueFromPartsAndChangedText(parts, plainText, `${emoji}Hello`)).toBe(
+      `${emoji}Hello`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- avoid rendering plain composer text through nested attributed TextInput children when there are no styled mention parts
- keep the styled mention rendering path for actual mentions
- add a regression test that preserves an emoji when text is typed after it

Closes #1053

## Tests
- pnpm test src/screens/chat-screen/components/reply-box/mentions-input/utils/specs/utils.spec.ts --runInBand
- pnpm exec eslint src/screens/chat-screen/components/reply-box/mentions-input/components/mention-input.tsx src/screens/chat-screen/components/reply-box/mentions-input/utils/specs/utils.spec.ts
- git diff --check

## Notes
- Full `pnpm lint` is still blocked by unrelated existing lint/prettier issues outside this change.
- Full `pnpm exec tsc --noEmit` is still blocked by unrelated existing repo-wide type errors outside this change.