### PR TITLE
fix: audio player duration/progress and smoother slider

### DIFF
--- a/src/components-next/common/audio-timer/AudioTimer.tsx
+++ b/src/components-next/common/audio-timer/AudioTimer.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { TextInput } from 'react-native';
+import Animated, { SharedValue, useAnimatedProps, useDerivedValue } from 'react-native-reanimated';
+
+import { tailwind } from '@/theme';
+
+const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
+
+const formatTime = (milliseconds: number) => {
+  'worklet';
+  if (!milliseconds || isNaN(milliseconds) || milliseconds < 0) {
+    return '00:00';
+  }
+  const totalSeconds = Math.floor(milliseconds / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  const pad = (value: number) => (value < 10 ? `0${value}` : `${value}`);
+  return `${pad(minutes)}:${pad(seconds)}`;
+};
+
+type AudioTimerProps = {
+  currentPosition: SharedValue<number>;
+  totalDuration: SharedValue<number>;
+  textColor: string;
+};
+
+export const AudioTimer = ({ currentPosition, totalDuration, textColor }: AudioTimerProps) => {
+  const text = useDerivedValue(
+    () => `${formatTime(currentPosition.value)} / ${formatTime(totalDuration.value)}`,
+  );
+
+  // `text` is a native TextInput prop that is not part of the public prop types,
+  // so it is applied through animatedProps to update on the UI thread.
+  const animatedProps = useAnimatedProps(() => ({ text: text.value }) as object);
+
+  return (
+    <AnimatedTextInput
+      editable={false}
+      underlineColorAndroid="transparent"
+      value={text.value}
+      animatedProps={animatedProps}
+      style={tailwind.style(
+        'p-0 text-xs font-inter-420-20 tracking-[0.32px] leading-[14px]',
+        textColor,
+      )}
+    />
+  );
+};

--- a/src/components-next/common/audio-timer/AudioTimer.tsx
+++ b/src/components-next/common/audio-timer/AudioTimer.tsx
@@ -29,8 +29,6 @@ export const AudioTimer = ({ currentPosition, totalDuration, textColor }: AudioT
     () => `${formatTime(currentPosition.value)} / ${formatTime(totalDuration.value)}`,
   );
 
-  // `text` is a native TextInput prop that is not part of the public prop types,
-  // so it is applied through animatedProps to update on the UI thread.
   const animatedProps = useAnimatedProps(() => ({ text: text.value }) as object);
 
   return (

--- a/src/components-next/common/audio-timer/index.ts
+++ b/src/components-next/common/audio-timer/index.ts
@@ -1,0 +1,1 @@
+export * from './AudioTimer';

--- a/src/components-next/common/index.ts
+++ b/src/components-next/common/index.ts
@@ -1,3 +1,4 @@
+export * from './audio-timer';
 export * from './avatar';
 export * from './bottomsheet';
 export * from './filters';

--- a/src/components-next/common/slider/Slider.tsx
+++ b/src/components-next/common/slider/Slider.tsx
@@ -3,6 +3,7 @@ import { LayoutChangeEvent, StyleSheet } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   clamp,
+  Easing,
   Extrapolation,
   interpolate,
   runOnJS,
@@ -11,6 +12,7 @@ import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withSpring,
+  withTiming,
   WithSpringConfig,
 } from 'react-native-reanimated';
 
@@ -21,6 +23,11 @@ const DefaultSpringConfig: WithSpringConfig = {
   damping: 18,
   stiffness: 280,
 };
+
+// Length of the linear tween between playback samples. Matches the player's
+// subscription interval (setSubscriptionDuration in AudioManager) so the knob
+// glides continuously from one sample to the next.
+const PROGRESS_TWEEN_DURATION = 100;
 
 type SliderProps = {
   currentPosition: SharedValue<number>;
@@ -54,13 +61,21 @@ export const Slider = (props: SliderProps) => {
   useAnimatedReaction(
     () => currentPosition.value,
     (next, _prev) => {
-      translationX.value = withSpring(
-        interpolate(next, [0, totalDuration.value], [0, sliderMaxWidth.value - 16]),
-        {
-          damping: 24,
-          stiffness: 200,
-        },
-      );
+      // Guard against a zero/unknown duration (e.g. some Android voice notes),
+      // which would make the interpolation input range degenerate.
+      const target =
+        totalDuration.value > 0
+          ? interpolate(
+              next,
+              [0, totalDuration.value],
+              [0, sliderMaxWidth.value - 16],
+              Extrapolation.CLAMP,
+            )
+          : 0;
+      translationX.value = withTiming(target, {
+        duration: PROGRESS_TWEEN_DURATION,
+        easing: Easing.linear,
+      });
     },
     [],
   );
@@ -104,9 +119,16 @@ export const Slider = (props: SliderProps) => {
     [],
   );
 
-  const animatedFilledTrack = useAnimatedStyle(() => ({
-    width: translationX.value + 8,
-  }));
+  // Scale a full-width bar from its left edge instead of animating `width`, so
+  // the fill is composited on the UI thread without triggering a layout pass.
+  const animatedFilledTrack = useAnimatedStyle(() => {
+    const maxWidth = sliderMaxWidth.value;
+    return {
+      width: maxWidth,
+      transformOrigin: 'left',
+      transform: [{ scaleX: maxWidth > 0 ? (translationX.value + 8) / maxWidth : 0 }],
+    };
+  });
 
   return (
     <Animated.View style={tailwind.style('flex flex-row flex-1 mx-1.5')}>
@@ -115,10 +137,7 @@ export const Slider = (props: SliderProps) => {
         style={tailwind.style('relative rounded-2xl flex-1 h-1', trackColor)}
       />
       <Animated.View
-        style={[
-          tailwind.style('absolute rounded-2xl flex-1 w-1/2 h-1', filledTrackColor),
-          animatedFilledTrack,
-        ]}
+        style={[tailwind.style('absolute rounded-2xl h-1', filledTrackColor), animatedFilledTrack]}
       />
       <GestureDetector gesture={panGesture}>
         <Animated.View

--- a/src/components-next/common/slider/Slider.tsx
+++ b/src/components-next/common/slider/Slider.tsx
@@ -24,9 +24,6 @@ const DefaultSpringConfig: WithSpringConfig = {
   stiffness: 280,
 };
 
-// Length of the linear tween between playback samples. Matches the player's
-// subscription interval (setSubscriptionDuration in AudioManager) so the knob
-// glides continuously from one sample to the next.
 const PROGRESS_TWEEN_DURATION = 100;
 
 type SliderProps = {
@@ -61,8 +58,6 @@ export const Slider = (props: SliderProps) => {
   useAnimatedReaction(
     () => currentPosition.value,
     (next, _prev) => {
-      // Guard against a zero/unknown duration (e.g. some Android voice notes),
-      // which would make the interpolation input range degenerate.
       const target =
         totalDuration.value > 0
           ? interpolate(
@@ -119,8 +114,6 @@ export const Slider = (props: SliderProps) => {
     [],
   );
 
-  // Scale a full-width bar from its left edge instead of animating `width`, so
-  // the fill is composited on the UI thread without triggering a layout pass.
   const animatedFilledTrack = useAnimatedStyle(() => {
     const maxWidth = sliderMaxWidth.value;
     return {

--- a/src/screens/chat-screen/components/audio-recorder/AudioManager.ts
+++ b/src/screens/chat-screen/components/audio-recorder/AudioManager.ts
@@ -36,9 +36,7 @@ export const startPlayer = async (path: string, callback: Callback) => {
 
   if (audioRecorderPlayer === undefined) {
     audioRecorderPlayer = new AudioRecorderPlayer();
-    // Emit playback updates every 100ms so the slider has enough samples to
-    // animate smoothly. Keep in sync with PROGRESS_TWEEN_DURATION in Slider.
-    await audioRecorderPlayer.setSubscriptionDuration(0.1);
+    audioRecorderPlayer.setSubscriptionDuration(0.1);
   }
 
   const shouldBeResumed = currentPath === path && currentPosition > 0;

--- a/src/screens/chat-screen/components/audio-recorder/AudioManager.ts
+++ b/src/screens/chat-screen/components/audio-recorder/AudioManager.ts
@@ -36,6 +36,9 @@ export const startPlayer = async (path: string, callback: Callback) => {
 
   if (audioRecorderPlayer === undefined) {
     audioRecorderPlayer = new AudioRecorderPlayer();
+    // Emit playback updates every 100ms so the slider has enough samples to
+    // animate smoothly. Keep in sync with PROGRESS_TWEEN_DURATION in Slider.
+    await audioRecorderPlayer.setSubscriptionDuration(0.1);
   }
 
   const shouldBeResumed = currentPath === path && currentPosition > 0;

--- a/src/screens/chat-screen/components/message-components/AudioBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioBubble.tsx
@@ -12,7 +12,7 @@ import {
 
 import { tailwind } from '@/theme';
 import { IconProps } from '@/types';
-import { Icon, Slider } from '@/components-next/common';
+import { AudioTimer, Icon, Slider } from '@/components-next/common';
 import { Spinner } from '@/components-next/spinner';
 import { pausePlayer, resumePlayer, seekTo, startPlayer, stopPlayer } from '../audio-recorder';
 import { MESSAGE_VARIANTS } from '@/constants';
@@ -161,40 +161,49 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
   );
 
   return (
-    <View style={tailwind.style('w-full flex flex-row items-center flex-1')}>
-      <Pressable disabled={isSoundLoading} hitSlop={10} onPress={togglePlayback}>
-        {isSoundLoading ? (
-          <Animated.View>
-            <Spinner size={13} stroke={variant === MESSAGE_VARIANTS.USER ? 'white' : 'black'} />
-          </Animated.View>
-        ) : isCurrentAudioSrcPlaying ? (
-          <Animated.View
-            style={tailwind.style('pl-0.5 pr-0.5')}
-            entering={FadeIn}
-            exiting={FadeOut}>
-            <Icon
-              icon={
-                <PauseIcon
-                  fillOpacity={variant === MESSAGE_VARIANTS.USER ? '1' : '0.565'}
-                  fill={variant === MESSAGE_VARIANTS.USER ? 'white' : 'black'}
-                />
-              }
-              size={13}
-            />
-          </Animated.View>
-        ) : (
-          <Animated.View
-            style={tailwind.style('pl-0.5 pr-0.5')}
-            entering={FadeIn}
-            exiting={FadeOut}>
-            <PlayIcon
-              fillOpacity={variant === MESSAGE_VARIANTS.USER ? '1' : '0.565'}
-              fill={variant === MESSAGE_VARIANTS.USER ? 'white' : 'black'}
-            />
-          </Animated.View>
-        )}
-      </Pressable>
-      <Slider {...sliderProps} />
+    <View style={tailwind.style('w-full flex flex-col flex-1')}>
+      <View style={tailwind.style('w-full flex flex-row items-center flex-1')}>
+        <Pressable disabled={isSoundLoading} hitSlop={10} onPress={togglePlayback}>
+          {isSoundLoading ? (
+            <Animated.View>
+              <Spinner size={13} stroke={variant === MESSAGE_VARIANTS.USER ? 'white' : 'black'} />
+            </Animated.View>
+          ) : isCurrentAudioSrcPlaying ? (
+            <Animated.View
+              style={tailwind.style('pl-0.5 pr-0.5')}
+              entering={FadeIn}
+              exiting={FadeOut}>
+              <Icon
+                icon={
+                  <PauseIcon
+                    fillOpacity={variant === MESSAGE_VARIANTS.USER ? '1' : '0.565'}
+                    fill={variant === MESSAGE_VARIANTS.USER ? 'white' : 'black'}
+                  />
+                }
+                size={13}
+              />
+            </Animated.View>
+          ) : (
+            <Animated.View
+              style={tailwind.style('pl-0.5 pr-0.5')}
+              entering={FadeIn}
+              exiting={FadeOut}>
+              <PlayIcon
+                fillOpacity={variant === MESSAGE_VARIANTS.USER ? '1' : '0.565'}
+                fill={variant === MESSAGE_VARIANTS.USER ? 'white' : 'black'}
+              />
+            </Animated.View>
+          )}
+        </Pressable>
+        <Slider {...sliderProps} />
+      </View>
+      <View style={tailwind.style('pl-0.5')}>
+        <AudioTimer
+          currentPosition={currentPosition}
+          totalDuration={totalDuration}
+          textColor={variant === MESSAGE_VARIANTS.USER ? 'text-whiteA-A11' : 'text-gray-700'}
+        />
+      </View>
     </View>
   );
 });


### PR DESCRIPTION
## Description 

- Adds duration and progress that were missing/blank during playback 
- Makes the scrubber animation smoother

<img width="1080" height="276" alt="Screenshot_20260714-185304" src="https://github.com/user-attachments/assets/eb9691e1-3f76-475e-ae3b-b07acd90c7ef" />


Fixes [CW-6172](https://linear.app/chatwoot/issue/CW-6172/audio-player-ui-missing-duration-and-progress-bar-during-playback) (#988)

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)