### PR TITLE
fix: macro names invisible on Android by pinning explicit text color

### DIFF
--- a/src/screens/chat-screen/components/macros/MacroDetails.tsx
+++ b/src/screens/chat-screen/components/macros/MacroDetails.tsx
@@ -82,7 +82,9 @@ const MacroDetails = ({ macro, onBack, onClose }: MacroDetailsProps) => {
       <View style={tailwind.style('flex-row items-center p-4')}>
         <Pressable onPress={onBack} style={tailwind.style('flex-1 flex-row items-center')}>
           <Icon icon={<ChevronLeft />} size={18} style={tailwind.style('mr-1')} />
-          <Animated.Text style={tailwind.style('flex-1 text-base')} numberOfLines={1}>
+          <Animated.Text
+            style={tailwind.style('flex-1 text-base text-gray-950')}
+            numberOfLines={1}>
             {macro.name}
           </Animated.Text>
         </Pressable>
@@ -124,7 +126,9 @@ const MacroDetails = ({ macro, onBack, onClose }: MacroDetailsProps) => {
                   'absolute left-0 top-[2px] w-3 h-3 rounded-full bg-gray-300 border-2 border-gray-300',
                 )}
               />
-              <Animated.Text style={tailwind.style('mb-1')}>{action.actionName}</Animated.Text>
+              <Animated.Text style={tailwind.style('mb-1 text-gray-950')}>
+                {action.actionName}
+              </Animated.Text>
               <Animated.Text style={tailwind.style('text-sm text-gray-900')}>
                 {action.actionValue}
               </Animated.Text>

--- a/src/screens/chat-screen/components/macros/MacroItem.tsx
+++ b/src/screens/chat-screen/components/macros/MacroItem.tsx
@@ -51,7 +51,9 @@ const MacroItem = (props: MacroItemProps) => {
           )}>
           <Animated.View>
             <Animated.Text
-              style={tailwind.style('font-inter-420-20 leading-[22px] tracking-[0.16px] ')}>
+              style={tailwind.style(
+                'text-gray-950 font-inter-420-20 leading-[22px] tracking-[0.16px]',
+              )}>
               {macro.name}
             </Animated.Text>
           </Animated.View>


### PR DESCRIPTION
## Description 

Macro names rendered blank on Android for some users (icons showed, text didn't). 
**Assumption**: the name `<Text>` had no explicit color and inherited the `DayNight` theme default, which blended into the white sheet.
Pinned `text-gray-950` on the macro name (list + detail) and the detail action name so they render consistently across platforms and themes. 
Needs verification on the reporter's device since the exact trigger couldn't be reproduced locally.

Fixes [CW-7429](https://linear.app/chatwoot/issue/CW-7429/macros-name-are-not-displayed-in-app)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
