### PR TITLE
fix(analytics): Sentry AxiosError: Network Error

### DIFF
--- a/src/utils/analyticsUtils.ts
+++ b/src/utils/analyticsUtils.ts
@@ -44,6 +44,11 @@ class AnalyticsHelper {
     }
   }
 
+  // Analytics is non-critical: swallow network/request failures so a flaky
+  // connection never surfaces as an unhandled promise rejection (reported to
+  // Sentry as "AxiosError: Network Error").
+  private silenceError(): void {}
+
   private identifyUser() {
     return this.APIHelper.post('identify', {
       userId: this.user.id,
@@ -53,7 +58,7 @@ class AnalyticsHelper {
         avatar: this.user.avatar_url,
       },
       timestamp: new Date(),
-    });
+    }).catch(this.silenceError);
   }
 
   private identifyGroup() {
@@ -66,7 +71,7 @@ class AnalyticsHelper {
           name: currentAccount.name,
         },
         timestamp: new Date(),
-      });
+      }).catch(this.silenceError);
     }
   }
 
@@ -89,7 +94,7 @@ class AnalyticsHelper {
         context: {
           groupId: currentAccount ? currentAccount.id : '',
         },
-      });
+      }).catch(this.silenceError);
     }
   }
 }

--- a/src/utils/analyticsUtils.ts
+++ b/src/utils/analyticsUtils.ts
@@ -44,9 +44,7 @@ class AnalyticsHelper {
     }
   }
 
-  // Analytics is non-critical: swallow network/request failures so a flaky
-  // connection never surfaces as an unhandled promise rejection (reported to
-  // Sentry as "AxiosError: Network Error").
+  // Suppress failures: analytics is non-critical and must not throw.
   private silenceError(): void {}
 
   private identifyUser() {


### PR DESCRIPTION
## Description 

Analytics calls (track/identify) returned the raw axios promise with no .catch(), so failed June.so pings on flaky networks became unhandled rejections, flooding Sentry with ~231K `AxiosError: Network Error` events at zero user impact. Now suppressing these failures at the source since analytics is non-critical.

### Note : 
This stops the Sentry flood but doesn't make analytics delivery reliable. Failed events are intentionally dropped. The failures are inherent to mobile: each event fires an immediate POST to june.so, and iOS tears down in-flight requests when the app backgrounds (breadcrumbs show `status_code: 0` aligning with background transitions). Cancelling mid-flight wouldn't help as it still loses the event and still needs this .catch(). 

The real weakness is the hand-rolled one-POST-per-event design in `analyticsUtils.ts `(no batching, no offline queue, no retry, no flush-on-background). A robust analytics layer would buffer events locally, batch + flush them (especially flushing on the background transition), and retry with backoff.
  
If accurate event counts ever matter, the real fix is a batching/offline-queue SDK (June has no RN SDK but is Segment-compatible).

Fixes [Sentry AxiosError: Network Error](https://linear.app/chatwoot/issue/CW-7335/sentry-axioserror)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)