### PR TITLE
fix: Prevent crash in getCurrentAccount when user is null

### DIFF
--- a/src/utils/permissionUtils.ts
+++ b/src/utils/permissionUtils.ts
@@ -6,7 +6,7 @@ export const getCurrentAccount = (
   user: User = {} as User,
   accountId: number | null = null,
 ): Account | undefined => {
-  const accounts = user.accounts || [];
+  const accounts = user?.accounts || [];
   return accounts.find(account => Number(account.id) === Number(accountId));
 };
 


### PR DESCRIPTION
## Description 

Fix a year-old crash (TypeError: Cannot read property 'accounts' of null, 737 users) by using optional chaining in `getCurrentAccount`, since the `= {} as User` default doesn't catch an explicitly `null` user.

Fixes [TypeError: Cannot read property 'accounts' of null](https://chatwoot-p3.sentry.io/issues/6294784941/?project=4508442772570112&query=release.version%3A4.3.0&referrer=issue-stream&sort=freq)

Relatedf to [android-bad-behaviour-warnings](https://linear.app/chatwoot/issue/CW-7220/android-bad-behaviour-warnings)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


