### PR TITLE
fix: isolate conversations when switching accounts

### DIFF
--- a/src/screens/conversations/ConversationScreen.tsx
+++ b/src/screens/conversations/ConversationScreen.tsx
@@ -61,7 +61,7 @@ import {
 import { selectFilters, FilterState } from '@/store/conversation/conversationFilterSlice';
 import { ConversationPayload } from '@/store/conversation/conversationTypes';
 import { clearAllConversations } from '@/store/conversation/conversationSlice';
-import { selectUserId } from '@/store/auth/authSelectors';
+import { selectCurrentUserAccountId, selectUserId } from '@/store/auth/authSelectors';
 import { clearAllContacts } from '@/store/contact/contactSlice';
 import { clearAssignableAgents } from '@/store/assignable-agent/assignableAgentSlice';
 
@@ -92,6 +92,8 @@ const ConversationList = () => {
   // This is used for pagination
   const [pageNumber, setPageNumber] = useState(1);
   const userId = useAppSelector(selectUserId);
+  const accountId = useAppSelector(selectCurrentUserAccountId);
+  const activeConversationRequest = useRef<{ abort: () => void } | null>(null);
 
   // This is used to store the index of the item that is currently selected
   const { openedRowIndex } = useConversationListStateContext();
@@ -113,7 +115,43 @@ const ConversationList = () => {
   }, []);
 
   const filters = useAppSelector(selectFilters);
-  const previousFilters = useRef(filters);
+
+  const fetchConversations = useCallback(
+    (filters: FilterState, page: number = 1) => {
+      if (!accountId) return;
+
+      const conversationFilters = {
+        accountId,
+        status: filters.status,
+        assigneeType: filters.assignee_type,
+        page,
+        sortBy: filters.sort_by,
+        inboxId: parseInt(filters.inbox_id),
+      } as ConversationPayload;
+
+      const request = dispatch(conversationActions.fetchConversations(conversationFilters));
+      activeConversationRequest.current = request;
+      request.finally(() => {
+        if (activeConversationRequest.current === request) {
+          activeConversationRequest.current = null;
+        }
+      });
+      return request;
+    },
+    [accountId, dispatch],
+  );
+
+  const clearAndFetchConversations = useCallback(
+    async (filters: FilterState) => {
+      activeConversationRequest.current?.abort();
+      setPageNumber(1);
+      dispatch(clearAllConversations());
+      dispatch(clearAllContacts());
+      dispatch(clearAssignableAgents());
+      return fetchConversations(filters);
+    },
+    [dispatch, fetchConversations],
+  );
 
   // Reset last active timestamp when the conversation screen is opened
   useEffect(() => {
@@ -121,27 +159,12 @@ const ConversationList = () => {
   }, []);
 
   useEffect(() => {
-    if (previousFilters.current !== filters) {
-      previousFilters.current = filters;
-      clearAndFetchConversations(filters);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filters]);
+    if (!accountId) return undefined;
 
-  useEffect(() => {
     dismissAll();
     clearAndFetchConversations(filters);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const clearAndFetchConversations = useCallback(async (filters: FilterState) => {
-    setPageNumber(1);
-    await dispatch(clearAllConversations());
-    await dispatch(clearAllContacts());
-    await dispatch(clearAssignableAgents());
-    fetchConversations(filters);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    return () => activeConversationRequest.current?.abort();
+  }, [accountId, clearAndFetchConversations, dismissAll, filters]);
 
   const ListFooterComponent = () => {
     if (isAllConversationsFetched) return null;
@@ -197,22 +220,6 @@ const ConversationList = () => {
       appStateListener?.remove();
     };
   }, [appState, checkAppStateAndFetchConversations, clearAndFetchConversations, filters]);
-
-  const fetchConversations = useCallback(
-    async (filters: FilterState, page: number = 1) => {
-      const conversationFilters = {
-        status: filters.status,
-        assigneeType: filters.assignee_type,
-        page: page,
-        sortBy: filters.sort_by,
-        inboxId: parseInt(filters.inbox_id),
-      } as ConversationPayload;
-
-      dispatch(conversationActions.fetchConversations(conversationFilters));
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  );
 
   const onChangePageNumber = () => {
     const nextPageNumber = pageNumber + 1;

--- a/src/screens/settings/SettingsScreen.tsx
+++ b/src/screens/settings/SettingsScreen.tsx
@@ -171,14 +171,19 @@ const SettingsScreen = () => {
     dispatch(setLocale(locale));
   };
 
-  const changeAccount = (accountId: number) => {
+  const changeAccount = async (accountId: number) => {
+    const previousAccountId = activeAccountId;
     dispatch(clearAllContacts());
     dispatch(clearAllConversations());
     dispatch(resetNotifications());
     dispatch(clearSearchResults());
     dispatch(setAccount(accountId));
-    dispatch(authActions.setActiveAccount({ profile: { account_id: accountId } }));
-    navigation.dispatch(StackActions.replace('Tab'));
+    try {
+      await dispatch(authActions.setActiveAccount({ profile: { account_id: accountId } })).unwrap();
+      navigation.dispatch(StackActions.replace('Tab'));
+    } catch {
+      if (previousAccountId) dispatch(setAccount(previousAccountId));
+    }
   };
 
   useEffect(() => {

--- a/src/store/conversation/conversationActions.ts
+++ b/src/store/conversation/conversationActions.ts
@@ -37,9 +37,9 @@ import { Platform } from 'react-native';
 export const conversationActions = {
   fetchConversations: createAsyncThunk<ConversationListResponse, ConversationPayload>(
     'conversations/fetchConversations',
-    async (payload, { rejectWithValue }) => {
+    async (payload, { rejectWithValue, signal }) => {
       try {
-        return await ConversationService.getConversations(payload);
+        return await ConversationService.getConversations(payload, signal);
       } catch (error) {
         const { response } = error as AxiosError<ApiErrorResponse>;
         if (!response) {
@@ -257,7 +257,11 @@ export const conversationActions = {
     },
   ),
   translateMessage: createAsyncThunk<
-    TranslateMessageAPIResponse & { conversationId: number; messageId: number; targetLanguage: string },
+    TranslateMessageAPIResponse & {
+      conversationId: number;
+      messageId: number;
+      targetLanguage: string;
+    },
     TranslateMessagePayload
   >('conversations/translateMessage', async (payload, { rejectWithValue }) => {
     try {

--- a/src/store/conversation/conversationSelectors.ts
+++ b/src/store/conversation/conversationSelectors.ts
@@ -6,6 +6,7 @@ import { CONVERSATION_PRIORITY_ORDER } from '@/constants';
 import { shouldApplyFilters } from '@/utils/conversationUtils';
 import type { Conversation } from '@/types';
 import { MESSAGE_TYPES } from '@/constants';
+import { selectCurrentUserAccountId } from '@/store/auth/authSelectors';
 
 export const selectConversationsState = (state: RootState) => state.conversations;
 
@@ -48,10 +49,11 @@ export const selectIsLoadingMessages = createSelector(
 export const getFilteredConversations = createDraftSafeSelector(
   [
     selectAllConversations,
+    selectCurrentUserAccountId,
     (_, filters: FilterState) => filters,
     (_, __, userId: number | undefined) => userId,
   ],
-  (conversations, filters, userId) => {
+  (conversations, activeAccountId, filters, userId) => {
     const { assignee_type: assigneeType, sort_by: sortBy } = filters;
     let sortType = filters.sort_by; // Create mutable variable
 
@@ -81,7 +83,9 @@ export const getFilteredConversations = createDraftSafeSelector(
       sortType = 'latest';
     }
 
-    const sortedConversations = conversations.sort(comparator[sortType as keyof SortComparator]);
+    const sortedConversations = conversations
+      .filter(conversation => Number(conversation.accountId) === Number(activeAccountId))
+      .sort(comparator[sortType as keyof SortComparator]);
 
     if (assigneeType === 'me') {
       return sortedConversations.filter(conversation => {

--- a/src/store/conversation/conversationService.ts
+++ b/src/store/conversation/conversationService.ts
@@ -42,7 +42,10 @@ import {
 import type { AxiosRequestConfig } from 'axios';
 
 export class ConversationService {
-  static async getConversations(payload: ConversationPayload): Promise<ConversationListResponse> {
+  static async getConversations(
+    payload: ConversationPayload,
+    signal?: AbortSignal,
+  ): Promise<ConversationListResponse> {
     const { status, assigneeType, page, sortBy, inboxId = 0 } = payload;
 
     const params = {
@@ -54,6 +57,7 @@ export class ConversationService {
     };
     const response = await apiService.get<ConversationListAPIResponse>('conversations', {
       params,
+      signal,
     });
     const {
       data: { payload: conversations, meta },

--- a/src/store/conversation/conversationSlice.ts
+++ b/src/store/conversation/conversationSlice.ts
@@ -8,6 +8,8 @@ import { Message } from '@/types/Message';
 import { PendingMessage } from './conversationTypes';
 
 export interface ConversationState {
+  activeAccountId: number | null;
+  currentListRequestId: string | null;
   meta: {
     mineCount: number;
     unassignedCount: number;
@@ -25,6 +27,8 @@ export interface ConversationState {
 export const conversationAdapter = createEntityAdapter<Conversation>();
 
 const initialState = conversationAdapter.getInitialState<ConversationState>({
+  activeAccountId: null,
+  currentListRequestId: null,
   meta: {
     mineCount: 0,
     unassignedCount: 0,
@@ -114,7 +118,15 @@ const conversationSlice = createSlice({
   name: 'conversation',
   initialState,
   reducers: {
-    clearAllConversations: conversationAdapter.removeAll,
+    clearAllConversations: state => {
+      conversationAdapter.removeAll(state);
+      state.activeAccountId = null;
+      state.currentListRequestId = null;
+      state.isLoadingConversations = false;
+      state.isAllConversationsFetched = false;
+      state.error = null;
+      state.meta = { ...initialState.meta };
+    },
     addConversation: (state, action) => {
       const conversation = action.payload;
       conversationAdapter.addOne(state, conversation);
@@ -181,14 +193,30 @@ const conversationSlice = createSlice({
   },
   extraReducers: builder => {
     builder
-      .addCase(conversationActions.fetchConversations.pending, state => {
+      .addCase(conversationActions.fetchConversations.pending, (state, action) => {
+        const { accountId } = action.meta.arg;
+        if (state.activeAccountId !== accountId) {
+          conversationAdapter.removeAll(state);
+          state.isAllConversationsFetched = false;
+          state.meta = { ...initialState.meta };
+        }
+        state.activeAccountId = accountId;
+        state.currentListRequestId = action.meta.requestId;
         state.error = null;
         state.isLoadingConversations = true;
       })
-      .addCase(conversationActions.fetchConversations.fulfilled, (state, { payload }) => {
+      .addCase(conversationActions.fetchConversations.fulfilled, (state, action) => {
+        const { payload, meta: requestMeta } = action;
+        if (
+          state.activeAccountId !== requestMeta.arg.accountId ||
+          state.currentListRequestId !== requestMeta.requestId
+        ) {
+          return;
+        }
         const { conversations, meta } = payload;
         const conversationsToUpsert = conversations.filter(
           conversation =>
+            Number(conversation.accountId) === Number(requestMeta.arg.accountId) &&
             !isOutdatedConversationUpdate(state.entities[conversation.id], conversation),
         );
         conversationAdapter.upsertMany(
@@ -200,9 +228,17 @@ const conversationSlice = createSlice({
         state.isLoadingConversations = false;
         state.isAllConversationsFetched = conversations.length < 20 || false;
         state.meta = meta;
+        state.currentListRequestId = null;
       })
-      .addCase(conversationActions.fetchConversations.rejected, (state, { error }) => {
+      .addCase(conversationActions.fetchConversations.rejected, (state, action) => {
+        if (
+          state.activeAccountId !== action.meta.arg.accountId ||
+          state.currentListRequestId !== action.meta.requestId
+        ) {
+          return;
+        }
         state.isLoadingConversations = false;
+        state.currentListRequestId = null;
       })
       .addCase(conversationActions.fetchConversation.pending, state => {
         state.error = null;

--- a/src/store/conversation/conversationTypes.ts
+++ b/src/store/conversation/conversationTypes.ts
@@ -35,6 +35,7 @@ export interface ConversationResponse {
 }
 
 export interface ConversationPayload {
+  accountId: number;
   page: number;
   status: ConversationStatus;
   assigneeType: AssigneeTypes;

--- a/src/store/conversation/specs/conversationSelectors.spec.ts
+++ b/src/store/conversation/specs/conversationSelectors.spec.ts
@@ -1,0 +1,29 @@
+import type { RootState } from '@/store';
+import { defaultFilterState } from '../conversationFilterSlice';
+import { getFilteredConversations } from '../conversationSelectors';
+import conversationReducer, { addConversation } from '../conversationSlice';
+import { conversation } from './conversationMockData';
+
+describe('conversation selectors', () => {
+  it('returns conversations only for the active account', () => {
+    const accountTwoConversation = {
+      ...conversation,
+      id: 251,
+      accountId: 2,
+    };
+    let conversations = conversationReducer(undefined, addConversation(conversation));
+    conversations = conversationReducer(conversations, addConversation(accountTwoConversation));
+    const state = {
+      auth: { user: { account_id: 2 } },
+      conversations,
+    } as unknown as RootState;
+
+    const result = getFilteredConversations(
+      state,
+      { ...defaultFilterState, assignee_type: 'all' },
+      1,
+    );
+
+    expect(result.map(item => item.id)).toEqual([accountTwoConversation.id]);
+  });
+});

--- a/src/store/conversation/specs/conversationService.spec.ts
+++ b/src/store/conversation/specs/conversationService.spec.ts
@@ -26,16 +26,21 @@ jest.mock('@/services/APIService', () => ({
 
 describe('ConversationService', () => {
   it('should fetch all conversations', async () => {
+    const controller = new AbortController();
     (apiService.get as jest.Mock).mockResolvedValueOnce({
       data: conversationListResponse,
     });
 
-    const result = await ConversationService.getConversations({
-      status: 'open',
-      assigneeType: 'all',
-      page: 1,
-      sortBy: 'latest',
-    });
+    const result = await ConversationService.getConversations(
+      {
+        accountId: 1,
+        status: 'open',
+        assigneeType: 'all',
+        page: 1,
+        sortBy: 'latest',
+      },
+      controller.signal,
+    );
     expect(apiService.get).toHaveBeenCalledWith('conversations', {
       params: {
         inbox_id: null,
@@ -44,6 +49,7 @@ describe('ConversationService', () => {
         page: 1,
         sort_by: 'latest',
       },
+      signal: controller.signal,
     });
     expect(result).toEqual({
       conversations: conversationListResponse.data.payload.map(transformConversation),

--- a/src/store/conversation/specs/conversationSlice.spec.ts
+++ b/src/store/conversation/specs/conversationSlice.spec.ts
@@ -215,6 +215,13 @@ describe('conversation reducer', () => {
   });
 
   it('ignores outdated conversations from list fetches', () => {
+    const requestArg = {
+      accountId: 1,
+      status: 'open' as const,
+      assigneeType: 'all' as const,
+      page: 1,
+      sortBy: 'latest' as const,
+    };
     const initialConversation = {
       ...conversation,
       status: 'resolved' as const,
@@ -227,7 +234,11 @@ describe('conversation reducer', () => {
       updatedAt: 100,
     };
 
-    let state = conversationReducer(undefined, addConversation(initialConversation));
+    let state = conversationReducer(
+      undefined,
+      conversationActions.fetchConversations.pending('request-id', requestArg),
+    );
+    state = conversationReducer(state, addConversation(initialConversation));
     state = conversationReducer(
       state,
       conversationActions.fetchConversations.fulfilled(
@@ -240,16 +251,65 @@ describe('conversation reducer', () => {
           },
         },
         'request-id',
-        {
-          status: 'open',
-          assigneeType: 'all',
-          page: 1,
-          sortBy: 'latest',
-        },
+        requestArg,
       ),
     );
 
     expect(state.entities[conversation.id]?.status).toBe('resolved');
     expect(state.entities[conversation.id]?.updatedAt).toBe(200);
+  });
+
+  it('ignores a list response from the previously active account', () => {
+    const accountOneRequest = {
+      accountId: 1,
+      status: 'open' as const,
+      assigneeType: 'all' as const,
+      page: 1,
+      sortBy: 'latest' as const,
+    };
+    const accountTwoRequest = { ...accountOneRequest, accountId: 2 };
+    const accountTwoConversation = {
+      ...conversation,
+      id: 251,
+      accountId: 2,
+    };
+
+    let state = conversationReducer(
+      undefined,
+      conversationActions.fetchConversations.pending('request-a', accountOneRequest),
+    );
+    state = conversationReducer(
+      state,
+      conversationActions.fetchConversations.pending('request-b', accountTwoRequest),
+    );
+    state = conversationReducer(
+      state,
+      conversationActions.fetchConversations.fulfilled(
+        {
+          conversations: [conversation],
+          meta: { mineCount: 1, unassignedCount: 0, allCount: 1 },
+        },
+        'request-a',
+        accountOneRequest,
+      ),
+    );
+
+    expect(state.ids).toEqual([]);
+    expect(state.isLoadingConversations).toBe(true);
+
+    state = conversationReducer(
+      state,
+      conversationActions.fetchConversations.fulfilled(
+        {
+          conversations: [accountTwoConversation],
+          meta: { mineCount: 1, unassignedCount: 0, allCount: 1 },
+        },
+        'request-b',
+        accountTwoRequest,
+      ),
+    );
+
+    expect(state.ids).toEqual([accountTwoConversation.id]);
+    expect(state.entities[accountTwoConversation.id]?.accountId).toBe(2);
   });
 });


### PR DESCRIPTION
## Description

Prevents conversations from multiple accessible accounts from appearing together after a user switches the active account.

### Reproduction

1. Sign in as a user with access to accounts A and B.
2. Load the conversation list for account A.
3. Switch to account B while a conversation-list request for A is still in flight.
4. Let the account B request complete, followed by the older account A request.

Before this change, both responses were upserted into the same persisted Redux entity store and the list selector did not filter by `accountId`. The UI could therefore show conversations from A and B together until a refresh cleared the store.

### Changes

- Carry the active account ID with every conversation-list request.
- Propagate the RTK `AbortSignal` to Axios and cancel replaced list requests.
- Ignore fulfilled or rejected list actions whose account or request ID is no longer active.
- Filter rendered conversations by the active account as a defense in depth.
- Wait for `set_active_account` to complete before replacing the navigation tree, avoiding a race with profile initialization.
- Reset account-scoped conversation metadata when clearing or changing accounts.

No customer screenshot is included because the issue is reproducible with synthetic accounts and contacts.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `pnpm exec jest --runInBand src/store/conversation/specs` — 8 suites, 52 tests passed.
- ESLint passed for every changed file.
- Added regression coverage for a late response from the previously active account and selector-level account isolation.
- Global `pnpm lint` and `pnpm exec tsc --noEmit` still report pre-existing errors in unrelated files on `develop`; no new focused lint or test failures were introduced.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added regression tests
- [x] My changes generate no new focused lint warnings
- [ ] I have tested in both Android and iOS platform
- [x] No dependent package changes are required