### PR TITLE
fix: contain render errors with an app-level error boundary

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,15 +4,17 @@ import { Alert, BackHandler } from 'react-native';
 import { PersistGate } from 'redux-persist/integration/react';
 import { store, persistor } from './store';
 import { AppNavigator } from '@/navigation';
+import { AppErrorBoundary } from '@/components-next/error-boundary';
 
 import i18n from '@/i18n';
 
 const Chatwoot = () => {
   useEffect(() => {
-    BackHandler.addEventListener('hardwareBackPress', handleBackButtonClick);
-    return () => {
-      BackHandler.removeEventListener('hardwareBackPress', handleBackButtonClick);
-    };
+    const subscription = BackHandler.addEventListener(
+      'hardwareBackPress',
+      handleBackButtonClick,
+    );
+    return () => subscription.remove();
   }, []);
   const handleBackButtonClick = () => {
     Alert.alert(
@@ -34,7 +36,9 @@ const Chatwoot = () => {
   return (
     <Provider store={store}>
       <PersistGate loading={null} persistor={persistor}>
-        <AppNavigator />
+        <AppErrorBoundary>
+          <AppNavigator />
+        </AppErrorBoundary>
       </PersistGate>
     </Provider>
   );

--- a/src/components-next/error-boundary/AppErrorBoundary.tsx
+++ b/src/components-next/error-boundary/AppErrorBoundary.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { SafeAreaView } from 'react-native';
+import Animated from 'react-native-reanimated';
+import { ErrorBoundary } from '@sentry/react-native';
+
+import i18n from '@/i18n';
+import { tailwind } from '@/theme';
+import { Button } from '../button';
+
+type FallbackProps = {
+  resetError: () => void;
+};
+
+const Fallback = ({ resetError }: FallbackProps) => (
+  <SafeAreaView style={tailwind.style('flex-1 bg-white')}>
+    <Animated.View style={tailwind.style('flex-1 items-center justify-center px-6')}>
+      <Animated.Text
+        style={tailwind.style(
+          'text-lg font-inter-medium-24 tracking-[0.16px] text-gray-950 text-center',
+        )}>
+        {i18n.t('ERRORS.UNEXPECTED_TITLE')}
+      </Animated.Text>
+      <Animated.Text
+        style={tailwind.style(
+          'pt-2 text-md font-inter-420-20 tracking-[0.16px] text-gray-700 text-center',
+        )}>
+        {i18n.t('ERRORS.UNEXPECTED_DESCRIPTION')}
+      </Animated.Text>
+      <Animated.View style={tailwind.style('pt-6 w-full')}>
+        <Button text={i18n.t('ERRORS.TRY_AGAIN')} handlePress={resetError} />
+      </Animated.View>
+    </Animated.View>
+  </SafeAreaView>
+);
+
+type AppErrorBoundaryProps = {
+  children: React.ReactNode;
+};
+
+/**
+ * Contains render-phase exceptions that would otherwise reach React Native's
+ * ExceptionsManager and terminate the process via RCTFatal.
+ *
+ * Sentry's ErrorBoundary reports the exception with its React component stack
+ * before the fallback renders. `resetError` remounts the subtree, so a fault in
+ * one screen does not require the user to relaunch.
+ */
+export const AppErrorBoundary = ({ children }: AppErrorBoundaryProps) => (
+  <ErrorBoundary fallback={({ resetError }) => <Fallback resetError={resetError} />}>
+    {children}
+  </ErrorBoundary>
+);

--- a/src/components-next/error-boundary/index.ts
+++ b/src/components-next/error-boundary/index.ts
@@ -1,0 +1,1 @@
+export * from './AppErrorBoundary';

--- a/src/components-next/index.ts
+++ b/src/components-next/index.ts
@@ -1,5 +1,6 @@
 export * from './button';
 export * from './common';
+export * from './error-boundary';
 export * from './label-section';
 export * from './list-components';
 export * from './sheet-components';

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -459,7 +459,10 @@
     "OfFLINE": "You must connect to Wi-fi or a cellular network to get online again",
     "CANNOT_FETCH": "There was an error fetching the information, please try again",
     "AUTH": "Username / Password Incorrect. Please try again",
-    "NO_ACCOUNTS_MESSAGE": "You don't have access to any chatwoot accounts"
+    "NO_ACCOUNTS_MESSAGE": "You don't have access to any chatwoot accounts",
+    "UNEXPECTED_TITLE": "Something went wrong",
+    "UNEXPECTED_DESCRIPTION": "The app ran into an unexpected problem. You can try again without restarting.",
+    "TRY_AGAIN": "Try again"
   },
   "SUCCESS": {
     "AUTH": "Login Successful"


### PR DESCRIPTION
## Description 

Render-phase exceptions below AppNavigator reached React Native's ExceptionsManager and terminated the process through RCTFatal, so a fault in a single component ended the session rather than the screen.

Sentry's ErrorBoundary captures the exception with its React component stack before rendering a fallback, and resetError remounts the subtree without a relaunch.

Also replaces BackHandler.removeEventListener, which RN 0.79 removed, with the subscription returned by addEventListener.

Fixes [CW-7885](https://linear.app/chatwoot/issue/CW-7885/add-app-level-error-boundary)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Mocked a throw, which showed the fallback screen. [Sentry captured the log](https://chatwoot-p3.sentry.io/issues/7655943655/?environment=production&project=4508442772570112&query=&referrer=issue-stream&sort=recommended)


<video src="https://github.com/user-attachments/assets/26a87a4d-de2a-4196-bffc-75503e373460" />


