### PR TITLE
fix: stop sending unactionable network errors to Sentry

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/react-native';
 
 import Constants from 'expo-constants';
 import App from './src/app';
+import { isTransportError } from './src/utils/sentryUtils';
 
 // TODO: It is a temporary fix to fix the reanimated logger issue
 // Ref: https://github.com/gorhom/react-native-bottom-sheet/issues/1983
@@ -14,8 +15,8 @@ const isStorybookEnabled = Constants.expoConfig?.extra?.eas?.storybookEnabled;
 if (!__DEV__) {
   Sentry.init({
     dsn: process.env.EXPO_PUBLIC_SENTRY_DSN,
-    tracesSampleRate: 1.0,
-    attachScreenshot: true,
+    tracesSampleRate: 0.05,
+    beforeSend: (event, hint) => (isTransportError(hint?.originalException) ? null : event),
   });
 }
 

--- a/src/utils/sentryUtils.ts
+++ b/src/utils/sentryUtils.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+/**
+ * True when a request failed before any server response was received — offline
+ * device, DNS/TLS failure, timeout, or a client-side cancellation.
+ *
+ * These carry no server-side detail to act on and their volume tracks device
+ * connectivity rather than app defects, so they are excluded from error reporting.
+ */
+export const isTransportError = (error: unknown): boolean =>
+  axios.isCancel(error) || (axios.isAxiosError(error) && !error.response);


### PR DESCRIPTION
## Description 

The mobile app is exhausting our Sentry quota. The largest group : `AxiosError: Network Error` at `handleError(axios/lib/adapters/xhr)`, reached 7.7M events, and several sibling axios groups are still ingesting. They're currently suppressed via inbound discard rules, which hides them but means deleting a rule brings the volume straight back.

**Changes**

- `beforeSend` drops errors that never received a server response: offline, DNS/TLS failure, timeout, cancellation. Applied globally rather than at the call site so future paths can't reintroduce it.
- `tracesSampleRate` 1.0 → 0.05. This was sampling 100% of transactions (every launch, navigation, XHR) against a separate quota bucket the discard rules never touched, likely a larger line item than the errors.
- Removed `attachScreenshot`, which attached a PNG to every error event. 

Errors are unaffected by the sampling change, `sampleRate` stays at its default of 1.0. Breadcrumbs are unaffected too, so error events still show the preceding HTTP calls and navigation.

**Tradeoff**

5xx responses still report (they have a `response` object). Genuinely unreachable servers no longer do. We're already blind to this via the discard rules, but the filter now lives client-side, so restoring visibility needs a release rather than deleting a rule. 

Fixes [CW-7781](https://linear.app/chatwoot/issue/CW-7781/sentry-quota-exhausted-by-axios-errors)