### PR TITLE
  fix: whatsapp templates crash on unsynced inboxes and clipped last list row

### DIFF
--- a/src/screens/chat-screen/components/macros/MacrosList.tsx
+++ b/src/screens/chat-screen/components/macros/MacrosList.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View } from 'react-native';
 import Animated from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { BottomSheetModal, BottomSheetScrollView } from '@gorhom/bottom-sheet';
 
 import { BottomSheetBackdrop } from '@/components-next';
@@ -15,7 +16,10 @@ import MacroStack from './MacroStack';
 import MacroDetails from './MacroDetails';
 import { MacroProvider } from './MacroContext';
 
+const LIST_BOTTOM_PADDING = 24;
+
 export const MacrosList = ({ conversationId }: { conversationId: number }) => {
+  const { bottom } = useSafeAreaInsets();
   const macros = useAppSelector(selectAllMacros);
   const [selectedMacro, setSelectedMacro] = useState<Macro | null>(null);
 
@@ -61,7 +65,11 @@ export const MacrosList = ({ conversationId }: { conversationId: number }) => {
                 </View>
                 <BottomSheetScrollView
                   showsVerticalScrollIndicator={false}
-                  contentContainerStyle={tailwind.style('px-3 pb-6')}>
+                  // The sheet reaches the screen edge, so the last row needs to clear the home indicator.
+                  contentContainerStyle={tailwind.style(
+                    'px-3',
+                    `pb-[${LIST_BOTTOM_PADDING + bottom}px]`,
+                  )}>
                   <MacroStack
                     handleMacroPress={handleMacroPress}
                     macrosList={macros}

--- a/src/screens/chat-screen/components/whatsapp-templates/WhatsAppTemplatesList.tsx
+++ b/src/screens/chat-screen/components/whatsapp-templates/WhatsAppTemplatesList.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import Animated from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { BottomSheetModal, BottomSheetScrollView } from '@gorhom/bottom-sheet';
 
 import { BottomSheetBackdrop } from '@/components-next';
@@ -22,6 +23,8 @@ type WhatsAppTemplatesListProps = {
   conversationId: number;
 };
 
+const LIST_BOTTOM_PADDING = 24;
+
 const EmptyState = ({ label }: { label: string }) => (
   <Animated.View style={tailwind.style('flex-1 items-center justify-center px-6 pt-6')}>
     <Animated.Text
@@ -35,6 +38,7 @@ const EmptyState = ({ label }: { label: string }) => (
 
 export const WhatsAppTemplatesList = ({ conversationId }: WhatsAppTemplatesListProps) => {
   const dispatch = useAppDispatch();
+  const { bottom } = useSafeAreaInsets();
   const { whatsAppTemplatesSheetRef } = useRefsContext();
   const [selectedTemplate, setSelectedTemplate] = useState<NormalizedTemplate | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
@@ -94,7 +98,8 @@ export const WhatsAppTemplatesList = ({ conversationId }: WhatsAppTemplatesListP
       <BottomSheetScrollView
         showsVerticalScrollIndicator={false}
         keyboardShouldPersistTaps="handled"
-        contentContainerStyle={tailwind.style('pb-6')}>
+        // The sheet reaches the screen edge, so the last row needs to clear the home indicator.
+        contentContainerStyle={tailwind.style(`pb-[${LIST_BOTTOM_PADDING + bottom}px]`)}>
         {filteredTemplates.map((template, index) => (
           <WhatsAppTemplateItem
             key={`${template.platform}-${template.id}`}

--- a/src/utils/messageTemplateUtils.ts
+++ b/src/utils/messageTemplateUtils.ts
@@ -191,12 +191,16 @@ const normalizeTwilio = (template: TwilioContentTemplate): NormalizedTemplate | 
   };
 };
 
+// `message_templates` and `content_templates` are jsonb columns that default to
+// `{}`, so a channel that has never synced templates serves an object, not an array.
+const toArray = <T>(value: T[] | undefined): T[] => (Array.isArray(value) ? value : []);
+
 export const getTemplates = (
   messageTemplates: WhatsAppMessageTemplate[] | undefined,
   contentTemplates: TwilioContentTemplate[] | undefined,
 ): NormalizedTemplate[] => {
-  const whatsapp = (messageTemplates || []).filter(isSendableTemplate).map(normalizeWhatsApp);
-  const twilio = (contentTemplates || [])
+  const whatsapp = toArray(messageTemplates).filter(isSendableTemplate).map(normalizeWhatsApp);
+  const twilio = toArray(contentTemplates)
     .map(normalizeTwilio)
     .filter((entry): entry is NormalizedTemplate => entry !== null);
   return [...whatsapp, ...twilio];

--- a/src/utils/specs/messageTemplateUtils.spec.ts
+++ b/src/utils/specs/messageTemplateUtils.spec.ts
@@ -325,6 +325,22 @@ describe('getTemplatesForInbox', () => {
     expect(getTemplatesForInbox({} as Inbox)).toEqual([]);
     expect(getTemplatesForInbox(undefined)).toEqual([]);
   });
+
+  it('returns empty array when the api serves the jsonb defaults as objects', () => {
+    const inbox = {
+      messageTemplates: {},
+      contentTemplates: {},
+    } as unknown as Inbox;
+    expect(getTemplatesForInbox(inbox)).toEqual([]);
+  });
+
+  it('ignores non-array template collections', () => {
+    const inbox = {
+      messageTemplates: 'invalid',
+      contentTemplates: { templates: {} },
+    } as unknown as Inbox;
+    expect(getTemplatesForInbox(inbox)).toEqual([]);
+  });
 });
 
 describe('getHeaderSubtitle', () => {


### PR DESCRIPTION
## Description 

Templates Bug fixes

Fixes 
1. [CW-7828](https://linear.app/chatwoot/issue/CW-7828/sentry-issue-undefined-is-not-a-function-templates)
`message_templates`/`content_templates` are jsonb columns defaulting to `{}`, so an inbox that never synced templates crashed the chat window on `{}.filter` : now guarded with `Array.isArray`, matching the web dashboard's getter.
2. [CW-7829](https://linear.app/chatwoot/issue/CW-7829/templates-listing-scroll-issue)
The templates and macros sheets also padded their lists a flat 24px against a screen-edge sheet, clipping the last row behind the home indicator : now `24 + insets.bottom`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
