### PR TITLE
fix: make conversations header title responsive across languages 

### DIFF
--- a/src/screens/conversations/components/conversation-header/ConversationHeaderPresenter.tsx
+++ b/src/screens/conversations/components/conversation-header/ConversationHeaderPresenter.tsx
@@ -39,8 +39,9 @@ type RightSectionProps = {
 };
 
 const HeaderTitle = () => (
-  <Animated.View style={tailwind.style('flex-1')}>
+  <Animated.View style={tailwind.style('flex-2')}>
     <Text
+      numberOfLines={1}
       style={tailwind.style(
         'text-[17px] font-inter-medium-24 tracking-[0.32px] leading-[17px] text-center text-gray-950',
       )}>

--- a/src/screens/conversations/components/conversation-header/ConversationHeaderPresenter.tsx
+++ b/src/screens/conversations/components/conversation-header/ConversationHeaderPresenter.tsx
@@ -39,8 +39,9 @@ type RightSectionProps = {
 };
 
 const HeaderTitle = () => (
-  <Animated.View style={tailwind.style('flex-1')}>
+  <Animated.View style={tailwind.style('flex-[2]')}>
     <Text
+      numberOfLines={1}
       style={tailwind.style(
         'text-[17px] font-inter-medium-24 tracking-[0.32px] leading-[17px] text-center text-gray-950',
       )}>


### PR DESCRIPTION
## Description 

The "Conversations" list header title wrapped or overflowed in longer languages (German, Spanish, Vietnamese). The title had no `numberOfLines` and was boxed into ~1/3 of the row by three equal `flex-1` columns.

- Added `numberOfLines={1}` so it truncates with an ellipsis instead of wrapping (matches `ChatHeader`).
- Bumped the title column to `flex-[2]` so it gets ~half the row while staying centered.

Verified on-device across languages and in the Filter/Select header states.

| Before | After |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/a42ab723-c360-4822-91a6-0960f8c28d7d" width="300"/> | <img src="https://github.com/user-attachments/assets/13d14465-c9aa-41c1-9714-a5bbb92f7ad6" width="300"/> |

Fixes [CW-4036](https://linear.app/chatwoot/issue/CW-4036/conversation-title-is-not-responsive-in-other-languages)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
