### PR TITLE
fix: enable scrolling in conversation inbox filter bottom sheet

### DIFF
--- a/src/screens/conversations/ConversationScreen.tsx
+++ b/src/screens/conversations/ConversationScreen.tsx
@@ -1,5 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, AppState, RefreshControl, StatusBar } from 'react-native';
+import {
+  ActivityIndicator,
+  AppState,
+  RefreshControl,
+  StatusBar,
+  useWindowDimensions,
+} from 'react-native';
 import Animated, {
   LinearTransition,
   runOnJS,
@@ -294,6 +300,10 @@ const ConversationScreen = () => {
     dispatch(resetActionState());
   };
 
+  const { height: windowHeight } = useWindowDimensions();
+  // Cap the inbox sheet at 70% of the screen; it sizes to content below that.
+  const inboxSheetMaxHeight = Math.round(windowHeight * 0.7);
+
   const filterSnapPoints = useMemo(() => {
     switch (currentBottomSheet) {
       case 'status':
@@ -302,8 +312,10 @@ const ConversationScreen = () => {
         return [200];
       case 'assignee_type':
         return [200];
+      // Inbox list uses dynamic sizing (see maxDynamicContentSize) so the sheet
+      // hugs a short list and caps at 70% for a long, scrollable one.
       case 'inbox_id':
-        return ['70%'];
+        return undefined;
       default:
         return [250];
     }
@@ -330,13 +342,19 @@ const ConversationScreen = () => {
           animationConfigs={animationConfigs}
           enablePanDownToClose
           snapPoints={filterSnapPoints}
+          maxDynamicContentSize={
+            currentBottomSheet === 'inbox_id' ? inboxSheetMaxHeight : undefined
+          }
           onDismiss={handleOnDismiss}>
-          <BottomSheetWrapper>
-            {currentBottomSheet === 'status' ? <StatusFilters /> : null}
-            {currentBottomSheet === 'sort_by' ? <SortByFilters /> : null}
-            {currentBottomSheet === 'assignee_type' ? <AssigneeTypeFilters /> : null}
-            {currentBottomSheet === 'inbox_id' ? <InboxFilters /> : null}
-          </BottomSheetWrapper>
+          {currentBottomSheet === 'inbox_id' ? (
+            <InboxFilters />
+          ) : (
+            <BottomSheetWrapper>
+              {currentBottomSheet === 'status' ? <StatusFilters /> : null}
+              {currentBottomSheet === 'sort_by' ? <SortByFilters /> : null}
+              {currentBottomSheet === 'assignee_type' ? <AssigneeTypeFilters /> : null}
+            </BottomSheetWrapper>
+          )}
         </BottomSheetModal>
         <ActionBottomSheet />
         <ActionTabs />

--- a/src/screens/conversations/ConversationScreen.tsx
+++ b/src/screens/conversations/ConversationScreen.tsx
@@ -331,12 +331,15 @@ const ConversationScreen = () => {
           enablePanDownToClose
           snapPoints={filterSnapPoints}
           onDismiss={handleOnDismiss}>
-          <BottomSheetWrapper>
-            {currentBottomSheet === 'status' ? <StatusFilters /> : null}
-            {currentBottomSheet === 'sort_by' ? <SortByFilters /> : null}
-            {currentBottomSheet === 'assignee_type' ? <AssigneeTypeFilters /> : null}
-            {currentBottomSheet === 'inbox_id' ? <InboxFilters /> : null}
-          </BottomSheetWrapper>
+          {currentBottomSheet === 'inbox_id' ? (
+            <InboxFilters />
+          ) : (
+            <BottomSheetWrapper>
+              {currentBottomSheet === 'status' ? <StatusFilters /> : null}
+              {currentBottomSheet === 'sort_by' ? <SortByFilters /> : null}
+              {currentBottomSheet === 'assignee_type' ? <AssigneeTypeFilters /> : null}
+            </BottomSheetWrapper>
+          )}
         </BottomSheetModal>
         <ActionBottomSheet />
         <ActionTabs />

--- a/src/screens/conversations/components/conversation-filters/InboxFilters.tsx
+++ b/src/screens/conversations/components/conversation-filters/InboxFilters.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Pressable } from 'react-native';
 import Animated from 'react-native-reanimated';
+import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 
 import { useRefsContext } from '@/context';
 import { TickIcon } from '@/svg-icons';
@@ -62,26 +63,6 @@ const InboxCell = (props: InboxCellProps) => {
   );
 };
 
-type InboxStackProps = {
-  list: { id: number; name: string; channelType: Channel; medium: string }[];
-};
-
-const InboxStack = (props: InboxStackProps) => {
-  const { list } = props;
-  return (
-    <Animated.ScrollView
-      style={tailwind.style('pl-3 pb-4')}
-      bounces={false}
-      showsVerticalScrollIndicator={true}
-      scrollEventThrottle={16}
-      nestedScrollEnabled={true}>
-      {list.map((value, index) => (
-        <InboxCell key={index} {...{ value, index, isLastItem: index === list.length - 1 }} />
-      ))}
-    </Animated.ScrollView>
-  );
-};
-
 export const InboxFilters = () => {
   const inboxes = useAppSelector(selectAllInboxes);
   const inboxList = [
@@ -104,13 +85,21 @@ export const InboxFilters = () => {
   }));
 
   return (
-    <Animated.ScrollView
-      bounces={false}
-      showsVerticalScrollIndicator={true}
-      scrollEventThrottle={16}
-      nestedScrollEnabled={true}>
-      <BottomSheetHeader headerText={i18n.t('CONVERSATION.FILTERS.INBOX.TITLE')} />
-      <InboxStack list={inboxList} />
-    </Animated.ScrollView>
+    <BottomSheetScrollView
+      contentContainerStyle={tailwind.style('pb-4')}
+      stickyHeaderIndices={[0]}
+      showsVerticalScrollIndicator={true}>
+      <Animated.View style={tailwind.style('bg-white pb-3')}>
+        <BottomSheetHeader headerText={i18n.t('CONVERSATION.FILTERS.INBOX.TITLE')} />
+      </Animated.View>
+      <Animated.View style={tailwind.style('pl-3')}>
+        {inboxList.map((value, index) => (
+          <InboxCell
+            key={index}
+            {...{ value, index, isLastItem: index === inboxList.length - 1 }}
+          />
+        ))}
+      </Animated.View>
+    </BottomSheetScrollView>
   );
 };

--- a/src/screens/conversations/components/conversation-filters/InboxFilters.tsx
+++ b/src/screens/conversations/components/conversation-filters/InboxFilters.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Pressable } from 'react-native';
 import Animated from 'react-native-reanimated';
+import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 
 import { useRefsContext } from '@/context';
 import { TickIcon } from '@/svg-icons';
@@ -62,26 +63,6 @@ const InboxCell = (props: InboxCellProps) => {
   );
 };
 
-type InboxStackProps = {
-  list: { id: number; name: string; channelType: Channel; medium: string }[];
-};
-
-const InboxStack = (props: InboxStackProps) => {
-  const { list } = props;
-  return (
-    <Animated.ScrollView
-      style={tailwind.style('pl-3 pb-4')}
-      bounces={false}
-      showsVerticalScrollIndicator={true}
-      scrollEventThrottle={16}
-      nestedScrollEnabled={true}>
-      {list.map((value, index) => (
-        <InboxCell key={index} {...{ value, index, isLastItem: index === list.length - 1 }} />
-      ))}
-    </Animated.ScrollView>
-  );
-};
-
 export const InboxFilters = () => {
   const inboxes = useAppSelector(selectAllInboxes);
   const inboxList = [
@@ -104,13 +85,19 @@ export const InboxFilters = () => {
   }));
 
   return (
-    <Animated.ScrollView
-      bounces={false}
-      showsVerticalScrollIndicator={true}
-      scrollEventThrottle={16}
-      nestedScrollEnabled={true}>
+    <>
       <BottomSheetHeader headerText={i18n.t('CONVERSATION.FILTERS.INBOX.TITLE')} />
-      <InboxStack list={inboxList} />
-    </Animated.ScrollView>
+      <BottomSheetScrollView
+        style={tailwind.style('pl-3')}
+        contentContainerStyle={tailwind.style('pb-4')}
+        showsVerticalScrollIndicator={true}>
+        {inboxList.map((value, index) => (
+          <InboxCell
+            key={index}
+            {...{ value, index, isLastItem: index === inboxList.length - 1 }}
+          />
+        ))}
+      </BottomSheetScrollView>
+    </>
   );
 };


### PR DESCRIPTION
## Description 

The inbox filter bottom sheet on the conversations page didn't scroll with many inboxes (~20+), the list was clipped at ~18 entries.

**Cause:** the list used a reanimated `Animated.ScrollView` inside gorhom's non-scrolling `BottomSheetView`, which clips instead of scrolling.

**Fix:** switched to `BottomSheetScrollView` and rendered it directly in the sheet (not wrapped in `BottomSheetWrapper`).


| Before | After |
| :---: | :---: |
| <video src="https://github.com/user-attachments/assets/d14b1458-eaed-435d-8002-d33550838cb8" width="300" controls></video> | <video src="https://github.com/user-attachments/assets/f3b58d5e-5aa5-4477-9fcc-99c3d33e4af4" width="300" controls></video> |

Fixes [CW-7518](https://linear.app/chatwoot/issue/CW-7518/scroll-issue-in-conversation-page-inbox-filter-bottom-sheet)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

