### PR TITLE
fix: audio player reliability and playback UX

### DIFF
--- a/src/components-next/common/audio-timer/AudioTimer.tsx
+++ b/src/components-next/common/audio-timer/AudioTimer.tsx
@@ -37,10 +37,10 @@ export const AudioTimer = ({ currentPosition, totalDuration, textColor }: AudioT
       underlineColorAndroid="transparent"
       value={text.value}
       animatedProps={animatedProps}
-      style={tailwind.style(
-        'p-0 text-xs font-inter-420-20 tracking-[0.32px] leading-[14px]',
-        textColor,
-      )}
+      style={[
+        tailwind.style('p-0 text-xs font-inter-420-20 tracking-[0.32px]', textColor),
+        { includeFontPadding: false, height: 14, lineHeight: 14, textAlignVertical: 'center' },
+      ]}
     />
   );
 };

--- a/src/components-next/common/slider/Slider.tsx
+++ b/src/components-next/common/slider/Slider.tsx
@@ -116,10 +116,10 @@ export const Slider = (props: SliderProps) => {
 
   const animatedFilledTrack = useAnimatedStyle(() => {
     const maxWidth = sliderMaxWidth.value;
+    const fillRatio = maxWidth > 0 ? (translationX.value + 8) / maxWidth : 0;
     return {
       width: maxWidth,
-      transformOrigin: 'left',
-      transform: [{ scaleX: maxWidth > 0 ? (translationX.value + 8) / maxWidth : 0 }],
+      transform: [{ translateX: -(maxWidth * (1 - fillRatio)) / 2 }, { scaleX: fillRatio }],
     };
   });
 

--- a/src/screens/chat-screen/components/audio-recorder/AudioManager.ts
+++ b/src/screens/chat-screen/components/audio-recorder/AudioManager.ts
@@ -15,6 +15,16 @@ export enum AudioStatus {
   STOPPED = 'STOPPED',
 }
 
+// Thrown by startPlayer when a newer start (or a stop) replaced it while the
+// native player was still preparing. Callers should treat it as "did not
+// start" and must not claim playback.
+export class StartSupersededError extends Error {
+  constructor() {
+    super('Audio start superseded by a newer playback request');
+    this.name = 'StartSupersededError';
+  }
+}
+
 let audioRecorderPlayer: AudioRecorderPlayer | undefined;
 let currentCallback: Callback = () => {};
 // Bumped on every start/stop so a start that is still awaiting the native
@@ -39,9 +49,10 @@ export const startPlayer = async (path: string, callback: Callback) => {
   await player.startPlayer(path);
 
   // A newer start (or a stop) superseded this one while the native player was
-  // preparing; abandon so we don't attach a listener to a replaced player.
+  // preparing. Reject rather than resolve so callers don't treat a cancelled
+  // start as success and claim playback for a clip that never started.
   if (generation !== activeGeneration) {
-    return;
+    throw new StartSupersededError();
   }
 
   currentCallback({

--- a/src/screens/chat-screen/components/audio-recorder/AudioManager.ts
+++ b/src/screens/chat-screen/components/audio-recorder/AudioManager.ts
@@ -27,11 +27,29 @@ export class StartSupersededError extends Error {
 
 let audioRecorderPlayer: AudioRecorderPlayer | undefined;
 let currentCallback: Callback = () => {};
-// Bumped on every start/stop so a start that is still awaiting the native
-// player can detect it was superseded and avoid touching the replaced player.
-let activeGeneration = 0;
+// Monotonic token identifying the most recent playback request. Reserved at
+// intent time (the tap) so callers that defer their startPlayer to a later
+// frame still order correctly against callers that start immediately: whichever
+// tap is newest holds the latest token and wins, regardless of call timing.
+let latestToken = 0;
 
-export const startPlayer = async (path: string, callback: Callback) => {
+// Reserve a playback token synchronously. Deferred callers must reserve at the
+// moment of intent and pass the token to startPlayer; immediate callers can
+// rely on startPlayer's default, which reserves at call time.
+export const reservePlayback = (): number => ++latestToken;
+
+export const startPlayer = async (
+  path: string,
+  callback: Callback,
+  token: number = ++latestToken,
+) => {
+  // A newer request superseded this one before it began — e.g. it sat in a
+  // deferred frame while another control started playback. Reject so the caller
+  // does not claim playback for a clip that never started.
+  if (token !== latestToken) {
+    throw new StartSupersededError();
+  }
+
   // Always tear down any existing player so playback begins from a clean state,
   // bound to the current caller's callback with exactly one playback listener.
   // Resuming a paused clip goes through resumePlayer, never through startPlayer.
@@ -39,7 +57,6 @@ export const startPlayer = async (path: string, callback: Callback) => {
     await stopPlayer();
   }
 
-  const generation = ++activeGeneration;
   currentCallback = callback;
 
   const player = new AudioRecorderPlayer();
@@ -48,10 +65,8 @@ export const startPlayer = async (path: string, callback: Callback) => {
 
   await player.startPlayer(path);
 
-  // A newer start (or a stop) superseded this one while the native player was
-  // preparing. Reject rather than resolve so callers don't treat a cancelled
-  // start as success and claim playback for a clip that never started.
-  if (generation !== activeGeneration) {
+  // A newer request superseded this one while the native player was preparing.
+  if (token !== latestToken) {
     throw new StartSupersededError();
   }
 
@@ -59,7 +74,8 @@ export const startPlayer = async (path: string, callback: Callback) => {
     status: AudioStatus.STARTED,
   });
   player.addPlayBackListener(async e => {
-    if (generation !== activeGeneration) {
+    // Ignore stray callbacks from a player that has since been replaced.
+    if (audioRecorderPlayer !== player) {
       return;
     }
     // Use >= with a positive duration so completion still fires when the native
@@ -96,10 +112,12 @@ export const seekTo = async (position: number) => {
 };
 
 export const stopPlayer = async () => {
-  // Invalidate any in-flight start so it does not re-attach to this player.
-  activeGeneration++;
-  await audioRecorderPlayer?.stopPlayer();
-  audioRecorderPlayer?.removePlayBackListener();
-  currentCallback({ status: AudioStatus.STOPPED });
+  // Detach synchronously so any queued listener callback for this player is
+  // ignored, and so a concurrent start knows the player was replaced. Stopping
+  // does not bump latestToken — a stop must not supersede a queued start.
+  const player = audioRecorderPlayer;
   audioRecorderPlayer = undefined;
+  await player?.stopPlayer();
+  player?.removePlayBackListener();
+  currentCallback({ status: AudioStatus.STOPPED });
 };

--- a/src/screens/chat-screen/components/audio-recorder/AudioManager.ts
+++ b/src/screens/chat-screen/components/audio-recorder/AudioManager.ts
@@ -7,8 +7,6 @@ import AudioRecorderPlayer, { PlayBackType } from 'react-native-audio-recorder-p
 
 export type Callback = (args: { status: AudioStatus; data?: PlayBackType }) => void;
 
-type Path = string | undefined;
-
 export enum AudioStatus {
   PLAYING = 'PLAYING',
   STARTED = 'STARTED',
@@ -18,8 +16,10 @@ export enum AudioStatus {
 }
 
 let audioRecorderPlayer: AudioRecorderPlayer | undefined;
-let currentPath: Path;
 let currentCallback: Callback = () => {};
+// Bumped on every start/stop so a start that is still awaiting the native
+// player can detect it was superseded and avoid touching the replaced player.
+let activeGeneration = 0;
 
 export const startPlayer = async (path: string, callback: Callback) => {
   // Always tear down any existing player so playback begins from a clean state,
@@ -29,18 +29,31 @@ export const startPlayer = async (path: string, callback: Callback) => {
     await stopPlayer();
   }
 
-  currentPath = path;
+  const generation = ++activeGeneration;
   currentCallback = callback;
 
-  audioRecorderPlayer = new AudioRecorderPlayer();
-  audioRecorderPlayer.setSubscriptionDuration(0.1);
+  const player = new AudioRecorderPlayer();
+  audioRecorderPlayer = player;
+  player.setSubscriptionDuration(0.1);
 
-  await audioRecorderPlayer.startPlayer(currentPath);
+  await player.startPlayer(path);
+
+  // A newer start (or a stop) superseded this one while the native player was
+  // preparing; abandon so we don't attach a listener to a replaced player.
+  if (generation !== activeGeneration) {
+    return;
+  }
+
   currentCallback({
     status: AudioStatus.STARTED,
   });
-  audioRecorderPlayer.addPlayBackListener(async e => {
-    if (e.currentPosition === e.duration) {
+  player.addPlayBackListener(async e => {
+    if (generation !== activeGeneration) {
+      return;
+    }
+    // Use >= with a positive duration so completion still fires when the native
+    // position never lands exactly on the reported duration (common on Android).
+    if (e.duration > 0 && e.currentPosition >= e.duration) {
       currentCallback({
         status: AudioStatus.STOPPED,
         data: e,
@@ -72,9 +85,10 @@ export const seekTo = async (position: number) => {
 };
 
 export const stopPlayer = async () => {
+  // Invalidate any in-flight start so it does not re-attach to this player.
+  activeGeneration++;
   await audioRecorderPlayer?.stopPlayer();
   audioRecorderPlayer?.removePlayBackListener();
   currentCallback({ status: AudioStatus.STOPPED });
   audioRecorderPlayer = undefined;
-  currentPath = undefined;
 };

--- a/src/screens/chat-screen/components/audio-recorder/AudioManager.ts
+++ b/src/screens/chat-screen/components/audio-recorder/AudioManager.ts
@@ -20,34 +20,20 @@ export enum AudioStatus {
 let audioRecorderPlayer: AudioRecorderPlayer | undefined;
 let currentPath: Path;
 let currentCallback: Callback = () => {};
-let currentPosition = 0;
 
 export const startPlayer = async (path: string, callback: Callback) => {
-  if (currentPath === undefined) {
-    currentPath = path;
-    currentCallback = callback;
-  } else if (currentPath !== path) {
-    if (audioRecorderPlayer !== undefined) {
-      await stopPlayer();
-    }
-    currentPath = path;
-    currentCallback = callback;
+  // Always tear down any existing player so playback begins from a clean state,
+  // bound to the current caller's callback with exactly one playback listener.
+  // Resuming a paused clip goes through resumePlayer, never through startPlayer.
+  if (audioRecorderPlayer !== undefined) {
+    await stopPlayer();
   }
 
-  if (audioRecorderPlayer === undefined) {
-    audioRecorderPlayer = new AudioRecorderPlayer();
-    audioRecorderPlayer.setSubscriptionDuration(0.1);
-  }
+  currentPath = path;
+  currentCallback = callback;
 
-  const shouldBeResumed = currentPath === path && currentPosition > 0;
-
-  if (shouldBeResumed) {
-    await audioRecorderPlayer.resumePlayer();
-    currentCallback({
-      status: AudioStatus.RESUMED,
-    });
-    return;
-  }
+  audioRecorderPlayer = new AudioRecorderPlayer();
+  audioRecorderPlayer.setSubscriptionDuration(0.1);
 
   await audioRecorderPlayer.startPlayer(currentPath);
   currentCallback({
@@ -61,7 +47,6 @@ export const startPlayer = async (path: string, callback: Callback) => {
       });
       await stopPlayer();
     } else {
-      currentPosition = e.currentPosition;
       currentCallback({
         status: AudioStatus.PLAYING,
         data: e,
@@ -89,7 +74,7 @@ export const seekTo = async (position: number) => {
 export const stopPlayer = async () => {
   await audioRecorderPlayer?.stopPlayer();
   audioRecorderPlayer?.removePlayBackListener();
-  currentPosition = 0;
   currentCallback({ status: AudioStatus.STOPPED });
   audioRecorderPlayer = undefined;
+  currentPath = undefined;
 };

--- a/src/screens/chat-screen/components/message-components/AudioBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioBubble.tsx
@@ -105,11 +105,21 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
       }
       setAudioPlaying(!isAudioPlaying);
     } else {
+      // Show the loader immediately and consistently while the native player
+      // buffers, then switch to the pause icon once playback actually starts.
+      // Defer the heavier redux dispatch and native start to the next frame so
+      // the loader paints first instead of being blocked by that work.
       setIsSoundLoading(true);
-      startPlayer(convertedAudioSrc, audioPlayBackStatus).then(() => {
-        setIsSoundLoading(false);
-        setAudioPlaying(true);
-        dispatch(setCurrentPlayingAudioSrc(convertedAudioSrc));
+      requestAnimationFrame(() => {
+        startPlayer(convertedAudioSrc, audioPlayBackStatus)
+          .then(() => {
+            setIsSoundLoading(false);
+            setAudioPlaying(true);
+            dispatch(setCurrentPlayingAudioSrc(convertedAudioSrc));
+          })
+          .catch(() => {
+            setIsSoundLoading(false);
+          });
       });
     }
   }, [convertedAudioSrc, currentPlayingAudioSrc, isAudioPlaying, dispatch, audioPlayBackStatus]);

--- a/src/screens/chat-screen/components/message-components/AudioBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioBubble.tsx
@@ -200,6 +200,14 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
   );
 
   useEffect(() => {
+    // While our own start is still pending, keep ownership even though redux
+    // (currentPlayingAudioSrc) has not caught up yet — otherwise a clip ending
+    // or another player claiming redux in that window would drop this bubble's
+    // claim and leave its just-started audio untracked. A genuine supersession
+    // is instead handled by startPlayer rejecting via the generation guard.
+    if (startPendingRef.current) {
+      return;
+    }
     // Another src becoming active means this bubble no longer owns the player.
     if (currentPlayingAudioSrc !== convertedAudioSrc) {
       isPlaybackOwnerRef.current = false;

--- a/src/screens/chat-screen/components/message-components/AudioBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioBubble.tsx
@@ -110,7 +110,11 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
       // Defer the heavier redux dispatch and native start to the next frame so
       // the loader paints first instead of being blocked by that work.
       setIsSoundLoading(true);
-      requestAnimationFrame(() => {
+      // Claim ownership synchronously (before the deferred dispatch lands) so
+      // the unmount cleanup can still tear down a start that is mid-buffer.
+      isPlaybackOwnerRef.current = true;
+      rafHandleRef.current = requestAnimationFrame(() => {
+        rafHandleRef.current = null;
         startPlayer(convertedAudioSrc, audioPlayBackStatus)
           .then(() => {
             setIsSoundLoading(false);
@@ -119,6 +123,7 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
           })
           .catch(() => {
             setIsSoundLoading(false);
+            isPlaybackOwnerRef.current = false;
           });
       });
     }
@@ -139,11 +144,13 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
     [convertedAudioSrc, currentPlayingAudioSrc, isAudioPlaying],
   );
 
-  const activeSrcRef = useRef(currentPlayingAudioSrc);
-  const convertedSrcRef = useRef(convertedAudioSrc);
+  const rafHandleRef = useRef<number | null>(null);
+  const isPlaybackOwnerRef = useRef(false);
   useEffect(() => {
-    activeSrcRef.current = currentPlayingAudioSrc;
-    convertedSrcRef.current = convertedAudioSrc;
+    // Another src becoming active means this bubble no longer owns the player.
+    if (currentPlayingAudioSrc !== convertedAudioSrc) {
+      isPlaybackOwnerRef.current = false;
+    }
   }, [currentPlayingAudioSrc, convertedAudioSrc]);
 
   useEffect(() => {
@@ -155,10 +162,15 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
 
   useEffect(() => {
     return () => {
-      // Only tear down the shared player if this bubble is the one playing.
-      // Other bubbles unmounting (e.g. while the list settles on open) must not
-      // stop the audio the user just started.
-      if (activeSrcRef.current !== convertedSrcRef.current) {
+      // Cancel a start that is still queued for the next frame.
+      if (rafHandleRef.current !== null) {
+        cancelAnimationFrame(rafHandleRef.current);
+        rafHandleRef.current = null;
+      }
+      // Only tear down the shared player if this bubble owns playback (which it
+      // does from the tap onward, even while still buffering). Other bubbles
+      // unmounting while the list settles must not stop the audio in progress.
+      if (!isPlaybackOwnerRef.current) {
         return;
       }
       stopPlayer()

--- a/src/screens/chat-screen/components/message-components/AudioBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioBubble.tsx
@@ -14,7 +14,14 @@ import { tailwind } from '@/theme';
 import { IconProps } from '@/types';
 import { AudioTimer, Icon, Slider } from '@/components-next/common';
 import { Spinner } from '@/components-next/spinner';
-import { pausePlayer, resumePlayer, seekTo, startPlayer, stopPlayer } from '../audio-recorder';
+import {
+  AudioStatus,
+  pausePlayer,
+  resumePlayer,
+  seekTo,
+  startPlayer,
+  stopPlayer,
+} from '../audio-recorder';
 import { MESSAGE_VARIANTS } from '@/constants';
 import { useDispatch } from 'react-redux';
 import { useAppSelector } from '@/hooks';
@@ -63,12 +70,17 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
   const totalDuration = useSharedValue(0);
 
   const audioPlayBackStatus = useCallback(
-    (data: { data: PlayBackType }) => {
-      const playBackData = data.data as PlayBackType;
-      if (playBackData) {
-        currentPosition.value = playBackData.currentPosition;
-        totalDuration.value = playBackData.duration;
-        if (playBackData.currentPosition === playBackData.duration) {
+    ({ status, data }: { status: AudioStatus; data?: PlayBackType }) => {
+      if (status === AudioStatus.STOPPED) {
+        // The shared player was torn down (finished, or handed off because
+        // another clip started), so this bubble no longer owns it and must not
+        // stop it on a later unmount.
+        isPlaybackOwnerRef.current = false;
+      }
+      if (data) {
+        currentPosition.value = data.currentPosition;
+        totalDuration.value = data.duration;
+        if (data.currentPosition === data.duration) {
           currentPosition.value = 0;
           totalDuration.value = 0;
           setAudioPlaying(false);

--- a/src/screens/chat-screen/components/message-components/AudioBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioBubble.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState, useCallback } from 'react';
+import React, { useEffect, useMemo, useState, useCallback, useRef } from 'react';
 import { Platform, Pressable, View } from 'react-native';
 import { PlayBackType } from 'react-native-audio-recorder-player';
 import Animated, { FadeIn, FadeOut, useSharedValue } from 'react-native-reanimated';
@@ -129,6 +129,13 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
     [convertedAudioSrc, currentPlayingAudioSrc, isAudioPlaying],
   );
 
+  const activeSrcRef = useRef(currentPlayingAudioSrc);
+  const convertedSrcRef = useRef(convertedAudioSrc);
+  useEffect(() => {
+    activeSrcRef.current = currentPlayingAudioSrc;
+    convertedSrcRef.current = convertedAudioSrc;
+  }, [currentPlayingAudioSrc, convertedAudioSrc]);
+
   useEffect(() => {
     if (currentPlayingAudioSrc !== audioSrc) {
       currentPosition.value = 0;
@@ -138,10 +145,15 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
 
   useEffect(() => {
     return () => {
+      // Only tear down the shared player if this bubble is the one playing.
+      // Other bubbles unmounting (e.g. while the list settles on open) must not
+      // stop the audio the user just started.
+      if (activeSrcRef.current !== convertedSrcRef.current) {
+        return;
+      }
       stopPlayer()
         .then()
         .finally(() => {
-          setAudioPlaying(false);
           dispatch(setCurrentPlayingAudioSrc(''));
         });
     };

--- a/src/screens/chat-screen/components/message-components/AudioBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioBubble.tsx
@@ -17,6 +17,7 @@ import { Spinner } from '@/components-next/spinner';
 import {
   AudioStatus,
   pausePlayer,
+  reservePlayback,
   resumePlayer,
   seekTo,
   startPlayer,
@@ -146,9 +147,12 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
       // the unmount cleanup can still tear down a start that is mid-buffer.
       isPlaybackOwnerRef.current = true;
       startPendingRef.current = true;
+      // Reserve the playback token now, at tap time, so a later tap that starts
+      // before this deferred frame runs still wins the ordering.
+      const token = reservePlayback();
       rafHandleRef.current = requestAnimationFrame(() => {
         rafHandleRef.current = null;
-        startPlayer(convertedAudioSrc, audioPlayBackStatus)
+        startPlayer(convertedAudioSrc, audioPlayBackStatus, token)
           .then(() => {
             startPendingRef.current = false;
             // Superseded by another clip (or torn down) while buffering: our

--- a/src/screens/chat-screen/components/message-components/AudioBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioBubble.tsx
@@ -219,7 +219,7 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
         </Pressable>
         <Slider {...sliderProps} />
       </View>
-      <View style={tailwind.style('pl-0.5')}>
+      <View style={tailwind.style('pl-0.5 mt-1')}>
         <AudioTimer
           currentPosition={currentPosition}
           totalDuration={totalDuration}

--- a/src/screens/chat-screen/components/message-components/AudioBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioBubble.tsx
@@ -69,6 +69,18 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
   const currentPosition = useSharedValue(0);
   const totalDuration = useSharedValue(0);
 
+  const isMountedRef = useRef(true);
+  const rafHandleRef = useRef<number | null>(null);
+  const isPlaybackOwnerRef = useRef(false);
+  const startPendingRef = useRef(false);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
   const audioPlayBackStatus = useCallback(
     ({ status, data }: { status: AudioStatus; data?: PlayBackType }) => {
       if (status === AudioStatus.STOPPED) {
@@ -80,7 +92,7 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
       if (data) {
         currentPosition.value = data.currentPosition;
         totalDuration.value = data.duration;
-        if (data.currentPosition === data.duration) {
+        if (data.duration > 0 && data.currentPosition >= data.duration) {
           currentPosition.value = 0;
           totalDuration.value = 0;
           setAudioPlaying(false);
@@ -97,11 +109,15 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
         setIsSoundLoading(true);
         try {
           const convertedSrc = await convertOggToWav(audioSrc);
-          setConvertedAudioSrc(convertedSrc);
+          if (isMountedRef.current) {
+            setConvertedAudioSrc(convertedSrc);
+          }
         } catch (error) {
           Sentry.captureException(error);
         } finally {
-          setIsSoundLoading(false);
+          if (isMountedRef.current) {
+            setIsSoundLoading(false);
+          }
         }
       }
     };
@@ -117,6 +133,10 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
       }
       setAudioPlaying(!isAudioPlaying);
     } else {
+      // Ignore repeat taps while a start is already in flight.
+      if (startPendingRef.current) {
+        return;
+      }
       // Show the loader immediately and consistently while the native player
       // buffers, then switch to the pause icon once playback actually starts.
       // Defer the heavier redux dispatch and native start to the next frame so
@@ -125,17 +145,40 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
       // Claim ownership synchronously (before the deferred dispatch lands) so
       // the unmount cleanup can still tear down a start that is mid-buffer.
       isPlaybackOwnerRef.current = true;
+      startPendingRef.current = true;
       rafHandleRef.current = requestAnimationFrame(() => {
         rafHandleRef.current = null;
         startPlayer(convertedAudioSrc, audioPlayBackStatus)
           .then(() => {
+            startPendingRef.current = false;
+            // Superseded by another clip (or torn down) while buffering: our
+            // native player is already gone, so just clear the local loader.
+            if (!isPlaybackOwnerRef.current) {
+              if (isMountedRef.current) {
+                setIsSoundLoading(false);
+              }
+              return;
+            }
+            // Started successfully but this bubble unmounted meanwhile: nothing
+            // owns the player now, so stop it and clear the global marker.
+            if (!isMountedRef.current) {
+              stopPlayer()
+                .then()
+                .finally(() => {
+                  dispatch(setCurrentPlayingAudioSrc(''));
+                });
+              return;
+            }
             setIsSoundLoading(false);
             setAudioPlaying(true);
             dispatch(setCurrentPlayingAudioSrc(convertedAudioSrc));
           })
           .catch(() => {
-            setIsSoundLoading(false);
+            startPendingRef.current = false;
             isPlaybackOwnerRef.current = false;
+            if (isMountedRef.current) {
+              setIsSoundLoading(false);
+            }
           });
       });
     }
@@ -156,8 +199,6 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
     [convertedAudioSrc, currentPlayingAudioSrc, isAudioPlaying],
   );
 
-  const rafHandleRef = useRef<number | null>(null);
-  const isPlaybackOwnerRef = useRef(false);
   useEffect(() => {
     // Another src becoming active means this bubble no longer owns the player.
     if (currentPlayingAudioSrc !== convertedAudioSrc) {
@@ -166,11 +207,11 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
   }, [currentPlayingAudioSrc, convertedAudioSrc]);
 
   useEffect(() => {
-    if (currentPlayingAudioSrc !== audioSrc) {
+    if (currentPlayingAudioSrc !== convertedAudioSrc) {
       currentPosition.value = 0;
       totalDuration.value = 0;
     }
-  }, [currentPlayingAudioSrc, audioSrc, currentPosition, totalDuration]);
+  }, [currentPlayingAudioSrc, convertedAudioSrc, currentPosition, totalDuration]);
 
   useEffect(() => {
     return () => {
@@ -183,6 +224,11 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
       // does from the tap onward, even while still buffering). Other bubbles
       // unmounting while the list settles must not stop the audio in progress.
       if (!isPlaybackOwnerRef.current) {
+        return;
+      }
+      // A start is still in flight; its own continuation stops the now-ownerless
+      // player once it resolves. Stopping here would race the concurrent start.
+      if (startPendingRef.current) {
         return;
       }
       stopPlayer()

--- a/src/screens/chat-screen/components/message-components/AudioCell.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioCell.tsx
@@ -14,7 +14,14 @@ import { Channel, IconProps, Message, MessageStatus, UnixTimestamp } from '@/typ
 import { unixTimestampToReadableTime } from '@/utils';
 import { Avatar, Icon, Slider } from '@/components-next/common';
 import { Spinner } from '@/components-next/spinner';
-import { pausePlayer, resumePlayer, seekTo, startPlayer, stopPlayer } from '../audio-recorder';
+import {
+  AudioStatus,
+  pausePlayer,
+  resumePlayer,
+  seekTo,
+  startPlayer,
+  stopPlayer,
+} from '../audio-recorder';
 import { MenuOption, MessageMenu } from '../message-menu';
 import { MESSAGE_TYPES } from '@/constants';
 import { DeliveryStatus } from './DeliveryStatus';
@@ -69,12 +76,11 @@ export const AudioPlayer = (props: AudioPlayerProps) => {
   const currentPosition = useSharedValue(0);
   const totalDuration = useSharedValue(0);
 
-  const audioPlayBackStatus = (data: { data: PlayBackType }) => {
-    const playBackData = data.data as PlayBackType;
-    if (playBackData) {
-      currentPosition.value = playBackData.currentPosition;
-      totalDuration.value = playBackData.duration;
-      if (playBackData.currentPosition === playBackData.duration) {
+  const audioPlayBackStatus = ({ data }: { status: AudioStatus; data?: PlayBackType }) => {
+    if (data) {
+      currentPosition.value = data.currentPosition;
+      totalDuration.value = data.duration;
+      if (data.duration > 0 && data.currentPosition >= data.duration) {
         currentPosition.value = 0;
         totalDuration.value = 0;
         setAudioPlaying(false);
@@ -96,11 +102,17 @@ export const AudioPlayer = (props: AudioPlayerProps) => {
     } else {
       setIsSoundLoading(true);
 
-      startPlayer(audioSrc, audioPlayBackStatus).then(() => {
-        setIsSoundLoading(false);
-        setAudioPlaying(true);
-        dispatch(setCurrentPlayingAudioSrc(audioSrc));
-      });
+      startPlayer(audioSrc, audioPlayBackStatus)
+        .then(() => {
+          setIsSoundLoading(false);
+          setAudioPlaying(true);
+          dispatch(setCurrentPlayingAudioSrc(audioSrc));
+        })
+        .catch(() => {
+          // Start was superseded by a newer clip (or failed); don't claim
+          // playback for this src.
+          setIsSoundLoading(false);
+        });
     }
   };
 


### PR DESCRIPTION
## Description 

Follow-up fixes for the audio message player ([PR 1105](https://github.com/chatwoot/chatwoot-mobile-app/pull/1105)):

- Fix frozen slider/timer on replay by binding the playback listener to the active bubble
- Stop other bubbles unmounting from killing the audio just started (open-and-play)
- Show the loader for the whole buffering delay, then flip to pause when playback starts
- Anchor the slider fill with translateX/scaleX (drops transformOrigin, per [review comment](https://github.com/chatwoot/chatwoot-mobile-app/pull/1105#pullrequestreview-4694809063))
- Make the timer's elapsed/total spacing consistent across iOS and Android

Fixes [CW-7605](https://linear.app/chatwoot/issue/CW-7605/audio-player-issues)

## Type of change

- [x] Bug fixes (Changes which fix issues but there can be regressions)