### PR TITLE
fix: Prevent crash in checkServerSupport on non-semver versions

### DIFF
--- a/src/utils/serverUtils.ts
+++ b/src/utils/serverUtils.ts
@@ -31,10 +31,8 @@ export function checkServerSupport({ installedVersion, userRole }: ServerSupport
   if (!minimumVersion || !installedVersion) {
     return;
   }
-  // Coerce loose versions (e.g. 4-segment "4.11.1.004") into valid semver
-  // before comparing; semver.lt throws TypeError on non-standard strings.
-  const installedSemver = semver.coerce(installedVersion);
-  const minimumSemver = semver.coerce(minimumVersion);
+  const installedSemver = semver.valid(installedVersion) ?? semver.coerce(installedVersion);
+  const minimumSemver = semver.valid(minimumVersion) ?? semver.coerce(minimumVersion);
   if (!installedSemver || !minimumSemver) {
     return;
   }

--- a/src/utils/serverUtils.ts
+++ b/src/utils/serverUtils.ts
@@ -31,7 +31,14 @@ export function checkServerSupport({ installedVersion, userRole }: ServerSupport
   if (!minimumVersion || !installedVersion) {
     return;
   }
-  const shouldShowServerUpgradeWarning = semver.lt(installedVersion, minimumVersion);
+  // Coerce loose versions (e.g. 4-segment "4.11.1.004") into valid semver
+  // before comparing; semver.lt throws TypeError on non-standard strings.
+  const installedSemver = semver.coerce(installedVersion);
+  const minimumSemver = semver.coerce(minimumVersion);
+  if (!installedSemver || !minimumSemver) {
+    return;
+  }
+  const shouldShowServerUpgradeWarning = semver.lt(installedSemver, minimumSemver);
   if (shouldShowServerUpgradeWarning) {
     if (userRole === 'administrator') {
       Alert.alert(


### PR DESCRIPTION
## Description 

Fix `TypeError: Invalid Version in checkServerSupport `by coercing loose 4-segment server versions (e.g. `4.11.1.004`) with `semver.coerce` before comparing, instead of passing them straight to `semver.lt`.

Fixes [TypeError: Invalid Version in checkServerSupport](https://chatwoot-p3.sentry.io/issues/6227064436/?project=4508442772570112&query=release.version%3A4.3.0&referrer=issue-stream&sort=freq)

Relatedf to [android-bad-behaviour-warnings](https://linear.app/chatwoot/issue/CW-7220/android-bad-behaviour-warnings)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
