### PR TITLE
feat: send X-Chatwoot-* device metadata headers on every API request

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "expo-av": "~15.1.7",
     "expo-build-properties": "~0.14.8",
     "expo-constants": "^17.1.8",
+    "expo-device": "~7.1.4",
     "expo-file-system": "~18.1.11",
     "expo-font": "~13.3.2",
     "expo-haptics": "~14.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       expo-constants:
         specifier: ^17.1.8
         version: 17.1.8(expo@53.0.27(@babel/core@7.27.1)(react-native-webview@13.13.5(react-native@0.79.6(@babel/core@7.27.1)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.27.1)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.27.1)(@types/react@19.0.14)(react@19.0.0))
+      expo-device:
+        specifier: ~7.1.4
+        version: 7.1.4(expo@53.0.27(@babel/core@7.27.1)(react-native-webview@13.13.5(react-native@0.79.6(@babel/core@7.27.1)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.27.1)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))
       expo-file-system:
         specifier: ~18.1.11
         version: 18.1.11(expo@53.0.27(@babel/core@7.27.1)(react-native-webview@13.13.5(react-native@0.79.6(@babel/core@7.27.1)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.27.1)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.27.1)(@types/react@19.0.14)(react@19.0.0))
@@ -2057,6 +2060,7 @@ packages:
 
   '@react-navigation/bottom-tabs@6.6.1':
     resolution: {integrity: sha512-9oD4cypEBjPuaMiu9tevWGiQ4w/d6l3HNhcJ1IjXZ24xvYDSs0mqjUcdt8SWUolCvRrYc/DmNBLlT83bk0bHTw==}
+    deprecated: This version is no longer supported
     peerDependencies:
       '@react-navigation/native': ^6.0.0
       react: '*'
@@ -2066,11 +2070,13 @@ packages:
 
   '@react-navigation/core@6.4.17':
     resolution: {integrity: sha512-Nd76EpomzChWAosGqWOYE3ItayhDzIEzzZsT7PfGcRFDgW5miHV2t4MZcq9YIK4tzxZjVVpYbIynOOQQd1e0Cg==}
+    deprecated: This version is no longer supported
     peerDependencies:
       react: '*'
 
   '@react-navigation/elements@1.3.31':
     resolution: {integrity: sha512-bUzP4Awlljx5RKEExw8WYtif8EuQni2glDaieYROKTnaxsu9kEIA515sXQgUDZU4Ob12VoL7+z70uO3qrlfXcQ==}
+    deprecated: This version is no longer supported
     peerDependencies:
       '@react-navigation/native': ^6.0.0
       react: '*'
@@ -2088,12 +2094,14 @@ packages:
 
   '@react-navigation/native@6.1.18':
     resolution: {integrity: sha512-mIT9MiL/vMm4eirLcmw2h6h/Nm5FICtnYSdohq4vTLA2FF/6PNhByM7s8ffqoVfE5L0uAa6Xda1B7oddolUiGg==}
+    deprecated: This version is no longer supported
     peerDependencies:
       react: '*'
       react-native: '*'
 
   '@react-navigation/routers@6.1.9':
     resolution: {integrity: sha512-lTM8gSFHSfkJvQkxacGM6VJtBt61ip2XO54aNfswD+KMw6eeZ4oehl7m0me3CR9hnDE4+60iAZR8sAhvCiI3NA==}
+    deprecated: This version is no longer supported
 
   '@reduxjs/toolkit@2.7.0':
     resolution: {integrity: sha512-XVwolG6eTqwV0N8z/oDlN93ITCIGIop6leXlGJI/4EKy+0POYkR+ABHRSdGXY+0MQvJBP8yAzh+EYFxTuvmBiQ==}
@@ -2487,6 +2495,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-darwin-arm64@1.7.2':
     resolution: {integrity: sha512-vxtBno4xvowwNmO/ASL0Y45TpHqmNkAaDtz4Jqb+clmcVSSl8XCG/PNFFkGsXXXS6AMjP+ja/TtNCFFa1QwLRg==}
@@ -3647,6 +3656,11 @@ packages:
 
   expo-crypto@14.1.5:
     resolution: {integrity: sha512-ZXJoUMoUeiMNEoSD4itItFFz3cKrit6YJ/BR0hjuwNC+NczbV9rorvhvmeJmrU9O2cFQHhJQQR1fjQnt45Vu4Q==}
+    peerDependencies:
+      expo: '*'
+
+  expo-device@7.1.4:
+    resolution: {integrity: sha512-HS04IiE1Fy0FRjBLurr9e5A6yj3kbmQB+2jCZvbSGpsjBnCLdSk/LCii4f5VFhPIBWJLyYuN5QqJyEAw6BcS4Q==}
     peerDependencies:
       expo: '*'
 
@@ -6125,6 +6139,10 @@ packages:
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  ua-parser-js@0.7.41:
+    resolution: {integrity: sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg==}
     hasBin: true
 
   uc.micro@1.0.6:
