### PR TITLE
fix: handle iOS WhatsApp media attachments

### DIFF
--- a/src/hooks/useImageDimensions.ts
+++ b/src/hooks/useImageDimensions.ts
@@ -3,19 +3,28 @@ import { Image as RNImage } from 'react-native';
 
 export type ImageCellProps = {
   imageSrc: string;
+  sourceWidth?: number | null;
+  sourceHeight?: number | null;
 };
 
 export type ImageContainerProps = Pick<ImageCellProps, 'imageSrc'> & {
   maxWidth?: number;
   maxHeight?: number;
+  sourceWidth?: number | null;
+  sourceHeight?: number | null;
 };
 
 const imageDimensionsCache = new Map<string, { width: number; height: number }>();
+
+const isValidImageDimension = (dimension?: number | null) => {
+  return typeof dimension === 'number' && Number.isFinite(dimension) && dimension > 0;
+};
 
 export const useImageDimensions = (
   imageSrc: string,
   maxWidth = 300,
   maxHeight = 360,
+  sourceDimensions?: { width?: number | null; height?: number | null },
 ) => {
   const [imageDimensions, setImageDimensions] = useState<{ width: number; height: number } | null>(
     null,
@@ -23,6 +32,23 @@ export const useImageDimensions = (
 
   useEffect(() => {
     let isMounted = true;
+    const sourceWidth = sourceDimensions?.width;
+    const sourceHeight = sourceDimensions?.height;
+    const hasSourceDimensions =
+      isValidImageDimension(sourceWidth) && isValidImageDimension(sourceHeight);
+
+    if (hasSourceDimensions) {
+      const dimensions = {
+        width: sourceWidth as number,
+        height: sourceHeight as number,
+      };
+      imageDimensionsCache.set(imageSrc, dimensions);
+      setImageDimensions(dimensions);
+      return () => {
+        isMounted = false;
+      };
+    }
+
     const cachedImageDimensions = imageDimensionsCache.get(imageSrc);
 
     if (cachedImageDimensions) {
@@ -53,7 +79,7 @@ export const useImageDimensions = (
     return () => {
       isMounted = false;
     };
-  }, [imageSrc]);
+  }, [imageSrc, sourceDimensions?.height, sourceDimensions?.width]);
 
   const imageStyle = useMemo(() => {
     const fallbackHeight = Math.round(maxWidth * 0.75);

--- a/src/screens/chat-screen/components/message-components/AudioBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioBubble.tsx
@@ -16,6 +16,7 @@ import { Icon, Slider } from '@/components-next/common';
 import { Spinner } from '@/components-next/spinner';
 import { pausePlayer, resumePlayer, seekTo, startPlayer, stopPlayer } from '../audio-recorder';
 import { MESSAGE_VARIANTS } from '@/constants';
+import { isOggAudioAttachment } from '@/utils/attachmentUtils';
 import { useDispatch } from 'react-redux';
 import { useAppSelector } from '@/hooks';
 // eslint-disable-next-line import/no-unresolved
@@ -41,16 +42,18 @@ const PauseIcon = React.memo(({ fill, fillOpacity }: IconProps) => {
 
 type AudioBubbleProps = {
   audioSrc: string;
+  contentType?: string | null;
+  extension?: string | null;
   variant: string;
 };
 
-type AudioPlayerProps = Pick<AudioBubbleProps, 'audioSrc'> & {
+type AudioPlayerProps = Pick<AudioBubbleProps, 'audioSrc' | 'contentType' | 'extension'> & {
   variant: string;
 };
 
 // eslint-disable-next-line react/display-name
 export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
-  const { audioSrc, variant } = props;
+  const { audioSrc, contentType, extension, variant } = props;
 
   const [isSoundLoading, setIsSoundLoading] = useState(false);
   const [isAudioPlaying, setAudioPlaying] = useState(false);
@@ -81,10 +84,13 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
 
   useEffect(() => {
     const prepareAudio = async () => {
-      if (Platform.OS === 'ios' && audioSrc.toLowerCase().endsWith('.ogg')) {
+      if (Platform.OS === 'ios' && isOggAudioAttachment({ audioSrc, contentType, extension })) {
         setIsSoundLoading(true);
         try {
           const convertedSrc = await convertOggToWav(audioSrc);
+          if (convertedSrc instanceof Error) {
+            throw convertedSrc;
+          }
           setConvertedAudioSrc(convertedSrc);
         } catch (error) {
           Sentry.captureException(error);
@@ -94,7 +100,7 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
       }
     };
     prepareAudio();
-  }, [audioSrc]);
+  }, [audioSrc, contentType, extension]);
 
   const togglePlayback = useCallback(() => {
     if (convertedAudioSrc === currentPlayingAudioSrc) {
@@ -201,11 +207,16 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
 
 // eslint-disable-next-line react/display-name
 export const AudioBubble = React.memo<AudioBubbleProps>(props => {
-  const { audioSrc, variant } = props;
+  const { audioSrc, contentType, extension, variant } = props;
 
   return (
     <Animated.View style={tailwind.style('w-full flex flex-row items-center')}>
-      <AudioBubblePlayer audioSrc={audioSrc} variant={variant} />
+      <AudioBubblePlayer
+        audioSrc={audioSrc}
+        contentType={contentType}
+        extension={extension}
+        variant={variant}
+      />
     </Animated.View>
   );
 });

--- a/src/screens/chat-screen/components/message-components/AudioBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioBubble.tsx
@@ -83,23 +83,37 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
   );
 
   useEffect(() => {
+    let isActive = true;
+
     const prepareAudio = async () => {
-      if (Platform.OS === 'ios' && isOggAudioAttachment({ audioSrc, contentType, extension })) {
-        setIsSoundLoading(true);
-        try {
-          const convertedSrc = await convertOggToWav(audioSrc);
-          if (convertedSrc instanceof Error) {
-            throw convertedSrc;
-          }
+      setConvertedAudioSrc(audioSrc);
+
+      if (Platform.OS !== 'ios' || !isOggAudioAttachment({ audioSrc, contentType, extension })) {
+        return;
+      }
+
+      setIsSoundLoading(true);
+      try {
+        const convertedSrc = await convertOggToWav(audioSrc);
+        if (convertedSrc instanceof Error) {
+          throw convertedSrc;
+        }
+        if (isActive) {
           setConvertedAudioSrc(convertedSrc);
-        } catch (error) {
-          Sentry.captureException(error);
-        } finally {
+        }
+      } catch (error) {
+        Sentry.captureException(error);
+      } finally {
+        if (isActive) {
           setIsSoundLoading(false);
         }
       }
     };
     prepareAudio();
+
+    return () => {
+      isActive = false;
+    };
   }, [audioSrc, contentType, extension]);
 
   const togglePlayback = useCallback(() => {

--- a/src/screens/chat-screen/components/message-components/AudioBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioBubble.tsx
@@ -87,6 +87,7 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
 
     const prepareAudio = async () => {
       setConvertedAudioSrc(audioSrc);
+      setIsSoundLoading(false);
 
       if (Platform.OS !== 'ios' || !isOggAudioAttachment({ audioSrc, contentType, extension })) {
         return;

--- a/src/screens/chat-screen/components/message-components/ComposedBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/ComposedBubble.tsx
@@ -98,6 +98,8 @@ export const ComposedBubble = (props: ComposedBubbleProps) => {
                   <ImageBubbleContainer
                     imageSrc={attachment.dataUrl}
                     maxWidth={300 - 24 - (isPrivate ? 13 : 0)}
+                    sourceWidth={attachment.width}
+                    sourceHeight={attachment.height}
                   />
                 </Animated.View>
               );
@@ -139,7 +141,12 @@ export const ComposedBubble = (props: ComposedBubbleProps) => {
                 <Animated.View
                   key={attachment.fileType + index}
                   style={tailwind.style('flex flex-row items-center my-2')}>
-                  <AudioBubble audioSrc={attachment.dataUrl} variant={props.variant} />
+                  <AudioBubble
+                    audioSrc={attachment.dataUrl}
+                    contentType={attachment.contentType}
+                    extension={attachment.extension}
+                    variant={props.variant}
+                  />
                 </Animated.View>
               );
             }

--- a/src/screens/chat-screen/components/message-components/ImageBubble.android.tsx
+++ b/src/screens/chat-screen/components/message-components/ImageBubble.android.tsx
@@ -5,8 +5,11 @@ import { useImageDimensions } from '@/hooks/useImageDimensions';
 import type { ImageCellProps, ImageContainerProps } from '@/hooks/useImageDimensions';
 
 export const ImageBubbleContainer = (props: ImageContainerProps) => {
-  const { imageSrc, maxWidth = 300, maxHeight = 360 } = props;
-  const imageStyle = useImageDimensions(imageSrc, maxWidth, maxHeight);
+  const { imageSrc, maxWidth = 300, maxHeight = 360, sourceWidth, sourceHeight } = props;
+  const imageStyle = useImageDimensions(imageSrc, maxWidth, maxHeight, {
+    width: sourceWidth,
+    height: sourceHeight,
+  });
 
   return (
     <ImageModal

--- a/src/screens/chat-screen/components/message-components/ImageBubble.ios.tsx
+++ b/src/screens/chat-screen/components/message-components/ImageBubble.ios.tsx
@@ -6,8 +6,11 @@ import { useImageDimensions } from '@/hooks/useImageDimensions';
 import type { ImageCellProps, ImageContainerProps } from '@/hooks/useImageDimensions';
 
 export const ImageBubbleContainer = (props: ImageContainerProps) => {
-  const { imageSrc, maxWidth = 300, maxHeight = 360 } = props;
-  const imageStyle = useImageDimensions(imageSrc, maxWidth, maxHeight);
+  const { imageSrc, maxWidth = 300, maxHeight = 360, sourceWidth, sourceHeight } = props;
+  const imageStyle = useImageDimensions(imageSrc, maxWidth, maxHeight, {
+    width: sourceWidth,
+    height: sourceHeight,
+  });
 
   return (
     <Galeria urls={[imageSrc]}>

--- a/src/types/Message.ts
+++ b/src/types/Message.ts
@@ -33,8 +33,12 @@ export type ImageMetadata = {
   fileType: 'image' | 'video' | 'audio' | 'file' | 'ig_reel';
   accountId: number;
   extension: string | null;
+  contentType?: string | null;
   dataUrl: string;
   thumbUrl: string;
+  fileSize?: number | null;
+  width?: number | null;
+  height?: number | null;
   fallbackTitle: string;
   coordinatesLat: number;
   coordinatesLong: number;

--- a/src/utils/attachmentUtils.ts
+++ b/src/utils/attachmentUtils.ts
@@ -1,0 +1,35 @@
+type OggAudioAttachment = {
+  audioSrc: string;
+  contentType?: string | null;
+  extension?: string | null;
+};
+
+const OGG_EXTENSIONS = new Set(['ogg', 'oga', 'opus']);
+
+const extensionFromUrl = (url: string) => {
+  const path = (() => {
+    try {
+      return new URL(url).pathname;
+    } catch {
+      return url.split('?')[0].split('#')[0];
+    }
+  })();
+
+  const fileName = path.split('/').pop() || '';
+  const extension = fileName.includes('.') ? fileName.split('.').pop() : '';
+  return extension?.toLowerCase() || '';
+};
+
+export const isOggAudioAttachment = ({ audioSrc, contentType, extension }: OggAudioAttachment) => {
+  const normalizedContentType = contentType?.toLowerCase() || '';
+  const normalizedExtension = extension?.replace(/^\./, '').toLowerCase() || '';
+
+  const isOggOrOpusContentType =
+    normalizedContentType.includes('ogg') || normalizedContentType.includes('opus');
+
+  return (
+    isOggOrOpusContentType ||
+    OGG_EXTENSIONS.has(normalizedExtension) ||
+    OGG_EXTENSIONS.has(extensionFromUrl(audioSrc))
+  );
+};

--- a/src/utils/specs/attachmentUtils.spec.ts
+++ b/src/utils/specs/attachmentUtils.spec.ts
@@ -1,0 +1,55 @@
+import { isOggAudioAttachment } from '../attachmentUtils';
+
+describe('attachmentUtils', () => {
+  describe('isOggAudioAttachment', () => {
+    it('detects OGG audio from content type', () => {
+      expect(
+        isOggAudioAttachment({
+          audioSrc:
+            'https://chatwoot.example.com/rails/active_storage/blobs/redirect/token/audio-message',
+          contentType: 'audio/ogg; codecs=opus',
+        }),
+      ).toBe(true);
+    });
+
+    it('detects Opus audio from content type', () => {
+      expect(
+        isOggAudioAttachment({
+          audioSrc:
+            'https://chatwoot.example.com/rails/active_storage/blobs/redirect/token/audio-message',
+          contentType: 'audio/opus',
+        }),
+      ).toBe(true);
+    });
+
+    it('detects OGG audio from extension metadata', () => {
+      expect(
+        isOggAudioAttachment({
+          audioSrc:
+            'https://chatwoot.example.com/rails/active_storage/blobs/redirect/token/audio-message',
+          extension: 'oga',
+        }),
+      ).toBe(true);
+    });
+
+    it('detects OGG audio from redirected URL paths with query strings', () => {
+      expect(
+        isOggAudioAttachment({
+          audioSrc:
+            'https://chatwoot.example.com/rails/active_storage/blobs/redirect/token/audio.ogg?disposition=inline',
+        }),
+      ).toBe(true);
+    });
+
+    it('does not treat m4a audio as OGG audio', () => {
+      expect(
+        isOggAudioAttachment({
+          audioSrc:
+            'https://chatwoot.example.com/rails/active_storage/blobs/redirect/token/audio.m4a',
+          contentType: 'audio/mp4',
+          extension: 'm4a',
+        }),
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- use server-provided image attachment dimensions before falling back to React Native URL probing
- detect OGG/Opus audio from attachment metadata as well as URL extensions before iOS conversion
- keep failed audio conversion on the original source while reporting the conversion error

Fixes #1009

## Testing
- pnpm jest src/utils/specs/attachmentUtils.spec.ts --runInBand
- pnpm eslint src/utils/attachmentUtils.ts src/utils/specs/attachmentUtils.spec.ts src/hooks/useImageDimensions.ts src/screens/chat-screen/components/message-components/AudioBubble.tsx src/screens/chat-screen/components/message-components/ComposedBubble.tsx src/screens/chat-screen/components/message-components/ImageBubble.ios.tsx src/screens/chat-screen/components/message-components/ImageBubble.android.tsx src/types/Message.ts
- git diff --check

## Local iOS build note
- Ran Expo iOS prebuild and pod install locally. The simulator build is blocked before the app target by the generated Pods `fmt` target failing to compile under Xcode/iPhoneSimulator SDK 26.5 with `FMT_STRING` consteval errors in `format-inl.h`.
- Because of that generated Pod/toolchain failure, I could not complete a Baguette installed-app smoke test locally in this environment.