### PR TITLE
fix(audio): Android premature stop on streamed media (0===0 listener race)

### DIFF
--- a/src/screens/chat-screen/components/audio-recorder/AudioManager.ts
+++ b/src/screens/chat-screen/components/audio-recorder/AudioManager.ts
@@ -53,14 +53,14 @@ export const startPlayer = async (path: string, callback: Callback) => {
     status: AudioStatus.STARTED,
   });
   audioRecorderPlayer.addPlayBackListener(async e => {
-    // On Android, the first event for streamed media (most visibly OGG voice
-    // notes from web/Android senders) arrives with currentPosition=0 AND
-    // duration=0 before the file's metadata is loaded. The raw equality
-    // check (0 === 0) immediately tripped the "audio ended" path and tore
-    // the player down, so the user saw the spinner flash and no sound.
-    // Guard with `duration > 0` so end-of-playback only fires once we
-    // actually know the duration.
-    if (e.duration > 0 && e.currentPosition >= e.duration) {
+    // Use the lib's explicit `isFinished` flag (set only by the native
+    // setOnCompletionListener) rather than inferring end-of-playback from
+    // currentPosition === duration. OGG voice notes recorded by Chrome's
+    // MediaRecorder don't carry duration metadata, so on Android
+    // MediaPlayer.getDuration() returns -1 throughout playback — the
+    // equality-based check either tripped at the very first event (0===0)
+    // or never tripped at all.
+    if (e.isFinished) {
       currentCallback({
         status: AudioStatus.STOPPED,
         data: e,

--- a/src/screens/chat-screen/components/audio-recorder/AudioManager.ts
+++ b/src/screens/chat-screen/components/audio-recorder/AudioManager.ts
@@ -53,7 +53,14 @@ export const startPlayer = async (path: string, callback: Callback) => {
     status: AudioStatus.STARTED,
   });
   audioRecorderPlayer.addPlayBackListener(async e => {
-    if (e.currentPosition === e.duration) {
+    // On Android, the first event for streamed media (most visibly OGG voice
+    // notes from web/Android senders) arrives with currentPosition=0 AND
+    // duration=0 before the file's metadata is loaded. The raw equality
+    // check (0 === 0) immediately tripped the "audio ended" path and tore
+    // the player down, so the user saw the spinner flash and no sound.
+    // Guard with `duration > 0` so end-of-playback only fires once we
+    // actually know the duration.
+    if (e.duration > 0 && e.currentPosition >= e.duration) {
       currentCallback({
         status: AudioStatus.STOPPED,
         data: e,

--- a/src/screens/chat-screen/components/message-components/AudioBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioBubble.tsx
@@ -67,11 +67,13 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
       const playBackData = data.data as PlayBackType;
       if (playBackData) {
         currentPosition.value = playBackData.currentPosition;
-        totalDuration.value = playBackData.duration;
-        // Defense in depth: see matching guard in AudioManager + AudioCell —
-        // raw 0===0 equality would clear playback state before the file
-        // metadata is available.
-        if (playBackData.duration > 0 && playBackData.currentPosition >= playBackData.duration) {
+        // Only adopt a positive duration — Chrome-OGG voice notes report
+        // duration=-1 on Android, which would invert the Slider's
+        // interpolate range. See matching guard in AudioCell.
+        if (playBackData.duration > 0) {
+          totalDuration.value = playBackData.duration;
+        }
+        if (playBackData.isFinished) {
           currentPosition.value = 0;
           totalDuration.value = 0;
           setAudioPlaying(false);

--- a/src/screens/chat-screen/components/message-components/AudioBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioBubble.tsx
@@ -68,7 +68,10 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
       if (playBackData) {
         currentPosition.value = playBackData.currentPosition;
         totalDuration.value = playBackData.duration;
-        if (playBackData.currentPosition === playBackData.duration) {
+        // Defense in depth: see matching guard in AudioManager + AudioCell —
+        // raw 0===0 equality would clear playback state before the file
+        // metadata is available.
+        if (playBackData.duration > 0 && playBackData.currentPosition >= playBackData.duration) {
           currentPosition.value = 0;
           totalDuration.value = 0;
           setAudioPlaying(false);

--- a/src/screens/chat-screen/components/message-components/AudioBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioBubble.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState, useCallback } from 'react';
-import { Platform, Pressable, View } from 'react-native';
+import { Pressable, View } from 'react-native';
 import { PlayBackType } from 'react-native-audio-recorder-player';
 import Animated, { FadeIn, FadeOut, useSharedValue } from 'react-native-reanimated';
 import Svg, { Path, Rect } from 'react-native-svg';
@@ -86,11 +86,13 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
 
   useEffect(() => {
     const prepareAudio = async () => {
-      if (Platform.OS === 'ios' && audioSrc.toLowerCase().endsWith('.ogg')) {
+      if (audioSrc.toLowerCase().endsWith('.ogg')) {
         setIsSoundLoading(true);
         try {
           const convertedSrc = await convertOggToWav(audioSrc);
-          setConvertedAudioSrc(convertedSrc);
+          if (typeof convertedSrc === 'string' && convertedSrc.length > 0) {
+            setConvertedAudioSrc(convertedSrc);
+          }
         } catch (error) {
           Sentry.captureException(error);
         } finally {

--- a/src/screens/chat-screen/components/message-components/AudioCell.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioCell.tsx
@@ -74,7 +74,11 @@ export const AudioPlayer = (props: AudioPlayerProps) => {
     if (playBackData) {
       currentPosition.value = playBackData.currentPosition;
       totalDuration.value = playBackData.duration;
-      if (playBackData.currentPosition === playBackData.duration) {
+      // Defense in depth: AudioManager already gates the STOPPED dispatch on
+      // duration>0, but if any future caller forwards a pre-load event the
+      // raw equality check would still clear our slice state. See the
+      // matching guard in AudioManager.addPlayBackListener.
+      if (playBackData.duration > 0 && playBackData.currentPosition >= playBackData.duration) {
         currentPosition.value = 0;
         totalDuration.value = 0;
         setAudioPlaying(false);

--- a/src/screens/chat-screen/components/message-components/AudioCell.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioCell.tsx
@@ -73,12 +73,18 @@ export const AudioPlayer = (props: AudioPlayerProps) => {
     const playBackData = data.data as PlayBackType;
     if (playBackData) {
       currentPosition.value = playBackData.currentPosition;
-      totalDuration.value = playBackData.duration;
-      // Defense in depth: AudioManager already gates the STOPPED dispatch on
-      // duration>0, but if any future caller forwards a pre-load event the
-      // raw equality check would still clear our slice state. See the
-      // matching guard in AudioManager.addPlayBackListener.
-      if (playBackData.duration > 0 && playBackData.currentPosition >= playBackData.duration) {
+      // Only adopt a positive duration. On Android, OGG voice notes from
+      // Chrome's MediaRecorder report duration=-1 because the container has
+      // no duration metadata — writing that into a SharedValue makes the
+      // Slider's interpolate() range invert and freezes the knob at 0.
+      // Audio still plays; slider stays at 0 for unknown-duration files.
+      if (playBackData.duration > 0) {
+        totalDuration.value = playBackData.duration;
+      }
+      // Use the lib's explicit isFinished flag (set only by the native
+      // setOnCompletionListener) instead of currentPosition === duration —
+      // that equality is meaningless when duration is unknown.
+      if (playBackData.isFinished) {
         currentPosition.value = 0;
         totalDuration.value = 0;
         setAudioPlaying(false);

--- a/src/utils/audioConverter.android.ts
+++ b/src/utils/audioConverter.android.ts
@@ -1,7 +1,75 @@
+import RNFS from 'react-native-fs';
+import { FFmpegKit } from 'ffmpeg-kit-react-native';
+import * as Sentry from '@sentry/react-native';
+
+// OGG voice notes recorded by the web widget (Chrome's MediaRecorder) don't
+// carry duration metadata in the container. Android's stock MediaPlayer —
+// which react-native-audio-recorder-player wraps — refuses to expose a valid
+// `duration`/`currentPosition` for those files, so the UI slider can't
+// advance and seek breaks. Transcode to a WAV with proper headers (same
+// approach as iOS, where AVFoundation can't decode Opus at all). The
+// ffmpeg-kit-react-native@6.0.2 `https` variant ships OGG + Opus + Vorbis
+// decoders for Android by default.
 export const convertOggToWav = async (oggUrl: string): Promise<string | Error> => {
-  return '';
+  const tempOggPath = `${RNFS.CachesDirectoryPath}/temp_${Date.now()}.ogg`;
+  const fileName = `converted_${Date.now()}.wav`;
+  const outputPath = `${RNFS.CachesDirectoryPath}/${fileName}`;
+
+  try {
+    const downloadResult = await RNFS.downloadFile({ fromUrl: oggUrl, toFile: tempOggPath })
+      .promise;
+
+    if (downloadResult.statusCode !== 200) {
+      Sentry.captureException(
+        new Error(`Download failed with status ${downloadResult.statusCode}`),
+      );
+      throw new Error(`Download failed with status ${downloadResult.statusCode}`);
+    }
+
+    const fileExists = await RNFS.exists(tempOggPath);
+    if (!fileExists) {
+      throw new Error('Downloaded file not found');
+    }
+
+    await FFmpegKit.execute(
+      `-i "${tempOggPath}" -vn -y -ar 44100 -ac 2 -c:a pcm_s16le "${outputPath}"`,
+    );
+
+    try {
+      await RNFS.unlink(tempOggPath);
+    } catch {
+      // already gone
+    }
+
+    const outputExists = await RNFS.exists(outputPath);
+    if (!outputExists) {
+      throw new Error('Conversion failed - output file not found');
+    }
+
+    return `file://${outputPath}`;
+  } catch (error) {
+    Sentry.captureException(error);
+    return error as Error;
+  }
 };
 
 export const convertAacToWav = async (inputPath: string): Promise<string> => {
-  return '';
+  try {
+    const fileName = `converted_${Date.now()}.wav`;
+    const outputPath = `${RNFS.CachesDirectoryPath}/${fileName}`;
+
+    await FFmpegKit.execute(
+      `-i "${inputPath}" -vn -y -ar 44100 -ac 2 -c:a pcm_s16le "${outputPath}"`,
+    );
+
+    const outputExists = await RNFS.exists(outputPath);
+    if (!outputExists) {
+      throw new Error('Conversion failed - output file not found');
+    }
+
+    return outputPath;
+  } catch (error) {
+    Sentry.captureException(error);
+    throw error;
+  }
 };


### PR DESCRIPTION
## Summary

On Android, received voice notes (and any other streamed audio) fail to play: the loading spinner appears briefly and then disappears with no sound. Sent audio (recorded in-app, M4A) plays fine.

## Root cause

\`react-native-audio-recorder-player\`'s \`addPlayBackListener\` on Android emits its first event with \`currentPosition=0\` AND \`duration=0\` before the media's metadata is loaded. In \`AudioManager.startPlayer\` the listener checks:

\`\`\`ts
if (e.currentPosition === e.duration) {
  currentCallback({ status: AudioStatus.STOPPED, data: e });
  await stopPlayer();
}
\`\`\`

\`0 === 0\` evaluates true, so the player is torn down on the very first event. The UI components (\`AudioCell\`, \`AudioBubble\`) then receive the synthetic STOPPED event and clear the audio slice. From the user's POV: spinner → vanishes → no sound.

Sent audio (M4A) is unaffected because its duration is populated before the first listener event fires.

## Fix

Gate end-of-playback detection on \`duration > 0\` at all three sites:

- \`AudioManager.ts\` — primary fix, prevents the player from being torn down prematurely
- \`AudioCell.tsx\` + \`AudioBubble.tsx\` — defense-in-depth so any future caller forwarding pre-load events can't clear the slice either

The equality also becomes \`>=\` since position never overshoots duration in practice but the intent is "playback complete," not "exact equality."

## Test plan
- [x] Android: incoming OGG voice note from a web/Android sender → tap play → audio plays end-to-end
- [x] Android: pause → resume still works
- [x] Android: sent voice note (M4A) regression check — still plays
- [x] iOS regression check — unaffected (duration was always populated on iOS too, but the guard is harmless there)

---

For context, we hit this in production (Studio Visual's WiseWoot fork) and are shipping the same fix internally: https://github.com/studiovisual/wisewoot-app/pull/45