@@ -10598,6 +10616,11 @@ snapshots:
       base64-js: 1.5.1
       expo: 53.0.27(@babel/core@7.27.1)(react-native-webview@13.13.5(react-native@0.79.6(@babel/core@7.27.1)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.27.1)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
 
+  expo-device@7.1.4(expo@53.0.27(@babel/core@7.27.1)(react-native-webview@13.13.5(react-native@0.79.6(@babel/core@7.27.1)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.27.1)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)):
+    dependencies:
+      expo: 53.0.27(@babel/core@7.27.1)(react-native-webview@13.13.5(react-native@0.79.6(@babel/core@7.27.1)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.27.1)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      ua-parser-js: 0.7.41
+
   expo-file-system@18.1.11(expo@53.0.27(@babel/core@7.27.1)(react-native-webview@13.13.5(react-native@0.79.6(@babel/core@7.27.1)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.27.1)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.27.1)(@types/react@19.0.14)(react@19.0.0)):
     dependencies:
       expo: 53.0.27(@babel/core@7.27.1)(react-native-webview@13.13.5(react-native@0.79.6(@babel/core@7.27.1)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.27.1)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
@@ -13518,6 +13541,8 @@ snapshots:
       reflect.getprototypeof: 1.0.10
 
   typescript@5.8.3: {}
+
+  ua-parser-js@0.7.41: {}
 
   uc.micro@1.0.6: {}
 

--- a/src/services/APIService.ts
+++ b/src/services/APIService.ts
@@ -4,6 +4,9 @@ import axios, {
   AxiosError,
   InternalAxiosRequestConfig,
 } from 'axios';
+import Constants from 'expo-constants';
+import * as Device from 'expo-device';
+import { Platform } from 'react-native';
 
 import { getStore } from '@/store/storeAccessor';
 import I18n from '@/i18n';
@@ -16,11 +19,29 @@ const nonAccountRoutes = [
   'profile/set_active_account',
 ];
 
+const CLIENT_NAME = 'Chatwoot Mobile';
+const CLIENT_VERSION = Constants.expoConfig?.version ?? 'unknown';
+
+function deviceHeaders(): Record<string, string> {
+  const platform = Platform.OS;
+  const osVersion = String(Device.osVersion ?? Platform.Version);
+  const model = Device.modelName ?? 'Unknown';
+  return {
+    'X-Chatwoot-Client-Name': CLIENT_NAME,
+    'X-Chatwoot-Client-Version': CLIENT_VERSION,
+    'X-Chatwoot-Platform': platform,
+    'X-Chatwoot-Platform-Version': osVersion,
+    'X-Chatwoot-Device-Model': model,
+    'User-Agent': `${CLIENT_NAME}/${CLIENT_VERSION} (${platform} ${osVersion}; ${model})`,
+  };
+}
+
 class APIService {
   private static instance: APIService;
   private api = axios.create();
 
   private constructor() {
+    Object.assign(this.api.defaults.headers.common, deviceHeaders());
     this.setupInterceptors();
   }
 


### PR DESCRIPTION
## Description

Phase 2 mobile half of [INF-75](https://linear.app/chatwoot/issue/INF-75). The backend half is [chatwoot/chatwoot#14762](https://github.com/chatwoot/chatwoot/pull/14762) (independent merge order, that PR is a no-op until this one ships).

The Chatwoot dashboard's Active Sessions UI was rendering every mobile login as "Unknown Device" because the only User-Agent the React Native HTTP client sends is opaque to the backend's UA parser (`okhttp/x.y.z` on Android, `Chatwoot/<build> CFNetwork/...` on iOS). Sentry already side-steps the same problem by sending structured device context in the event JSON body via `@sentry/react-native`. This change does the equivalent for the backend's session tracking.

The axios singleton in \`APIService\` now populates these five custom headers on every request, plus a readable User-Agent for log/Sentry readability:

| Header | Source |
|---|---|
| \`X-Chatwoot-Client-Name\` | constant \`'Chatwoot Mobile'\` |
| \`X-Chatwoot-Client-Version\` | \`Constants.expoConfig?.version\` (\`expo-constants\`) |
| \`X-Chatwoot-Platform\` | \`Platform.OS\` (\`ios\` / \`android\`) |
| \`X-Chatwoot-Platform-Version\` | \`Device.osVersion\` (\`expo-device\`) |
| \`X-Chatwoot-Device-Model\` | \`Device.modelName\` (\`expo-device\`) |

Adds the \`expo-device\` dependency (\`~7.1.4\`, SDK 53 compatible). The backend reads these headers and maps them into the \`user_sessions\` row, so the dashboard renders e.g. \`Chatwoot Mobile 4.7.0 on Pixel 7 Pro\` instead of the Phase 1 floor of \`Chatwoot Mobile on Android\`. Older builds without this change keep falling back to the Phase 1 UA pattern (\`okhttp/*\`, \`Chatwoot/*CFNetwork*Darwin\`) → \`Chatwoot Mobile on Android/iPhone\`.

Fixes INF-75.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

The change is a 6-line constant builder + an \`Object.assign\` on axios defaults, so there is nothing meaningful to unit test without exercising the native networking layer. Once this PR is built into an internal release, smoke test by logging in and checking the Active Sessions list in the dashboard renders \`Chatwoot Mobile <version> on <model>\` instead of \`Unknown Device\` or \`Chatwoot Mobile on Android/iPhone\`.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested in both Android and iOS platform
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules