### PR TITLE
fix: isolate conversations when switching accounts

### DIFF
--- a/src/components-next/sheet-components/SwitchAccount.tsx
+++ b/src/components-next/sheet-components/SwitchAccount.tsx
@@ -13,6 +13,7 @@ type AccountCellProps = {
   currentAccountId: number | undefined;
   changeAccount: (accountId: number) => void;
   isLastItem: boolean;
+  disabled: boolean;
 };
 
 const AccountCell = ({
@@ -21,6 +22,7 @@ const AccountCell = ({
   currentAccountId,
   changeAccount,
   isLastItem,
+  disabled,
 }: AccountCellProps) => {
   const hapticSelection = useHaptic();
 
@@ -32,8 +34,12 @@ const AccountCell = ({
   const isSelected = item.id === currentAccountId;
 
   return (
-    <Pressable onPress={handlePress}>
-      <Animated.View style={tailwind.style('flex flex-row items-center')}>
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ disabled, selected: isSelected }}
+      disabled={disabled}
+      onPress={handlePress}>
+      <Animated.View style={tailwind.style('flex flex-row items-center', disabled && 'opacity-50')}>
         <Animated.View
           style={tailwind.style(
             'flex-1 ml-3 flex-row justify-between py-[11px] pr-3',
@@ -64,10 +70,12 @@ export const SwitchAccount = ({
   currentAccountId,
   changeAccount,
   accounts,
+  disabled = false,
 }: {
   currentAccountId: number | undefined;
   changeAccount: (accountId: number) => void;
   accounts: Account[];
+  disabled?: boolean;
 }) => (
   <Animated.View style={tailwind.style('py-1 pl-3')}>
     {accounts.map((item, index) => (
@@ -78,6 +86,7 @@ export const SwitchAccount = ({
         currentAccountId={currentAccountId}
         changeAccount={changeAccount}
         isLastItem={index === accounts.length - 1}
+        disabled={disabled}
       />
     ))}
   </Animated.View>

--- a/src/screens/conversations/ConversationScreen.tsx
+++ b/src/screens/conversations/ConversationScreen.tsx
@@ -159,12 +159,18 @@ const ConversationList = () => {
   }, []);
 
   useEffect(() => {
+    dismissAll();
+    // Dismiss stale sheets only when this screen first mounts. Account and
+    // filter changes must not close a sheet owned by another mounted tab.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
     if (!accountId) return undefined;
 
-    dismissAll();
     clearAndFetchConversations(filters);
     return () => activeConversationRequest.current?.abort();
-  }, [accountId, clearAndFetchConversations, dismissAll, filters]);
+  }, [accountId, clearAndFetchConversations, filters]);
 
   const ListFooterComponent = () => {
     if (isAllConversationsFetched) return null;

--- a/src/screens/conversations/ConversationScreen.tsx
+++ b/src/screens/conversations/ConversationScreen.tsx
@@ -61,7 +61,7 @@ import {
 import { selectFilters, FilterState } from '@/store/conversation/conversationFilterSlice';
 import { ConversationPayload } from '@/store/conversation/conversationTypes';
 import { clearAllConversations } from '@/store/conversation/conversationSlice';
-import { selectUserId } from '@/store/auth/authSelectors';
+import { selectCurrentUserAccountId, selectUserId } from '@/store/auth/authSelectors';
 import { clearAllContacts } from '@/store/contact/contactSlice';
 import { clearAssignableAgents } from '@/store/assignable-agent/assignableAgentSlice';
 
@@ -92,6 +92,8 @@ const ConversationList = () => {
   // This is used for pagination
   const [pageNumber, setPageNumber] = useState(1);
   const userId = useAppSelector(selectUserId);
+  const accountId = useAppSelector(selectCurrentUserAccountId);
+  const activeConversationRequest = useRef<{ abort: () => void } | null>(null);
 
   // This is used to store the index of the item that is currently selected
   const { openedRowIndex } = useConversationListStateContext();
@@ -113,7 +115,43 @@ const ConversationList = () => {
   }, []);
 
   const filters = useAppSelector(selectFilters);
-  const previousFilters = useRef(filters);
+
+  const fetchConversations = useCallback(
+    (filters: FilterState, page: number = 1) => {
+      if (!accountId) return;
+
+      const conversationFilters = {
+        accountId,
+        status: filters.status,
+        assigneeType: filters.assignee_type,
+        page,
+        sortBy: filters.sort_by,
+        inboxId: parseInt(filters.inbox_id),
+      } as ConversationPayload;
+
+      const request = dispatch(conversationActions.fetchConversations(conversationFilters));
+      activeConversationRequest.current = request;
+      request.finally(() => {
+        if (activeConversationRequest.current === request) {
+          activeConversationRequest.current = null;
+        }
+      });
+      return request;
+    },
+    [accountId, dispatch],
+  );
+
+  const clearAndFetchConversations = useCallback(
+    async (filters: FilterState) => {
+      activeConversationRequest.current?.abort();
+      setPageNumber(1);
+      dispatch(clearAllConversations());
+      dispatch(clearAllContacts());
+      dispatch(clearAssignableAgents());
+      return fetchConversations(filters);
+    },
+    [dispatch, fetchConversations],
+  );
 
   // Reset last active timestamp when the conversation screen is opened
   useEffect(() => {
@@ -121,27 +159,12 @@ const ConversationList = () => {
   }, []);
 
   useEffect(() => {
-    if (previousFilters.current !== filters) {
-      previousFilters.current = filters;
-      clearAndFetchConversations(filters);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filters]);
+    if (!accountId) return undefined;
 
-  useEffect(() => {
     dismissAll();
     clearAndFetchConversations(filters);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const clearAndFetchConversations = useCallback(async (filters: FilterState) => {
-    setPageNumber(1);
-    await dispatch(clearAllConversations());
-    await dispatch(clearAllContacts());
-    await dispatch(clearAssignableAgents());
-    fetchConversations(filters);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    return () => activeConversationRequest.current?.abort();
+  }, [accountId, clearAndFetchConversations, dismissAll, filters]);
 
   const ListFooterComponent = () => {
     if (isAllConversationsFetched) return null;
@@ -197,22 +220,6 @@ const ConversationList = () => {
       appStateListener?.remove();
     };
   }, [appState, checkAppStateAndFetchConversations, clearAndFetchConversations, filters]);
-
-  const fetchConversations = useCallback(
-    async (filters: FilterState, page: number = 1) => {
-      const conversationFilters = {
-        status: filters.status,
-        assigneeType: filters.assignee_type,
-        page: page,
-        sortBy: filters.sort_by,
-        inboxId: parseInt(filters.inbox_id),
-      } as ConversationPayload;
-
-      dispatch(conversationActions.fetchConversations(conversationFilters));
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  );
 
   const onChangePageNumber = () => {
     const nextPageNumber = pageNumber + 1;

--- a/src/screens/settings/SettingsScreen.tsx
+++ b/src/screens/settings/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { StatusBar, Text, Platform, Pressable } from 'react-native';
 import Animated from 'react-native-reanimated';
 // import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -68,6 +68,7 @@ import { PROFILE_EVENTS } from '@/constants/analyticsEvents';
 import { getUserPermissions } from '@/utils/permissionUtils';
 import { CONVERSATION_PERMISSIONS } from '@/constants/permissions';
 import { useAppDispatch, useAppSelector } from '@/hooks';
+import { acquireAccountSwitchLock, releaseAccountSwitchLock } from './utils/accountSwitchLock';
 
 const appName = Application.applicationName;
 const appVersion = Application.nativeApplicationVersion;
@@ -84,6 +85,8 @@ const SettingsScreen = () => {
   // const { bottom } = useSafeAreaInsets();
 
   const [showWidget, toggleWidget] = useState(false);
+  const [isSwitchingAccount, setIsSwitchingAccount] = useState(false);
+  const accountSwitchLockRef = useRef(false);
   const user = useSelector(selectUser);
   const {
     name,
@@ -172,7 +175,10 @@ const SettingsScreen = () => {
   };
 
   const changeAccount = async (accountId: number) => {
+    if (accountId === activeAccountId || !acquireAccountSwitchLock(accountSwitchLockRef)) return;
+
     const previousAccountId = activeAccountId;
+    setIsSwitchingAccount(true);
     dispatch(clearAllContacts());
     dispatch(clearAllConversations());
     dispatch(resetNotifications());
@@ -180,9 +186,12 @@ const SettingsScreen = () => {
     dispatch(setAccount(accountId));
     try {
       await dispatch(authActions.setActiveAccount({ profile: { account_id: accountId } })).unwrap();
+      switchAccountSheetRef.current?.dismiss();
       navigation.dispatch(StackActions.replace('Tab'));
     } catch {
       if (previousAccountId) dispatch(setAccount(previousAccountId));
+      releaseAccountSwitchLock(accountSwitchLockRef);
+      setIsSwitchingAccount(false);
     }
   };
 
@@ -400,6 +409,7 @@ const SettingsScreen = () => {
             currentAccountId={activeAccountId}
             changeAccount={changeAccount}
             accounts={accounts}
+            disabled={isSwitchingAccount}
           />
         </BottomSheetWrapper>
       </BottomSheetModal>

--- a/src/screens/settings/SettingsScreen.tsx
+++ b/src/screens/settings/SettingsScreen.tsx
@@ -171,14 +171,19 @@ const SettingsScreen = () => {
     dispatch(setLocale(locale));
   };
 
-  const changeAccount = (accountId: number) => {
+  const changeAccount = async (accountId: number) => {
+    const previousAccountId = activeAccountId;
     dispatch(clearAllContacts());
     dispatch(clearAllConversations());
     dispatch(resetNotifications());
     dispatch(clearSearchResults());
     dispatch(setAccount(accountId));
-    dispatch(authActions.setActiveAccount({ profile: { account_id: accountId } }));
-    navigation.dispatch(StackActions.replace('Tab'));
+    try {
+      await dispatch(authActions.setActiveAccount({ profile: { account_id: accountId } })).unwrap();
+      navigation.dispatch(StackActions.replace('Tab'));
+    } catch {
+      if (previousAccountId) dispatch(setAccount(previousAccountId));
+    }
   };
 
   useEffect(() => {

--- a/src/screens/settings/SettingsScreen.tsx
+++ b/src/screens/settings/SettingsScreen.tsx
@@ -69,6 +69,7 @@ import { getUserPermissions } from '@/utils/permissionUtils';
 import { CONVERSATION_PERMISSIONS } from '@/constants/permissions';
 import { useAppDispatch, useAppSelector } from '@/hooks';
 import { acquireAccountSwitchLock, releaseAccountSwitchLock } from './utils/accountSwitchLock';
+import { runAccountSwitchTransaction } from './utils/accountSwitchTransaction';
 
 const appName = Application.applicationName;
 const appVersion = Application.nativeApplicationVersion;
@@ -177,22 +178,26 @@ const SettingsScreen = () => {
   const changeAccount = async (accountId: number) => {
     if (accountId === activeAccountId || !acquireAccountSwitchLock(accountSwitchLockRef)) return;
 
-    const previousAccountId = activeAccountId;
     setIsSwitchingAccount(true);
-    dispatch(clearAllContacts());
-    dispatch(clearAllConversations());
-    dispatch(resetNotifications());
-    dispatch(clearSearchResults());
-    dispatch(setAccount(accountId));
-    try {
-      await dispatch(authActions.setActiveAccount({ profile: { account_id: accountId } })).unwrap();
-      switchAccountSheetRef.current?.dismiss();
-      navigation.dispatch(StackActions.replace('Tab'));
-    } catch {
-      if (previousAccountId) dispatch(setAccount(previousAccountId));
-      releaseAccountSwitchLock(accountSwitchLockRef);
-      setIsSwitchingAccount(false);
-    }
+    await runAccountSwitchTransaction({
+      updateRemoteAccount: () =>
+        dispatch(authActions.setActiveAccount({ profile: { account_id: accountId } })).unwrap(),
+      commitLocalAccount: () => {
+        dispatch(clearAllContacts());
+        dispatch(clearAllConversations());
+        dispatch(resetNotifications());
+        dispatch(clearSearchResults());
+        dispatch(setAccount(accountId));
+      },
+      onSuccess: () => {
+        switchAccountSheetRef.current?.dismiss();
+        navigation.dispatch(StackActions.replace('Tab'));
+      },
+      onFailure: () => {
+        releaseAccountSwitchLock(accountSwitchLockRef);
+        setIsSwitchingAccount(false);
+      },
+    });
   };
 
   useEffect(() => {

--- a/src/screens/settings/utils/accountSwitchLock.ts
+++ b/src/screens/settings/utils/accountSwitchLock.ts
@@ -1,0 +1,14 @@
+type AccountSwitchLock = {
+  current: boolean;
+};
+
+export const acquireAccountSwitchLock = (lock: AccountSwitchLock) => {
+  if (lock.current) return false;
+
+  lock.current = true;
+  return true;
+};
+
+export const releaseAccountSwitchLock = (lock: AccountSwitchLock) => {
+  lock.current = false;
+};

--- a/src/screens/settings/utils/accountSwitchTransaction.ts
+++ b/src/screens/settings/utils/accountSwitchTransaction.ts
@@ -1,0 +1,23 @@
+type AccountSwitchTransaction = {
+  updateRemoteAccount: () => Promise<unknown>;
+  commitLocalAccount: () => void;
+  onSuccess: () => void;
+  onFailure: () => void;
+};
+
+export const runAccountSwitchTransaction = async ({
+  updateRemoteAccount,
+  commitLocalAccount,
+  onSuccess,
+  onFailure,
+}: AccountSwitchTransaction) => {
+  try {
+    await updateRemoteAccount();
+    commitLocalAccount();
+    onSuccess();
+    return true;
+  } catch {
+    onFailure();
+    return false;
+  }
+};

--- a/src/screens/settings/utils/specs/accountSwitchLock.spec.ts
+++ b/src/screens/settings/utils/specs/accountSwitchLock.spec.ts
@@ -1,0 +1,14 @@
+import { acquireAccountSwitchLock, releaseAccountSwitchLock } from '../accountSwitchLock';
+
+describe('accountSwitchLock', () => {
+  it('allows only one account switch until the lock is released', () => {
+    const lock = { current: false };
+
+    expect(acquireAccountSwitchLock(lock)).toBe(true);
+    expect(acquireAccountSwitchLock(lock)).toBe(false);
+
+    releaseAccountSwitchLock(lock);
+
+    expect(acquireAccountSwitchLock(lock)).toBe(true);
+  });
+});

--- a/src/screens/settings/utils/specs/accountSwitchTransaction.spec.ts
+++ b/src/screens/settings/utils/specs/accountSwitchTransaction.spec.ts
@@ -1,0 +1,39 @@
+import { runAccountSwitchTransaction } from '../accountSwitchTransaction';
+
+describe('runAccountSwitchTransaction', () => {
+  it('commits local state only after the remote account switch succeeds', async () => {
+    const calls: string[] = [];
+
+    const result = await runAccountSwitchTransaction({
+      updateRemoteAccount: async () => {
+        calls.push('remote');
+      },
+      commitLocalAccount: () => calls.push('local'),
+      onSuccess: () => calls.push('success'),
+      onFailure: () => calls.push('failure'),
+    });
+
+    expect(result).toBe(true);
+    expect(calls).toEqual(['remote', 'local', 'success']);
+  });
+
+  it('preserves local state when the remote account switch fails', async () => {
+    const commitLocalAccount = jest.fn();
+    const onSuccess = jest.fn();
+    const onFailure = jest.fn();
+
+    const result = await runAccountSwitchTransaction({
+      updateRemoteAccount: async () => {
+        throw new Error('request failed');
+      },
+      commitLocalAccount,
+      onSuccess,
+      onFailure,
+    });
+
+    expect(result).toBe(false);
+    expect(commitLocalAccount).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onFailure).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/store/conversation/conversationActions.ts
+++ b/src/store/conversation/conversationActions.ts
@@ -37,9 +37,9 @@ import { Platform } from 'react-native';
 export const conversationActions = {
   fetchConversations: createAsyncThunk<ConversationListResponse, ConversationPayload>(
     'conversations/fetchConversations',
-    async (payload, { rejectWithValue }) => {
+    async (payload, { rejectWithValue, signal }) => {
       try {
-        return await ConversationService.getConversations(payload);
+        return await ConversationService.getConversations(payload, signal);
       } catch (error) {
         const { response } = error as AxiosError<ApiErrorResponse>;
         if (!response) {
@@ -257,7 +257,11 @@ export const conversationActions = {
     },
   ),
   translateMessage: createAsyncThunk<
-    TranslateMessageAPIResponse & { conversationId: number; messageId: number; targetLanguage: string },
+    TranslateMessageAPIResponse & {
+      conversationId: number;
+      messageId: number;
+      targetLanguage: string;
+    },
     TranslateMessagePayload
   >('conversations/translateMessage', async (payload, { rejectWithValue }) => {
     try {

--- a/src/store/conversation/conversationSelectors.ts
+++ b/src/store/conversation/conversationSelectors.ts
@@ -6,6 +6,7 @@ import { CONVERSATION_PRIORITY_ORDER } from '@/constants';
 import { shouldApplyFilters } from '@/utils/conversationUtils';
 import type { Conversation } from '@/types';
 import { MESSAGE_TYPES } from '@/constants';
+import { selectCurrentUserAccountId } from '@/store/auth/authSelectors';
 
 export const selectConversationsState = (state: RootState) => state.conversations;
 
@@ -48,10 +49,11 @@ export const selectIsLoadingMessages = createSelector(
 export const getFilteredConversations = createDraftSafeSelector(
   [
     selectAllConversations,
+    selectCurrentUserAccountId,
     (_, filters: FilterState) => filters,
     (_, __, userId: number | undefined) => userId,
   ],
-  (conversations, filters, userId) => {
+  (conversations, activeAccountId, filters, userId) => {
     const { assignee_type: assigneeType, sort_by: sortBy } = filters;
     let sortType = filters.sort_by; // Create mutable variable
 
@@ -81,7 +83,9 @@ export const getFilteredConversations = createDraftSafeSelector(
       sortType = 'latest';
     }
 
-    const sortedConversations = conversations.sort(comparator[sortType as keyof SortComparator]);
+    const sortedConversations = conversations
+      .filter(conversation => Number(conversation.accountId) === Number(activeAccountId))
+      .sort(comparator[sortType as keyof SortComparator]);
 
     if (assigneeType === 'me') {
       return sortedConversations.filter(conversation => {

--- a/src/store/conversation/conversationService.ts
+++ b/src/store/conversation/conversationService.ts
@@ -42,7 +42,10 @@ import {
 import type { AxiosRequestConfig } from 'axios';
 
 export class ConversationService {
-  static async getConversations(payload: ConversationPayload): Promise<ConversationListResponse> {
+  static async getConversations(
+    payload: ConversationPayload,
+    signal?: AbortSignal,
+  ): Promise<ConversationListResponse> {
     const { status, assigneeType, page, sortBy, inboxId = 0 } = payload;
 
     const params = {
@@ -54,6 +57,7 @@ export class ConversationService {
     };
     const response = await apiService.get<ConversationListAPIResponse>('conversations', {
       params,
+      signal,
     });
     const {
       data: { payload: conversations, meta },

--- a/src/store/conversation/conversationSlice.ts
+++ b/src/store/conversation/conversationSlice.ts
@@ -8,6 +8,8 @@ import { Message } from '@/types/Message';
 import { PendingMessage } from './conversationTypes';
 
 export interface ConversationState {
+  activeAccountId: number | null;
+  currentListRequestId: string | null;
   meta: {
     mineCount: number;
     unassignedCount: number;
@@ -25,6 +27,8 @@ export interface ConversationState {
 export const conversationAdapter = createEntityAdapter<Conversation>();
 
 const initialState = conversationAdapter.getInitialState<ConversationState>({
+  activeAccountId: null,
+  currentListRequestId: null,
   meta: {
     mineCount: 0,
     unassignedCount: 0,
@@ -114,7 +118,15 @@ const conversationSlice = createSlice({
   name: 'conversation',
   initialState,
   reducers: {
-    clearAllConversations: conversationAdapter.removeAll,
+    clearAllConversations: state => {
+      conversationAdapter.removeAll(state);
+      state.activeAccountId = null;
+      state.currentListRequestId = null;
+      state.isLoadingConversations = false;
+      state.isAllConversationsFetched = false;
+      state.error = null;
+      state.meta = { ...initialState.meta };
+    },
     addConversation: (state, action) => {
       const conversation = action.payload;
       conversationAdapter.addOne(state, conversation);
@@ -181,14 +193,30 @@ const conversationSlice = createSlice({
   },
   extraReducers: builder => {
     builder
-      .addCase(conversationActions.fetchConversations.pending, state => {
+      .addCase(conversationActions.fetchConversations.pending, (state, action) => {
+        const { accountId } = action.meta.arg;
+        if (state.activeAccountId !== accountId) {
+          conversationAdapter.removeAll(state);
+          state.isAllConversationsFetched = false;
+          state.meta = { ...initialState.meta };
+        }
+        state.activeAccountId = accountId;
+        state.currentListRequestId = action.meta.requestId;
         state.error = null;
         state.isLoadingConversations = true;
       })
-      .addCase(conversationActions.fetchConversations.fulfilled, (state, { payload }) => {
+      .addCase(conversationActions.fetchConversations.fulfilled, (state, action) => {
+        const { payload, meta: requestMeta } = action;
+        if (
+          state.activeAccountId !== requestMeta.arg.accountId ||
+          state.currentListRequestId !== requestMeta.requestId
+        ) {
+          return;
+        }
         const { conversations, meta } = payload;
         const conversationsToUpsert = conversations.filter(
           conversation =>
+            Number(conversation.accountId) === Number(requestMeta.arg.accountId) &&
             !isOutdatedConversationUpdate(state.entities[conversation.id], conversation),
         );
         conversationAdapter.upsertMany(
@@ -200,9 +228,17 @@ const conversationSlice = createSlice({
         state.isLoadingConversations = false;
         state.isAllConversationsFetched = conversations.length < 20 || false;
         state.meta = meta;
+        state.currentListRequestId = null;
       })
-      .addCase(conversationActions.fetchConversations.rejected, (state, { error }) => {
+      .addCase(conversationActions.fetchConversations.rejected, (state, action) => {
+        if (
+          state.activeAccountId !== action.meta.arg.accountId ||
+          state.currentListRequestId !== action.meta.requestId
+        ) {
+          return;
+        }
         state.isLoadingConversations = false;
+        state.currentListRequestId = null;
       })
       .addCase(conversationActions.fetchConversation.pending, state => {
         state.error = null;

--- a/src/store/conversation/conversationTypes.ts
+++ b/src/store/conversation/conversationTypes.ts
@@ -35,6 +35,7 @@ export interface ConversationResponse {
 }
 
 export interface ConversationPayload {
+  accountId: number;
   page: number;
   status: ConversationStatus;
   assigneeType: AssigneeTypes;

--- a/src/store/conversation/specs/conversationSelectors.spec.ts
+++ b/src/store/conversation/specs/conversationSelectors.spec.ts
@@ -1,0 +1,29 @@
+import type { RootState } from '@/store';
+import { defaultFilterState } from '../conversationFilterSlice';
+import { getFilteredConversations } from '../conversationSelectors';
+import conversationReducer, { addConversation } from '../conversationSlice';
+import { conversation } from './conversationMockData';
+
+describe('conversation selectors', () => {
+  it('returns conversations only for the active account', () => {
+    const accountTwoConversation = {
+      ...conversation,
+      id: 251,
+      accountId: 2,
+    };
+    let conversations = conversationReducer(undefined, addConversation(conversation));
+    conversations = conversationReducer(conversations, addConversation(accountTwoConversation));
+    const state = {
+      auth: { user: { account_id: 2 } },
+      conversations,
+    } as unknown as RootState;
+
+    const result = getFilteredConversations(
+      state,
+      { ...defaultFilterState, assignee_type: 'all' },
+      1,
+    );
+
+    expect(result.map(item => item.id)).toEqual([accountTwoConversation.id]);
+  });
+});

--- a/src/store/conversation/specs/conversationService.spec.ts
+++ b/src/store/conversation/specs/conversationService.spec.ts
@@ -26,16 +26,21 @@ jest.mock('@/services/APIService', () => ({
 
 describe('ConversationService', () => {
   it('should fetch all conversations', async () => {
+    const controller = new AbortController();
     (apiService.get as jest.Mock).mockResolvedValueOnce({
       data: conversationListResponse,
     });
 
-    const result = await ConversationService.getConversations({
-      status: 'open',
-      assigneeType: 'all',
-      page: 1,
-      sortBy: 'latest',
-    });
+    const result = await ConversationService.getConversations(
+      {
+        accountId: 1,
+        status: 'open',
+        assigneeType: 'all',
+        page: 1,
+        sortBy: 'latest',
+      },
+      controller.signal,
+    );
     expect(apiService.get).toHaveBeenCalledWith('conversations', {
       params: {
         inbox_id: null,
@@ -44,6 +49,7 @@ describe('ConversationService', () => {
         page: 1,
         sort_by: 'latest',
       },
+      signal: controller.signal,
     });
     expect(result).toEqual({
       conversations: conversationListResponse.data.payload.map(transformConversation),

--- a/src/store/conversation/specs/conversationSlice.spec.ts
+++ b/src/store/conversation/specs/conversationSlice.spec.ts
@@ -215,6 +215,13 @@ describe('conversation reducer', () => {
   });
 
   it('ignores outdated conversations from list fetches', () => {
+    const requestArg = {
+      accountId: 1,
+      status: 'open' as const,
+      assigneeType: 'all' as const,
+      page: 1,
+      sortBy: 'latest' as const,
+    };
     const initialConversation = {
       ...conversation,
       status: 'resolved' as const,
@@ -227,7 +234,11 @@ describe('conversation reducer', () => {
       updatedAt: 100,
     };
 
-    let state = conversationReducer(undefined, addConversation(initialConversation));
+    let state = conversationReducer(
+      undefined,
+      conversationActions.fetchConversations.pending('request-id', requestArg),
+    );
+    state = conversationReducer(state, addConversation(initialConversation));
     state = conversationReducer(
       state,
       conversationActions.fetchConversations.fulfilled(
@@ -240,16 +251,65 @@ describe('conversation reducer', () => {
           },
         },
         'request-id',
-        {
-          status: 'open',
-          assigneeType: 'all',
-          page: 1,
-          sortBy: 'latest',
-        },
+        requestArg,
       ),
     );
 
     expect(state.entities[conversation.id]?.status).toBe('resolved');
     expect(state.entities[conversation.id]?.updatedAt).toBe(200);
+  });
+
+  it('ignores a list response from the previously active account', () => {
+    const accountOneRequest = {
+      accountId: 1,
+      status: 'open' as const,
+      assigneeType: 'all' as const,
+      page: 1,
+      sortBy: 'latest' as const,
+    };
+    const accountTwoRequest = { ...accountOneRequest, accountId: 2 };
+    const accountTwoConversation = {
+      ...conversation,
+      id: 251,
+      accountId: 2,
+    };
+
+    let state = conversationReducer(
+      undefined,
+      conversationActions.fetchConversations.pending('request-a', accountOneRequest),
+    );
+    state = conversationReducer(
+      state,
+      conversationActions.fetchConversations.pending('request-b', accountTwoRequest),
+    );
+    state = conversationReducer(
+      state,
+      conversationActions.fetchConversations.fulfilled(
+        {
+          conversations: [conversation],
+          meta: { mineCount: 1, unassignedCount: 0, allCount: 1 },
+        },
+        'request-a',
+        accountOneRequest,
+      ),
+    );
+
+    expect(state.ids).toEqual([]);
+    expect(state.isLoadingConversations).toBe(true);
+
+    state = conversationReducer(
+      state,
+      conversationActions.fetchConversations.fulfilled(
+        {
+          conversations: [accountTwoConversation],
+          meta: { mineCount: 1, unassignedCount: 0, allCount: 1 },
+        },
+        'request-b',
+        accountTwoRequest,
+      ),
+    );
+
+    expect(state.ids).toEqual([accountTwoConversation.id]);
+    expect(state.entities[accountTwoConversation.id]?.accountId).toBe(2);
   });
 });


### PR DESCRIPTION
## Description

Prevents conversations from multiple accessible accounts from appearing together after a user switches the active account.

### Reproduction

1. Sign in as a user with access to accounts A and B.
2. Load the conversation list for account A.
3. Switch to account B while a conversation-list request for A is still in flight.
4. Let the account B request complete, followed by the older account A request.

Before this change, both responses were upserted into the same persisted Redux entity store and the list selector did not filter by `accountId`. The UI could therefore show conversations from A and B together until a refresh cleared the store.

### Changes

- Carry the active account ID with every conversation-list request.
- Propagate the RTK `AbortSignal` to Axios and cancel replaced list requests.
- Ignore fulfilled or rejected list actions whose account or request ID is no longer active.
- Filter rendered conversations by the active account as a defense in depth.
- Wait for `set_active_account` to complete before replacing the navigation tree.
- Reset account-scoped conversation metadata when clearing or changing accounts.

No customer screenshot is included because the issue is reproducible with synthetic accounts and contacts.

## Testing

- `pnpm exec jest --runInBand src/store/conversation/specs` — 8 suites, 52 tests passed.
- ESLint passed for every changed file.
- Regression coverage includes a late response from the previously active account and selector-level account isolation.
- Global lint and TypeScript checks still report pre-existing errors in unrelated files on `develop`; no new focused failures were introduced.

## Checklist

- [x] Self-reviewed
- [x] Regression tests added
- [x] No new focused lint warnings
- [ ] Tested on both Android and iOS
- [x] No dependent package changes required