### PR TITLE
fix: use resolve icon for the chat header status toggle

### DIFF
--- a/src/screens/chat-screen/components/chat-header/ChatHeader.tsx
+++ b/src/screens/chat-screen/components/chat-header/ChatHeader.tsx
@@ -4,7 +4,7 @@ import { BottomSheetModal, useBottomSheetSpringConfigs } from '@gorhom/bottom-sh
 import Animated from 'react-native-reanimated';
 
 import { Avatar, Icon } from '@/components-next';
-import { ChevronLeft, OpenIcon, Overflow, ResolvedIcon, SLAIcon } from '@/svg-icons';
+import { ChevronLeft, Overflow, ResolvedIcon, SLAIcon } from '@/svg-icons';
 import { BottomSheetBackdrop, BottomSheetWrapper } from '@/components-next';
 import { tailwind } from '@/theme';
 import { ChatDropdownMenu, DashboardList } from './DropdownMenu';
@@ -93,11 +93,10 @@ export const ChatHeader = ({
             <Pressable hitSlop={8} onPress={onToggleChatStatus}>
               <Icon
                 icon={
-                  isResolved ? (
-                    <ResolvedIcon strokeWidth={2} stroke={tailwind.color('bg-green-700')} />
-                  ) : (
-                    <OpenIcon strokeWidth={2} />
-                  )
+                  <ResolvedIcon
+                    strokeWidth={2}
+                    {...(isResolved && { stroke: tailwind.color('bg-green-700') })}
+                  />
                 }
                 size={24}
               />


### PR DESCRIPTION
The chat header status toggle rendered a refresh glyph (`OpenIcon`) when a conversation was unresolved, which didn't read as a resolve action.

It now uses `ResolvedIcon` in the same grey as the other header icons (#858585), turning green once the conversation is resolved.

Fixes [DESN-53](https://linear.app/chatwoot/issue/DESN-53/resolving-on-mobile)

| Before | After |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/f81ff0a6-282f-4b9f-a7b7-1e3713cacfb8"  width="300"/> | <img src="https://github.com/user-attachments/assets/c4c3f709-030f-41a0-b650-06ab9fb5e4bc" width="300"/> |

