### PR TITLE
feat: support captain assistant message sender type

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -307,6 +307,7 @@ export const SENDER_TYPES = {
   CONTACT: 'Contact',
   USER: 'User',
   AGENT_BOT: 'agent_bot',
+  CAPTAIN_ASSISTANT: 'captain_assistant',
 };
 
 export const MESSAGE_VARIANTS = {

--- a/src/screens/chat-screen/components/message-item/Message.tsx
+++ b/src/screens/chat-screen/components/message-item/Message.tsx
@@ -44,6 +44,20 @@ import { useTargetMessageAnimation } from './useTargetMessageAnimation';
 
 // import { ImageMetadata } from '@/types';
 
+const BOT_SENDER_TYPES: string[] = [SENDER_TYPES.AGENT_BOT, SENDER_TYPES.CAPTAIN_ASSISTANT];
+
+const isBotSender = (senderType?: string) => !!senderType && BOT_SENDER_TYPES.includes(senderType);
+
+// Captain assistants are serialized with `avatarUrl`, the other sender types with `thumbnail`.
+const senderAvatarSource = (sender: Message['sender']) => {
+  if (!sender) {
+    return null;
+  }
+  const avatarUrl = 'avatarUrl' in sender ? sender.avatarUrl : null;
+  const thumbnail = 'thumbnail' in sender ? sender.thumbnail : null;
+  return avatarUrl || thumbnail || null;
+};
+
 type MessageComponentProps = {
   item: Message;
   index: number;
@@ -251,7 +265,7 @@ export const MessageComponent = (props: MessageComponentProps) => {
     if (status === MESSAGE_STATUS.FAILED) return MESSAGE_VARIANTS.ERROR;
     if (item.contentAttributes?.isUnsupported) return MESSAGE_VARIANTS.UNSUPPORTED;
 
-    const isBot = !sender || sender.type === SENDER_TYPES.AGENT_BOT;
+    const isBot = !sender || isBotSender(sender.type);
     if (isBot && messageType === MESSAGE_TYPES.OUTGOING) {
       return MESSAGE_VARIANTS.BOT;
     }
@@ -404,7 +418,7 @@ export const MessageComponent = (props: MessageComponentProps) => {
     return {
       name: sender?.name || '',
       src: {
-        uri: sender?.thumbnail || null,
+        uri: senderAvatarSource(sender),
       },
     };
   };

--- a/src/types/CaptainAssistant.ts
+++ b/src/types/CaptainAssistant.ts
@@ -1,0 +1,8 @@
+export interface CaptainAssistant {
+  id: number;
+  name: string | null;
+  description: string | null;
+  avatarUrl?: string | null;
+  createdAt?: string;
+  type: string;
+}

--- a/src/types/Message.ts
+++ b/src/types/Message.ts
@@ -1,5 +1,6 @@
 import { Agent } from './Agent';
 import { AgentBot } from './AgentBot';
+import { CaptainAssistant } from './CaptainAssistant';
 import { UnixTimestamp } from './common';
 import { Contact } from './Contact';
 import { Conversation } from './Conversation';
@@ -78,7 +79,7 @@ export interface Message {
   inboxId: number;
   messageType: MessageType;
   private: boolean;
-  sender?: Agent | User | AgentBot | Contact | null;
+  sender?: Agent | User | AgentBot | CaptainAssistant | Contact | null;
   sourceId: string | null;
   status: MessageStatus;
   lastNonActivityMessage: Message | null;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@ import { AllStatusTypes, AssigneeTypes, SortTypes } from './common';
 
 export * from './Agent';
 export * from './AgentBot';
+export * from './CaptainAssistant';
 export * from './common';
 export * from './Contact';
 export * from './Conversation';


### PR DESCRIPTION
## Description 

Messages generated by a Captain assistant arrive with a sender type of `captain_assistant` and carry the assistant's name and `avatarUrl`.

- Add `CAPTAIN_ASSISTANT` to `SENDER_TYPES`
- Add a `CaptainAssistant` sender type to the `Message.sender` union
- Treat captain assistants as bot senders when picking the bubble variant
- Resolve sender avatars from `avatarUrl` with a `thumbnail` fallback

Fixes [CW-4348](https://linear.app/chatwoot/issue/CW-4348/add-assistant-type)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
