### PR TITLE
fix: audio player UI polish : slider fill, timer spacing, loader timing

### DIFF
--- a/src/components-next/common/audio-timer/AudioTimer.tsx
+++ b/src/components-next/common/audio-timer/AudioTimer.tsx
@@ -37,10 +37,10 @@ export const AudioTimer = ({ currentPosition, totalDuration, textColor }: AudioT
       underlineColorAndroid="transparent"
       value={text.value}
       animatedProps={animatedProps}
-      style={tailwind.style(
-        'p-0 text-xs font-inter-420-20 tracking-[0.32px] leading-[14px]',
-        textColor,
-      )}
+      style={[
+        tailwind.style('p-0 text-xs font-inter-420-20 tracking-[0.32px]', textColor),
+        { includeFontPadding: false, height: 14, lineHeight: 14, textAlignVertical: 'center' },
+      ]}
     />
   );
 };

--- a/src/components-next/common/slider/Slider.tsx
+++ b/src/components-next/common/slider/Slider.tsx
@@ -116,10 +116,10 @@ export const Slider = (props: SliderProps) => {
 
   const animatedFilledTrack = useAnimatedStyle(() => {
     const maxWidth = sliderMaxWidth.value;
+    const fillRatio = maxWidth > 0 ? (translationX.value + 8) / maxWidth : 0;
     return {
       width: maxWidth,
-      transformOrigin: 'left',
-      transform: [{ scaleX: maxWidth > 0 ? (translationX.value + 8) / maxWidth : 0 }],
+      transform: [{ translateX: -(maxWidth * (1 - fillRatio)) / 2 }, { scaleX: fillRatio }],
     };
   });
 

--- a/src/screens/chat-screen/components/message-components/AudioBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioBubble.tsx
@@ -105,11 +105,20 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
       }
       setAudioPlaying(!isAudioPlaying);
     } else {
+      // Show the loader immediately, then defer the native start one frame so
+      // the spinner paints before the bridge call instead of lagging behind it
+      // (noticeable on Android). Flip to pause once playback actually starts.
       setIsSoundLoading(true);
-      startPlayer(convertedAudioSrc, audioPlayBackStatus).then(() => {
-        setIsSoundLoading(false);
-        setAudioPlaying(true);
-        dispatch(setCurrentPlayingAudioSrc(convertedAudioSrc));
+      requestAnimationFrame(() => {
+        startPlayer(convertedAudioSrc, audioPlayBackStatus)
+          .then(() => {
+            setIsSoundLoading(false);
+            setAudioPlaying(true);
+            dispatch(setCurrentPlayingAudioSrc(convertedAudioSrc));
+          })
+          .catch(() => {
+            setIsSoundLoading(false);
+          });
       });
     }
   }, [convertedAudioSrc, currentPlayingAudioSrc, isAudioPlaying, dispatch, audioPlayBackStatus]);

--- a/src/screens/chat-screen/components/message-components/AudioBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioBubble.tsx
@@ -197,7 +197,7 @@ export const AudioBubblePlayer = React.memo((props: AudioPlayerProps) => {
         </Pressable>
         <Slider {...sliderProps} />
       </View>
-      <View style={tailwind.style('pl-0.5')}>
+      <View style={tailwind.style('pl-0.5 mt-1')}>
         <AudioTimer
           currentPosition={currentPosition}
           totalDuration={totalDuration}


### PR DESCRIPTION
## Description 

- Follow-up UI fixes for the audio message player (builds on the CW-6172 timer that
already merged). 
- Scoped to presentation only, no playback/state-management changes.

### Changes
- **Slider fill**
  -  Anchor the filled track with `translateX` + `scaleX` instead of `transformOrigin`, which isn't reliably handled inside `useAnimatedStyle` on the pinned reanimated version (per review). Fill still grows from the left, with no layout pass per frame.
- **Timer spacing** 
  - Pin the elapsed/total `00:01 / 00:08` label to a fixed line box (`includeFontPadding: false`, fixed height, centered) so the gap under the scrubber is identical on iOS and Android instead of Android reserving extra space.
- **Loader timing** 
  - Defer the native `startPlayer` one frame so the loading spinner paints immediately on tap instead of lagging behind the bridge call on Android; flip to the pause icon once playback starts. Added a `.catch` so a failed load clears the spinner.

### Not in scope
Deeper audio playback concurrency/reliability work (shared-player race handling) will handled in future PRs.

Fixes [CW-7162](https://linear.app/chatwoot/issue/CW-6172/audio-player-ui-missing-duration-and-progress-bar-during-playback)
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
