### PR TITLE
fix: Android outgoing email reply text is invisible on light background

### DIFF
--- a/src/screens/chat-screen/components/message-components/Email.tsx
+++ b/src/screens/chat-screen/components/message-components/Email.tsx
@@ -60,15 +60,12 @@ export const Email = (props: EmailProps) => {
         }
       `;
   const outgoingReadableStyle = `
+        :root {
+          color-scheme: light;
+        }
         html, body {
-          background: #ffffff !important;
-          color: #111827 !important;
-        }
-        body, p, div, span, td, th, li, h1, h2, h3, h4, h5, h6 {
-          color: #111827 !important;
-        }
-        a {
-          color: #2563eb !important;
+          background: #ffffff;
+          color: #111827;
         }
       `;
   const emailCustomStyle = isOutgoing ? `${outgoingReadableStyle}${baseStyle}` : baseStyle;

--- a/src/screens/chat-screen/components/message-components/Email.tsx
+++ b/src/screens/chat-screen/components/message-components/Email.tsx
@@ -50,6 +50,29 @@ export const Email = (props: EmailProps) => {
   const windowWidth = Dimensions.get('window').width;
   const WIDTH = windowWidth - 52; // 52 is the sum of the left and right padding (12 + 12) and avatar width (24) and gap between avatar and message (4)
 
+  const baseStyle = `
+        * {
+          font-family: system,-apple-system,".SFNSText-Regular","San Francisco",Roboto,"Segoe UI","Helvetica Neue","Lucida Grande",sans-serif;
+          font-size: 14px;
+        }
+        img{
+          max-width: 100% !important;
+        }
+      `;
+  const outgoingReadableStyle = `
+        html, body {
+          background: #ffffff !important;
+          color: #111827 !important;
+        }
+        body, p, div, span, td, th, li, h1, h2, h3, h4, h5, h6 {
+          color: #111827 !important;
+        }
+        a {
+          color: #2563eb !important;
+        }
+      `;
+  const emailCustomStyle = isOutgoing ? `${outgoingReadableStyle}${baseStyle}` : baseStyle;
+
   return (
     <Animated.View
       style={[
@@ -72,15 +95,8 @@ export const Email = (props: EmailProps) => {
           <AutoHeightWebView
             style={{ width: '100%', minHeight: 1, minWidth: '100%' }}
             scrollEnabled={false}
-            customStyle={`
-        * {
-          font-family: system,-apple-system,".SFNSText-Regular","San Francisco",Roboto,"Segoe UI","Helvetica Neue","Lucida Grande",sans-serif;
-          font-size: 14px;
-        } 
-        img{
-          max-width: 100% !important;
-        }
-      `}
+            forceDarkOn={false}
+            customStyle={emailCustomStyle}
             source={{
               html: FormattedEmail,
             }}


### PR DESCRIPTION
## Description 

Outgoing email replies rendered as white text on a white bubble on Android. Email bodies render in a native AutoHeightWebView whose customStyle never set a text color, so Android's force-dark (triggered by the device's dark mode) inverted the text to white.

Fix (Email.tsx):
  - Set forceDarkOn={false} on the WebView.
  - Inject dark text (#111827) + white background into customStyle, scoped to outgoing emails only so incoming HTML emails keep their own colors.

Fixes #1076  ([CW-7259)](https://linear.app/chatwoot/issue/CW-7259/android-outgoing-email-reply-text-is-invisible-on-light-background)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

