### PR TITLE
fix: register Android notification channel for DND and per-app sound settings

### DIFF
--- a/__mocks__/@notifee/react-native.js
+++ b/__mocks__/@notifee/react-native.js
@@ -1,1 +1,19 @@
-jest.mock('@notifee/react-native', () => require('@notifee/react-native/jest-mock'));
+// Self-contained Notifee mock.
+//
+// Notifee's official jest mock (@notifee/react-native/jest-mock) ships as
+// untransformed ES modules, which this project's Jest config does not transform,
+// so requiring it throws "Cannot use import statement outside a module". We mock
+// only the surface the app uses (see src/utils/pushUtils.ts).
+const notifee = {
+  createChannel: jest.fn(() => Promise.resolve('default')),
+  cancelAllNotifications: jest.fn(() => Promise.resolve()),
+  setBadgeCount: jest.fn(() => Promise.resolve()),
+  getBadgeCount: jest.fn(() => Promise.resolve(0)),
+  displayNotification: jest.fn(() => Promise.resolve()),
+};
+
+module.exports = {
+  __esModule: true,
+  default: notifee,
+  AndroidImportance: { NONE: 0, MIN: 1, LOW: 2, DEFAULT: 3, HIGH: 4 },
+};

--- a/app.config.ts
+++ b/app.config.ts
@@ -100,6 +100,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
         },
       ],
       './with-ffmpeg-pod.js',
+      './with-android-notification-channel.js',
     ],
     androidNavigationBar: { backgroundColor: '#ffffff' },
   };

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -5,10 +5,8 @@ module.exports = {
         android: null, // 👈 prevents Android autolinking
       },
     },
-    '@notifee/react-native': {
-      platforms: {
-        android: null, // 👈 prevents Android autolinking
-      },
-    },
+    // @notifee/react-native must autolink on Android so notifee.createChannel()
+    // has a native module to call. The channel is what makes the app appear in
+    // Do Not Disturb exceptions and per-app notification sound settings.
   },
 };

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,10 +4,17 @@ import { Alert, BackHandler } from 'react-native';
 import { PersistGate } from 'redux-persist/integration/react';
 import { store, persistor } from './store';
 import { AppNavigator } from '@/navigation';
+import { createDefaultNotificationChannel } from '@/utils/pushUtils';
 
 import i18n from '@/i18n';
 
 const Chatwoot = () => {
+  useEffect(() => {
+    // Register the Android notification channel so the app shows up in system
+    // settings like Do Not Disturb exceptions and per-app notification sounds.
+    createDefaultNotificationChannel();
+  }, []);
+
   useEffect(() => {
     BackHandler.addEventListener('hardwareBackPress', handleBackButtonClick);
     return () => {

--- a/src/utils/pushUtils.ts
+++ b/src/utils/pushUtils.ts
@@ -1,23 +1,36 @@
 import { Platform } from 'react-native';
+import notifee, { AndroidImportance } from '@notifee/react-native';
 import { NOTIFICATION_TYPES } from '@/constants';
 import { Notification } from '@/types/Notification';
 
-let notifee: typeof import('@notifee/react-native').default | undefined;
+// Android notification channel that all Chatwoot push notifications are posted to.
+// On Android 8.0+ an app only appears in system menus such as "Do Not Disturb"
+// app exceptions and per-app custom notification sounds once it has registered at
+// least one notification channel, so we create this channel on startup.
+// This id must stay in sync with the default channel declared for Firebase
+// Messaging in with-android-notification-channel.js.
+export const ANDROID_DEFAULT_CHANNEL_ID = 'default';
+export const ANDROID_DEFAULT_CHANNEL_NAME = 'Notifications';
 
-if (Platform.OS === 'ios') {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  notifee = require('@notifee/react-native')
-    .default as typeof import('@notifee/react-native').default;
-}
+export const createDefaultNotificationChannel = async () => {
+  if (Platform.OS !== 'android') {
+    return;
+  }
+  await notifee.createChannel({
+    id: ANDROID_DEFAULT_CHANNEL_ID,
+    name: ANDROID_DEFAULT_CHANNEL_NAME,
+    importance: AndroidImportance.HIGH,
+  });
+};
 
 export const clearAllDeliveredNotifications = async () => {
-  if (Platform.OS === 'ios' && notifee) {
+  if (Platform.OS === 'ios') {
     await notifee.cancelAllNotifications();
   }
 };
 
 export const updateBadgeCount = async ({ count = 0 }) => {
-  if (Platform.OS === 'ios' && count >= 0 && notifee) {
+  if (Platform.OS === 'ios' && count >= 0) {
     await notifee.setBadgeCount(count);
   }
 };

--- a/src/utils/specs/pushUtils.spec.ts
+++ b/src/utils/specs/pushUtils.spec.ts
@@ -1,5 +1,38 @@
+import { Platform } from 'react-native';
+import notifee, { AndroidImportance } from '@notifee/react-native';
 import { transformNotification } from '../camelCaseKeys';
-import { findConversationLinkFromPush, findNotificationFromFCM } from '../pushUtils';
+import {
+  ANDROID_DEFAULT_CHANNEL_ID,
+  createDefaultNotificationChannel,
+  findConversationLinkFromPush,
+  findNotificationFromFCM,
+} from '../pushUtils';
+
+describe('createDefaultNotificationChannel', () => {
+  const originalOS = Platform.OS;
+
+  afterEach(() => {
+    (Platform as { OS: string }).OS = originalOS;
+    jest.clearAllMocks();
+  });
+
+  it('creates the default channel on Android', async () => {
+    (Platform as { OS: string }).OS = 'android';
+    await createDefaultNotificationChannel();
+    expect(notifee.createChannel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: ANDROID_DEFAULT_CHANNEL_ID,
+        importance: AndroidImportance.HIGH,
+      }),
+    );
+  });
+
+  it('does not create a channel on iOS', async () => {
+    (Platform as { OS: string }).OS = 'ios';
+    await createDefaultNotificationChannel();
+    expect(notifee.createChannel).not.toHaveBeenCalled();
+  });
+});
 
 describe('findNotificationFromFCM', () => {
   it('should return notification from FCM HTTP v1 message', () => {

--- a/with-android-notification-channel.js
+++ b/with-android-notification-channel.js
@@ -1,0 +1,50 @@
+const { withAndroidManifest, createRunOncePlugin } = require('@expo/config-plugins');
+
+// Keep in sync with ANDROID_DEFAULT_CHANNEL_ID in src/utils/pushUtils.ts.
+const DEFAULT_CHANNEL_ID = 'default';
+
+// Firebase Cloud Messaging displays incoming notifications on the channel named by
+// this manifest meta-data. Without it, FCM falls back to an auto-generated
+// "Miscellaneous" channel that the app never registers, so custom sound / Do Not
+// Disturb settings made against our own channel have no effect. Pointing FCM at the
+// channel we create on startup makes those per-channel settings actually apply.
+const META_DATA_NAME = 'com.google.firebase.messaging.default_notification_channel_id';
+
+function setDefaultNotificationChannel(androidManifest) {
+  const application = androidManifest.manifest.application?.[0];
+  if (!application) {
+    return androidManifest;
+  }
+
+  application['meta-data'] = application['meta-data'] || [];
+
+  const existing = application['meta-data'].find(
+    item => item.$?.['android:name'] === META_DATA_NAME,
+  );
+
+  if (existing) {
+    existing.$['android:value'] = DEFAULT_CHANNEL_ID;
+  } else {
+    application['meta-data'].push({
+      $: {
+        'android:name': META_DATA_NAME,
+        'android:value': DEFAULT_CHANNEL_ID,
+      },
+    });
+  }
+
+  return androidManifest;
+}
+
+const withAndroidNotificationChannel = config => {
+  return withAndroidManifest(config, cfg => {
+    cfg.modResults = setDefaultNotificationChannel(cfg.modResults);
+    return cfg;
+  });
+};
+
+module.exports = createRunOncePlugin(
+  withAndroidNotificationChannel,
+  'with-android-notification-channel',
+  '1.0.0',
+);


### PR DESCRIPTION
## Description

On Android 8.0+ (API 26), an app only appears in system notification menus — **Do Not Disturb → App exceptions** and **per-app custom notification sounds** — once it has registered at least one **notification channel**.

Chatwoot loaded Notifee only on iOS (`pushUtils.ts`), so **no notification channel was ever created on Android**. As a result the app is missing from both of those system pickers, and Firebase Messaging falls back to an auto-generated channel the app doesn't own — so any per-app sound / DND override has nothing stable to attach to.

This PR registers a notification channel on Android at startup and points Firebase Messaging at it.

Fixes #1091

### Changes
- **`src/utils/pushUtils.ts`** — load Notifee on both platforms and add `createDefaultNotificationChannel()`, which creates a `default` channel with `AndroidImportance.HIGH` on Android.
- **`src/app.tsx`** — call `createDefaultNotificationChannel()` once on app startup, so the channel exists from first launch and the app shows up in the system menus.
- **`with-android-notification-channel.js`** (new Expo config plugin, mirroring `with-ffmpeg-pod.js`) — sets the `com.google.firebase.messaging.default_notification_channel_id` manifest meta-data so FCM-displayed notifications route to our channel, making the per-channel sound/DND settings actually take effect.
- **`__mocks__/@notifee/react-native.js`** — replaced with a self-contained mock. Notifee's official `jest-mock` ships untransformed ESM that this project's Jest config doesn't transform; it was never exercised before because Notifee was iOS-gated. Now that Notifee loads on Android too (and through the store in tests), the mock needs to be loadable.
- **`src/utils/specs/pushUtils.spec.ts`** — tests for `createDefaultNotificationChannel`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `pnpm exec jest` — full suite green (40 suites, 184 tests).
- `tsc --noEmit` — no new type errors introduced (74 pre-existing before and after this change).
- ⚠️ **Not yet verified on a physical Android build/device.** The channel-creation logic and config-plugin manifest change should be confirmed on-device: after install, Chatwoot should appear under Settings → Notifications → Do Not Disturb app exceptions and per-app sound selection. Help validating on-device is welcome.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested in both Android and iOS platform
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
