### PR TITLE
fix: render attachments on email inbox messages

### DIFF
--- a/src/screens/chat-screen/components/message-components/ComposedBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/ComposedBubble.tsx
@@ -16,6 +16,7 @@ import { MessageAttachments } from './MessageAttachments';
 type ComposedBubbleProps = {
   item: Message;
   variant: string;
+  orientation?: string;
 };
 
 export const ComposedBubble = (props: ComposedBubbleProps) => {
@@ -54,7 +55,11 @@ export const ComposedBubble = (props: ComposedBubbleProps) => {
             <Spinner size={12} stroke={tailwind.color('text-gray-900')} />
           </Animated.View>
         )}
-        <MessageAttachments item={props.item} variant={props.variant} />
+        <MessageAttachments
+          item={props.item}
+          variant={props.variant}
+          orientation={props.orientation}
+        />
       </Animated.View>
     </Animated.View>
   );

--- a/src/screens/chat-screen/components/message-components/ComposedBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/ComposedBubble.tsx
@@ -1,47 +1,25 @@
 import React, { useMemo } from 'react';
 import Animated from 'react-native-reanimated';
 
-import { FileErrorIcon } from '@/svg-icons';
-import { differenceInHours } from 'date-fns';
 import { tailwind } from '@/theme';
 import { Message } from '@/types';
-import { Icon, Spinner } from '@/components-next';
+import { Spinner } from '@/components-next';
 import { ReplyMessageBubble } from './ReplyMessageBubble';
-
-import { ImageBubbleContainer } from './ImageBubble';
 
 import { useAppSelector } from '@/hooks';
 import { useChatWindowContext } from '@/context';
 import { getMessagesByConversationId } from '@/store/conversation/conversationSelectors';
-import { ATTACHMENT_TYPES, MESSAGE_STATUS } from '@/constants';
-import i18n from '@/i18n';
+import { MESSAGE_STATUS } from '@/constants';
 import { MarkdownBubble } from './MarkdownBubble';
-import { FileBubblePreview } from './FileBubble';
-import { AudioBubble } from './AudioBubble';
-import { VideoBubble } from './VideoBubble';
-import { LocationBubble } from './LocationBubble';
+import { MessageAttachments } from './MessageAttachments';
 
 type ComposedBubbleProps = {
   item: Message;
   variant: string;
 };
 
-const isMessageCreatedAtLessThan24HoursOld = (messageTimestamp: number) => {
-  const currentTime = new Date();
-  const messageTime = new Date(messageTimestamp * 1000);
-  const hoursDifference = differenceInHours(currentTime, messageTime);
-
-  return hoursDifference > 24;
-};
-
 export const ComposedBubble = (props: ComposedBubbleProps) => {
-  const {
-    content,
-    private: isPrivate,
-    createdAt,
-    contentAttributes,
-    status,
-  } = props.item as Message;
+  const { content, private: isPrivate, contentAttributes, status } = props.item as Message;
   const { conversationId } = useChatWindowContext();
 
   const messages = useAppSelector(state => getMessagesByConversationId(state, { conversationId }));
@@ -58,9 +36,7 @@ export const ComposedBubble = (props: ComposedBubbleProps) => {
         : null,
     [messages, contentAttributes],
   );
-  const { imageType } = contentAttributes || {};
-  const isAnInstagramStory = imageType === ATTACHMENT_TYPES.STORY_MENTION;
-  const isInstagramStoryExpired = isMessageCreatedAtLessThan24HoursOld(createdAt);
+
   const isMessageSending = status === MESSAGE_STATUS.PROGRESS;
 
   return (
@@ -78,88 +54,7 @@ export const ComposedBubble = (props: ComposedBubbleProps) => {
             <Spinner size={12} stroke={tailwind.color('text-gray-900')} />
           </Animated.View>
         )}
-        {props.item.attachments &&
-          props.item.attachments.map((attachment, index) => {
-            if (attachment.fileType === 'image') {
-              return isAnInstagramStory && isInstagramStoryExpired ? (
-                <Animated.View
-                  key={attachment.fileType + index}
-                  style={tailwind.style(
-                    'flex flex-row items-center justify-center py-8 bg-slate-100 gap-1 rounded-lg',
-                  )}>
-                  <Icon icon={<FileErrorIcon fill={tailwind.color('text-gray-900')} />} />
-                  <Animated.Text
-                    style={tailwind.style('text-cxs font-inter-420-20 text-gray-900 mt-[1px]')}>
-                    {i18n.t('CONVERSATION.STORY_NOT_AVAILABLE')}
-                  </Animated.Text>
-                </Animated.View>
-              ) : (
-                <Animated.View key={attachment.fileType + index} style={tailwind.style('my-2')}>
-                  <ImageBubbleContainer
-                    imageSrc={attachment.dataUrl}
-                    maxWidth={300 - 24 - (isPrivate ? 13 : 0)}
-                  />
-                </Animated.View>
-              );
-            }
-
-            if (attachment.fileType === ATTACHMENT_TYPES.FILE) {
-              return (
-                <Animated.View
-                  key={attachment.fileType + index}
-                  style={tailwind.style('flex flex-row items-center relative max-w-[300px] my-2')}>
-                  <FileBubblePreview
-                    fileSrc={attachment.dataUrl}
-                    isComposed
-                    variant={props.variant}
-                  />
-                </Animated.View>
-              );
-            }
-            if (attachment.fileType === ATTACHMENT_TYPES.VIDEO) {
-              return (
-                <Animated.View
-                  key={attachment.fileType + index}
-                  style={tailwind.style('flex flex-row items-center my-2')}>
-                  <VideoBubble videoSrc={attachment.dataUrl} />
-                </Animated.View>
-              );
-            }
-            if (attachment.fileType === ATTACHMENT_TYPES.IG_REEL) {
-              return (
-                <Animated.View
-                  key={attachment.fileType + index}
-                  style={tailwind.style('flex flex-row items-center my-2')}>
-                  <VideoBubble videoSrc={attachment.dataUrl} />
-                </Animated.View>
-              );
-            }
-            if (attachment.fileType === ATTACHMENT_TYPES.AUDIO) {
-              return (
-                <Animated.View
-                  key={attachment.fileType + index}
-                  style={tailwind.style('flex flex-row items-center my-2')}>
-                  <AudioBubble audioSrc={attachment.dataUrl} variant={props.variant} />
-                </Animated.View>
-              );
-            }
-
-            if (attachment.fileType === ATTACHMENT_TYPES.LOCATION) {
-              return (
-                <Animated.View
-                  key={attachment.fileType + index}
-                  style={tailwind.style('flex flex-row items-center my-2')}>
-                  <LocationBubble
-                    latitude={attachment.coordinatesLat}
-                    longitude={attachment.coordinatesLong}
-                    variant={props.variant}
-                  />
-                </Animated.View>
-              );
-            }
-
-            return null;
-          })}
+        <MessageAttachments item={props.item} variant={props.variant} />
       </Animated.View>
     </Animated.View>
   );

--- a/src/screens/chat-screen/components/message-components/EmailBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/EmailBubble.tsx
@@ -7,6 +7,7 @@ import { tailwind } from '@/theme';
 import { EmailMeta } from './EmailMeta';
 import { Message } from '@/types';
 import { MarkdownBubble } from './MarkdownBubble';
+import { MessageAttachments } from './MessageAttachments';
 import { MESSAGE_TYPES } from '@/constants';
 
 type EmailBubbleProps = {
@@ -79,6 +80,7 @@ export const EmailBubble = (props: EmailBubbleProps) => {
             />
           )}
         </Animated.View>
+        <MessageAttachments item={messageItem} variant={props.variant} mediaSize="thumbnail" />
       </Animated.View>
     </React.Fragment>
   );

--- a/src/screens/chat-screen/components/message-components/EmailBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/EmailBubble.tsx
@@ -13,6 +13,7 @@ import { MESSAGE_TYPES } from '@/constants';
 type EmailBubbleProps = {
   item: Message;
   variant: string;
+  orientation?: string;
 };
 
 export const EmailBubble = (props: EmailBubbleProps) => {
@@ -80,7 +81,12 @@ export const EmailBubble = (props: EmailBubbleProps) => {
             />
           )}
         </Animated.View>
-        <MessageAttachments item={messageItem} variant={props.variant} mediaSize="thumbnail" />
+        <MessageAttachments
+          item={messageItem}
+          variant={props.variant}
+          orientation={props.orientation}
+          mediaSize="thumbnail"
+        />
       </Animated.View>
     </React.Fragment>
   );

--- a/src/screens/chat-screen/components/message-components/ImageBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/ImageBubble.tsx
@@ -22,6 +22,23 @@ export const ImageBubbleContainer = (props: ImageContainerProps) => {
   );
 };
 
+// Fixed-size media thumbnail.
+export const ImageThumbnail = (props: ImageCellProps) => {
+  const { imageSrc } = props;
+
+  return (
+    <Galeria urls={[imageSrc]}>
+      <Galeria.Image>
+        <Image
+          source={{ uri: imageSrc }}
+          contentFit="cover"
+          style={tailwind.style('h-[72px] w-[72px] rounded-xl bg-gray-100 overflow-hidden')}
+        />
+      </Galeria.Image>
+    </Galeria>
+  );
+};
+
 export const ImageBubble = (props: ImageCellProps) => {
   const { imageSrc } = props;
 

--- a/src/screens/chat-screen/components/message-components/MessageAttachments.tsx
+++ b/src/screens/chat-screen/components/message-components/MessageAttachments.tsx
@@ -4,7 +4,7 @@ import { differenceInHours } from 'date-fns';
 
 import { FileErrorIcon } from '@/svg-icons';
 import { tailwind } from '@/theme';
-import { Message } from '@/types';
+import { ImageMetadata, Message } from '@/types';
 import { Icon } from '@/components-next';
 import { ATTACHMENT_TYPES, TEXT_MAX_WIDTH } from '@/constants';
 import i18n from '@/i18n';
@@ -27,6 +27,26 @@ const isInstagramStoryExpired = (messageTimestamp: number) => {
   return differenceInHours(currentTime, messageTime) > 24;
 };
 
+// Attachments render grouped by type rather than in payload order: media, then audio,
+// then files.
+const MEDIA_TYPES = [ATTACHMENT_TYPES.IMAGE, ATTACHMENT_TYPES.VIDEO, ATTACHMENT_TYPES.IG_REEL];
+
+const groupByType = (attachments: ImageMetadata[]) => {
+  const ofType = (...types: string[]) =>
+    attachments.filter(attachment => types.includes(attachment.fileType));
+
+  const media = ofType(...MEDIA_TYPES).sort(
+    (a, b) => MEDIA_TYPES.indexOf(a.fileType) - MEDIA_TYPES.indexOf(b.fileType),
+  );
+
+  return [
+    ...media,
+    ...ofType(ATTACHMENT_TYPES.AUDIO),
+    ...ofType(ATTACHMENT_TYPES.FILE),
+    ...ofType(ATTACHMENT_TYPES.LOCATION),
+  ];
+};
+
 export const MessageAttachments = (props: MessageAttachmentsProps) => {
   const { item, variant } = props;
   const { attachments, private: isPrivate, contentAttributes, createdAt } = item;
@@ -40,7 +60,7 @@ export const MessageAttachments = (props: MessageAttachmentsProps) => {
 
   return (
     <React.Fragment>
-      {attachments.map((attachment, index) => {
+      {groupByType(attachments).map((attachment, index) => {
         const key = attachment.fileType + index;
 
         if (attachment.fileType === ATTACHMENT_TYPES.IMAGE) {

--- a/src/screens/chat-screen/components/message-components/MessageAttachments.tsx
+++ b/src/screens/chat-screen/components/message-components/MessageAttachments.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import Animated from 'react-native-reanimated';
+import { differenceInHours } from 'date-fns';
+
+import { FileErrorIcon } from '@/svg-icons';
+import { tailwind } from '@/theme';
+import { Message } from '@/types';
+import { Icon } from '@/components-next';
+import { ATTACHMENT_TYPES, TEXT_MAX_WIDTH } from '@/constants';
+import i18n from '@/i18n';
+
+import { ImageBubbleContainer } from './ImageBubble';
+import { FileBubblePreview } from './FileBubble';
+import { AudioBubble } from './AudioBubble';
+import { VideoBubble } from './VideoBubble';
+import { LocationBubble } from './LocationBubble';
+
+type MessageAttachmentsProps = {
+  item: Message;
+  variant: string;
+};
+
+const isInstagramStoryExpired = (messageTimestamp: number) => {
+  const currentTime = new Date();
+  const messageTime = new Date(messageTimestamp * 1000);
+
+  return differenceInHours(currentTime, messageTime) > 24;
+};
+
+export const MessageAttachments = (props: MessageAttachmentsProps) => {
+  const { item, variant } = props;
+  const { attachments, private: isPrivate, contentAttributes, createdAt } = item;
+
+  if (!attachments || attachments.length === 0) {
+    return null;
+  }
+
+  const isAnInstagramStory = contentAttributes?.imageType === ATTACHMENT_TYPES.STORY_MENTION;
+  const imageWidth = TEXT_MAX_WIDTH - 24 - (isPrivate ? 13 : 0);
+
+  return (
+    <React.Fragment>
+      {attachments.map((attachment, index) => {
+        const key = attachment.fileType + index;
+
+        if (attachment.fileType === ATTACHMENT_TYPES.IMAGE) {
+          return isAnInstagramStory && isInstagramStoryExpired(createdAt) ? (
+            <Animated.View
+              key={key}
+              style={tailwind.style(
+                'flex flex-row items-center justify-center py-8 bg-slate-100 gap-1 rounded-lg',
+              )}>
+              <Icon icon={<FileErrorIcon fill={tailwind.color('text-gray-900')} />} />
+              <Animated.Text
+                style={tailwind.style('text-cxs font-inter-420-20 text-gray-900 mt-[1px]')}>
+                {i18n.t('CONVERSATION.STORY_NOT_AVAILABLE')}
+              </Animated.Text>
+            </Animated.View>
+          ) : (
+            <Animated.View key={key} style={tailwind.style('my-2')}>
+              <ImageBubbleContainer imageSrc={attachment.dataUrl} maxWidth={imageWidth} />
+            </Animated.View>
+          );
+        }
+
+        if (attachment.fileType === ATTACHMENT_TYPES.FILE) {
+          return (
+            <Animated.View
+              key={key}
+              style={tailwind.style('flex flex-row items-center relative max-w-[300px] my-2')}>
+              <FileBubblePreview fileSrc={attachment.dataUrl} isComposed variant={variant} />
+            </Animated.View>
+          );
+        }
+
+        if (
+          attachment.fileType === ATTACHMENT_TYPES.VIDEO ||
+          attachment.fileType === ATTACHMENT_TYPES.IG_REEL
+        ) {
+          return (
+            <Animated.View key={key} style={tailwind.style('flex flex-row items-center my-2')}>
+              <VideoBubble videoSrc={attachment.dataUrl} />
+            </Animated.View>
+          );
+        }
+
+        if (attachment.fileType === ATTACHMENT_TYPES.AUDIO) {
+          return (
+            <Animated.View key={key} style={tailwind.style('flex flex-row items-center my-2')}>
+              <AudioBubble audioSrc={attachment.dataUrl} variant={variant} />
+            </Animated.View>
+          );
+        }
+
+        if (attachment.fileType === ATTACHMENT_TYPES.LOCATION) {
+          return (
+            <Animated.View key={key} style={tailwind.style('flex flex-row items-center my-2')}>
+              <LocationBubble
+                latitude={attachment.coordinatesLat}
+                longitude={attachment.coordinatesLong}
+                variant={variant}
+              />
+            </Animated.View>
+          );
+        }
+
+        return null;
+      })}
+    </React.Fragment>
+  );
+};

--- a/src/screens/chat-screen/components/message-components/MessageAttachments.tsx
+++ b/src/screens/chat-screen/components/message-components/MessageAttachments.tsx
@@ -6,7 +6,7 @@ import { FileErrorIcon } from '@/svg-icons';
 import { tailwind } from '@/theme';
 import { ImageMetadata, Message } from '@/types';
 import { Icon } from '@/components-next';
-import { ATTACHMENT_TYPES, TEXT_MAX_WIDTH } from '@/constants';
+import { ATTACHMENT_TYPES, ORIENTATION, TEXT_MAX_WIDTH } from '@/constants';
 import i18n from '@/i18n';
 
 import { ImageBubbleContainer, ImageThumbnail } from './ImageBubble';
@@ -18,6 +18,7 @@ import { LocationBubble } from './LocationBubble';
 type MessageAttachmentsProps = {
   item: Message;
   variant: string;
+  orientation?: string;
   /** Email bubbles show fixed-size thumbnails, chat bubbles show full-width media. */
   mediaSize?: 'default' | 'thumbnail';
 };
@@ -50,7 +51,7 @@ const groupByType = (attachments: ImageMetadata[]) => {
 };
 
 export const MessageAttachments = (props: MessageAttachmentsProps) => {
-  const { item, variant, mediaSize = 'default' } = props;
+  const { item, variant, orientation = ORIENTATION.LEFT, mediaSize = 'default' } = props;
   const { attachments, private: isPrivate, contentAttributes, createdAt } = item;
 
   if (!attachments || attachments.length === 0) {
@@ -61,7 +62,8 @@ export const MessageAttachments = (props: MessageAttachmentsProps) => {
   const imageWidth = TEXT_MAX_WIDTH - 24 - (isPrivate ? 13 : 0);
 
   return (
-    <React.Fragment>
+    <Animated.View
+      style={tailwind.style(orientation === ORIENTATION.RIGHT ? 'items-end' : 'items-start')}>
       {groupByType(attachments).map((attachment, index) => {
         const key = attachment.fileType + index;
 
@@ -136,6 +138,6 @@ export const MessageAttachments = (props: MessageAttachmentsProps) => {
 
         return null;
       })}
-    </React.Fragment>
+    </Animated.View>
   );
 };

--- a/src/screens/chat-screen/components/message-components/MessageAttachments.tsx
+++ b/src/screens/chat-screen/components/message-components/MessageAttachments.tsx
@@ -9,15 +9,17 @@ import { Icon } from '@/components-next';
 import { ATTACHMENT_TYPES, TEXT_MAX_WIDTH } from '@/constants';
 import i18n from '@/i18n';
 
-import { ImageBubbleContainer } from './ImageBubble';
+import { ImageBubbleContainer, ImageThumbnail } from './ImageBubble';
 import { FileBubblePreview } from './FileBubble';
 import { AudioBubble } from './AudioBubble';
-import { VideoBubble } from './VideoBubble';
+import { VideoBubble, VideoThumbnail } from './VideoBubble';
 import { LocationBubble } from './LocationBubble';
 
 type MessageAttachmentsProps = {
   item: Message;
   variant: string;
+  /** Email bubbles show fixed-size thumbnails, chat bubbles show full-width media. */
+  mediaSize?: 'default' | 'thumbnail';
 };
 
 const isInstagramStoryExpired = (messageTimestamp: number) => {
@@ -48,7 +50,7 @@ const groupByType = (attachments: ImageMetadata[]) => {
 };
 
 export const MessageAttachments = (props: MessageAttachmentsProps) => {
-  const { item, variant } = props;
+  const { item, variant, mediaSize = 'default' } = props;
   const { attachments, private: isPrivate, contentAttributes, createdAt } = item;
 
   if (!attachments || attachments.length === 0) {
@@ -78,7 +80,11 @@ export const MessageAttachments = (props: MessageAttachmentsProps) => {
             </Animated.View>
           ) : (
             <Animated.View key={key} style={tailwind.style('my-2')}>
-              <ImageBubbleContainer imageSrc={attachment.dataUrl} maxWidth={imageWidth} />
+              {mediaSize === 'thumbnail' ? (
+                <ImageThumbnail imageSrc={attachment.dataUrl} />
+              ) : (
+                <ImageBubbleContainer imageSrc={attachment.dataUrl} maxWidth={imageWidth} />
+              )}
             </Animated.View>
           );
         }
@@ -99,7 +105,11 @@ export const MessageAttachments = (props: MessageAttachmentsProps) => {
         ) {
           return (
             <Animated.View key={key} style={tailwind.style('flex flex-row items-center my-2')}>
-              <VideoBubble videoSrc={attachment.dataUrl} />
+              {mediaSize === 'thumbnail' ? (
+                <VideoThumbnail videoSrc={attachment.dataUrl} />
+              ) : (
+                <VideoBubble videoSrc={attachment.dataUrl} />
+              )}
             </Animated.View>
           );
         }

--- a/src/screens/chat-screen/components/message-components/MessageAttachments.tsx
+++ b/src/screens/chat-screen/components/message-components/MessageAttachments.tsx
@@ -38,16 +38,14 @@ const groupByType = (attachments: ImageMetadata[]) => {
   const ofType = (...types: string[]) =>
     attachments.filter(attachment => types.includes(attachment.fileType));
 
-  const media = ofType(...MEDIA_TYPES).sort(
-    (a, b) => MEDIA_TYPES.indexOf(a.fileType) - MEDIA_TYPES.indexOf(b.fileType),
-  );
-
-  return [
-    ...media,
-    ...ofType(ATTACHMENT_TYPES.AUDIO),
-    ...ofType(ATTACHMENT_TYPES.FILE),
-    ...ofType(ATTACHMENT_TYPES.LOCATION),
-  ];
+  return {
+    media: ofType(...MEDIA_TYPES).sort(
+      (a, b) => MEDIA_TYPES.indexOf(a.fileType) - MEDIA_TYPES.indexOf(b.fileType),
+    ),
+    recordings: ofType(ATTACHMENT_TYPES.AUDIO),
+    files: ofType(ATTACHMENT_TYPES.FILE),
+    locations: ofType(ATTACHMENT_TYPES.LOCATION),
+  };
 };
 
 export const MessageAttachments = (props: MessageAttachmentsProps) => {
@@ -60,84 +58,94 @@ export const MessageAttachments = (props: MessageAttachmentsProps) => {
 
   const isAnInstagramStory = contentAttributes?.imageType === ATTACHMENT_TYPES.STORY_MENTION;
   const imageWidth = TEXT_MAX_WIDTH - 24 - (isPrivate ? 13 : 0);
+  const isThumbnail = mediaSize === 'thumbnail';
+  const isRightAligned = orientation === ORIENTATION.RIGHT;
+  const { media, recordings, files, locations } = groupByType(attachments);
+
+  // Thumbnails sit side by side and wrap; full-width media stacks.
+  const mediaItemStyle = isThumbnail ? '' : 'my-2';
+
+  const renderMedia = (attachment: ImageMetadata, index: number) => {
+    const key = `${attachment.fileType}-${attachment.id ?? index}`;
+
+    if (attachment.fileType === ATTACHMENT_TYPES.IMAGE) {
+      if (isAnInstagramStory && isInstagramStoryExpired(createdAt)) {
+        return (
+          <Animated.View
+            key={key}
+            style={tailwind.style(
+              'flex flex-row items-center justify-center py-8 bg-slate-100 gap-1 rounded-lg',
+            )}>
+            <Icon icon={<FileErrorIcon fill={tailwind.color('text-gray-900')} />} />
+            <Animated.Text
+              style={tailwind.style('text-cxs font-inter-420-20 text-gray-900 mt-[1px]')}>
+              {i18n.t('CONVERSATION.STORY_NOT_AVAILABLE')}
+            </Animated.Text>
+          </Animated.View>
+        );
+      }
+
+      return (
+        <Animated.View key={key} style={tailwind.style(mediaItemStyle)}>
+          {isThumbnail ? (
+            <ImageThumbnail imageSrc={attachment.dataUrl} />
+          ) : (
+            <ImageBubbleContainer imageSrc={attachment.dataUrl} maxWidth={imageWidth} />
+          )}
+        </Animated.View>
+      );
+    }
+
+    return (
+      <Animated.View key={key} style={tailwind.style('flex flex-row items-center', mediaItemStyle)}>
+        {isThumbnail ? (
+          <VideoThumbnail videoSrc={attachment.dataUrl} />
+        ) : (
+          <VideoBubble videoSrc={attachment.dataUrl} />
+        )}
+      </Animated.View>
+    );
+  };
 
   return (
-    <Animated.View
-      style={tailwind.style(orientation === ORIENTATION.RIGHT ? 'items-end' : 'items-start')}>
-      {groupByType(attachments).map((attachment, index) => {
-        const key = attachment.fileType + index;
+    <Animated.View style={tailwind.style(isRightAligned ? 'items-end' : 'items-start')}>
+      {media.length > 0 ? (
+        <Animated.View
+          style={tailwind.style(
+            isThumbnail ? 'flex flex-row flex-wrap gap-1 my-2' : '',
+            isThumbnail && isRightAligned ? 'justify-end' : '',
+          )}>
+          {media.map(renderMedia)}
+        </Animated.View>
+      ) : null}
 
-        if (attachment.fileType === ATTACHMENT_TYPES.IMAGE) {
-          return isAnInstagramStory && isInstagramStoryExpired(createdAt) ? (
-            <Animated.View
-              key={key}
-              style={tailwind.style(
-                'flex flex-row items-center justify-center py-8 bg-slate-100 gap-1 rounded-lg',
-              )}>
-              <Icon icon={<FileErrorIcon fill={tailwind.color('text-gray-900')} />} />
-              <Animated.Text
-                style={tailwind.style('text-cxs font-inter-420-20 text-gray-900 mt-[1px]')}>
-                {i18n.t('CONVERSATION.STORY_NOT_AVAILABLE')}
-              </Animated.Text>
-            </Animated.View>
-          ) : (
-            <Animated.View key={key} style={tailwind.style('my-2')}>
-              {mediaSize === 'thumbnail' ? (
-                <ImageThumbnail imageSrc={attachment.dataUrl} />
-              ) : (
-                <ImageBubbleContainer imageSrc={attachment.dataUrl} maxWidth={imageWidth} />
-              )}
-            </Animated.View>
-          );
-        }
+      {recordings.map((attachment, index) => (
+        <Animated.View
+          key={`audio-${attachment.id ?? index}`}
+          style={tailwind.style('flex flex-row items-center my-2')}>
+          <AudioBubble audioSrc={attachment.dataUrl} variant={variant} />
+        </Animated.View>
+      ))}
 
-        if (attachment.fileType === ATTACHMENT_TYPES.FILE) {
-          return (
-            <Animated.View
-              key={key}
-              style={tailwind.style('flex flex-row items-center relative max-w-[300px] my-2')}>
-              <FileBubblePreview fileSrc={attachment.dataUrl} isComposed variant={variant} />
-            </Animated.View>
-          );
-        }
+      {files.map((attachment, index) => (
+        <Animated.View
+          key={`file-${attachment.id ?? index}`}
+          style={tailwind.style('flex flex-row items-center relative max-w-[300px] my-2')}>
+          <FileBubblePreview fileSrc={attachment.dataUrl} isComposed variant={variant} />
+        </Animated.View>
+      ))}
 
-        if (
-          attachment.fileType === ATTACHMENT_TYPES.VIDEO ||
-          attachment.fileType === ATTACHMENT_TYPES.IG_REEL
-        ) {
-          return (
-            <Animated.View key={key} style={tailwind.style('flex flex-row items-center my-2')}>
-              {mediaSize === 'thumbnail' ? (
-                <VideoThumbnail videoSrc={attachment.dataUrl} />
-              ) : (
-                <VideoBubble videoSrc={attachment.dataUrl} />
-              )}
-            </Animated.View>
-          );
-        }
-
-        if (attachment.fileType === ATTACHMENT_TYPES.AUDIO) {
-          return (
-            <Animated.View key={key} style={tailwind.style('flex flex-row items-center my-2')}>
-              <AudioBubble audioSrc={attachment.dataUrl} variant={variant} />
-            </Animated.View>
-          );
-        }
-
-        if (attachment.fileType === ATTACHMENT_TYPES.LOCATION) {
-          return (
-            <Animated.View key={key} style={tailwind.style('flex flex-row items-center my-2')}>
-              <LocationBubble
-                latitude={attachment.coordinatesLat}
-                longitude={attachment.coordinatesLong}
-                variant={variant}
-              />
-            </Animated.View>
-          );
-        }
-
-        return null;
-      })}
+      {locations.map((attachment, index) => (
+        <Animated.View
+          key={`location-${attachment.id ?? index}`}
+          style={tailwind.style('flex flex-row items-center my-2')}>
+          <LocationBubble
+            latitude={attachment.coordinatesLat}
+            longitude={attachment.coordinatesLong}
+            variant={variant}
+          />
+        </Animated.View>
+      ))}
     </Animated.View>
   );
 };

--- a/src/screens/chat-screen/components/message-components/MessageAttachments.tsx
+++ b/src/screens/chat-screen/components/message-components/MessageAttachments.tsx
@@ -59,11 +59,13 @@ export const MessageAttachments = (props: MessageAttachmentsProps) => {
   const isAnInstagramStory = contentAttributes?.imageType === ATTACHMENT_TYPES.STORY_MENTION;
   const imageWidth = TEXT_MAX_WIDTH - 24 - (isPrivate ? 13 : 0);
   const isThumbnail = mediaSize === 'thumbnail';
-  const isRightAligned = orientation === ORIENTATION.RIGHT;
+  // Rows stay stretched so percentage-width media resolves against the bubble; the
+  // contents are aligned inside each row instead.
+  const rowAlignment = orientation === ORIENTATION.RIGHT ? 'justify-end' : 'justify-start';
   const { media, recordings, files, locations } = groupByType(attachments);
 
   // Thumbnails sit side by side and wrap; full-width media stacks.
-  const mediaItemStyle = isThumbnail ? '' : 'my-2';
+  const mediaItemStyle = isThumbnail ? '' : `flex flex-row my-2 ${rowAlignment}`;
 
   const renderMedia = (attachment: ImageMetadata, index: number) => {
     const key = `${attachment.fileType}-${attachment.id ?? index}`;
@@ -97,7 +99,7 @@ export const MessageAttachments = (props: MessageAttachmentsProps) => {
     }
 
     return (
-      <Animated.View key={key} style={tailwind.style('flex flex-row items-center', mediaItemStyle)}>
+      <Animated.View key={key} style={tailwind.style('items-center', mediaItemStyle)}>
         {isThumbnail ? (
           <VideoThumbnail videoSrc={attachment.dataUrl} />
         ) : (
@@ -108,12 +110,11 @@ export const MessageAttachments = (props: MessageAttachmentsProps) => {
   };
 
   return (
-    <Animated.View style={tailwind.style(isRightAligned ? 'items-end' : 'items-start')}>
+    <Animated.View>
       {media.length > 0 ? (
         <Animated.View
           style={tailwind.style(
-            isThumbnail ? 'flex flex-row flex-wrap gap-1 my-2' : '',
-            isThumbnail && isRightAligned ? 'justify-end' : '',
+            isThumbnail ? `flex flex-row flex-wrap gap-1 my-2 ${rowAlignment}` : '',
           )}>
           {media.map(renderMedia)}
         </Animated.View>
@@ -122,7 +123,7 @@ export const MessageAttachments = (props: MessageAttachmentsProps) => {
       {recordings.map((attachment, index) => (
         <Animated.View
           key={`audio-${attachment.id ?? index}`}
-          style={tailwind.style('flex flex-row items-center my-2')}>
+          style={tailwind.style('flex flex-row items-center my-2', rowAlignment)}>
           <AudioBubble audioSrc={attachment.dataUrl} variant={variant} />
         </Animated.View>
       ))}
@@ -130,7 +131,10 @@ export const MessageAttachments = (props: MessageAttachmentsProps) => {
       {files.map((attachment, index) => (
         <Animated.View
           key={`file-${attachment.id ?? index}`}
-          style={tailwind.style('flex flex-row items-center relative max-w-[300px] my-2')}>
+          style={tailwind.style(
+            'flex flex-row items-center relative max-w-[300px] my-2',
+            rowAlignment,
+          )}>
           <FileBubblePreview fileSrc={attachment.dataUrl} isComposed variant={variant} />
         </Animated.View>
       ))}
@@ -138,7 +142,7 @@ export const MessageAttachments = (props: MessageAttachmentsProps) => {
       {locations.map((attachment, index) => (
         <Animated.View
           key={`location-${attachment.id ?? index}`}
-          style={tailwind.style('flex flex-row items-center my-2')}>
+          style={tailwind.style('flex flex-row items-center my-2', rowAlignment)}>
           <LocationBubble
             latitude={attachment.coordinatesLat}
             longitude={attachment.coordinatesLong}

--- a/src/screens/chat-screen/components/message-components/VideoBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/VideoBubble.tsx
@@ -86,6 +86,64 @@ export const VideoBubblePlayer = (props: VideoPlayerProps) => {
   );
 };
 
+// Fixed-size media thumbnail. Playback is handed to the fullscreen player, so the
+// inline view carries no controls.
+export const VideoThumbnail = (props: VideoBubbleProps) => {
+  const { videoSrc } = props;
+  const videoRef = useRef<VideoView>(null);
+  const [status, setStatus] = useState<VideoPlayerStatus>('loading');
+
+  const player = useVideoPlayer({ uri: videoSrc }, instance => {
+    instance.loop = false;
+  });
+
+  useEffect(() => {
+    const statusSub = player.addListener('statusChange', ({ status: nextStatus }) => {
+      setStatus(nextStatus);
+    });
+    setStatus(player.status);
+    return () => {
+      statusSub.remove();
+    };
+  }, [player]);
+
+  const handlePlayPress = async () => {
+    player.play();
+    await videoRef.current?.enterFullscreen();
+  };
+
+  return (
+    <Animated.View
+      style={tailwind.style('h-[72px] w-[72px] rounded-xl bg-gray-100 overflow-hidden')}>
+      <VideoView
+        style={tailwind.style('h-full w-full')}
+        ref={videoRef}
+        player={player}
+        contentFit="cover"
+        nativeControls={false}
+        onFullscreenExit={() => {
+          player.pause();
+          player.currentTime = 0;
+        }}
+      />
+      {status === 'loading' || status === 'idle' ? (
+        <Animated.View style={tailwind.style('absolute inset-0 flex items-center justify-center')}>
+          <Spinner size={16} />
+        </Animated.View>
+      ) : (
+        <Pressable
+          onPress={handlePlayPress}
+          style={tailwind.style('absolute inset-0 flex items-center justify-center')}>
+          <Image
+            source={require('../../../../assets/local/PlayIcon.png')} // eslint-disable-line @typescript-eslint/no-require-imports
+            style={tailwind.style('h-7 w-7')}
+          />
+        </Pressable>
+      )}
+    </Animated.View>
+  );
+};
+
 export const VideoBubble = (props: VideoBubbleProps) => {
   const { videoSrc } = props;
 

--- a/src/screens/chat-screen/components/message-components/index.ts
+++ b/src/screens/chat-screen/components/message-components/index.ts
@@ -2,6 +2,7 @@ export * from './TextBubble';
 export * from './ActivityBubble';
 export * from './MarkdownBubble';
 export * from './ComposedBubble';
+export * from './MessageAttachments';
 export * from './FileBubble';
 export * from './AudioBubble';
 export * from './LocationBubble';

--- a/src/screens/chat-screen/components/message-item/Message.tsx
+++ b/src/screens/chat-screen/components/message-item/Message.tsx
@@ -457,16 +457,18 @@ export const MessageComponent = (props: MessageComponentProps) => {
     if (isUnsupported) {
       messageContent = <UnsupportedBubble />;
     } else if (contentType === CONTENT_TYPES.INCOMING_EMAIL) {
-      messageContent = <EmailBubble item={item} variant={variant()} />;
+      messageContent = <EmailBubble item={item} variant={variant()} orientation={orientation()} />;
     } else if (isEmailInbox && !item.private) {
-      messageContent = <EmailBubble item={item} variant={variant()} />;
+      messageContent = <EmailBubble item={item} variant={variant()} orientation={orientation()} />;
     }
     // TODO: Add this once we have a proper way to render single attachments
     // else if (attachments?.length === 1 && !item.content && !isReplyMessage) {
     //   messageContent = renderSingleAttachment(attachments[0]);
     // }
     else if (attachments?.length >= 1 || isReplyMessage) {
-      messageContent = <ComposedBubble item={item} variant={variant()} />;
+      messageContent = (
+        <ComposedBubble item={item} variant={variant()} orientation={orientation()} />
+      );
     } else if (item.content) {
       messageContent = <TextBubble item={item} variant={variant()} />;
     } else {

--- a/src/screens/chat-screen/components/message-list/stories/EmailMessageList.stories.tsx
+++ b/src/screens/chat-screen/components/message-list/stories/EmailMessageList.stories.tsx
@@ -7,10 +7,12 @@ import { configureStore, createSlice } from '@reduxjs/toolkit';
 import { tailwind } from '@/theme';
 import { MessagesList } from '../MessagesList';
 import { EMAIL_MESSAGES } from './mock-data/simpleEmail';
+import { EMAIL_ATTACHMENTS } from './mock-data/emailAttachments';
 import { ChatWindowProvider, RefsProvider } from '@/context';
 import { Provider } from 'react-redux';
 import { getAllGroupedMessages } from './mock-data/helper';
 const ALL_MESSAGES_MOCKDATA = getAllGroupedMessages(EMAIL_MESSAGES);
+const EMAIL_ATTACHMENTS_MOCKDATA = getAllGroupedMessages(EMAIL_ATTACHMENTS);
 
 const PlatformSpecificKeyboardWrapperComponent =
   Platform.OS === 'android' ? Animated.View : KeyboardGestureArea;
@@ -29,13 +31,19 @@ const mockSendMessageSlice = createSlice({
 const mockConversationSlice = createSlice({
   name: 'conversation',
   initialState: {
-    ids: [29],
+    ids: [29, 134],
     entities: {
       29: {
         id: 29,
         status: 'open',
         channel: 'Channel::Email',
         messages: ALL_MESSAGES_MOCKDATA,
+      },
+      134: {
+        id: 134,
+        status: 'open',
+        channel: 'Channel::Email',
+        messages: EMAIL_ATTACHMENTS_MOCKDATA,
       },
     },
   },
@@ -82,6 +90,36 @@ export const EmailMessageList: Story = {
                 </ScrollView>
               </ChatWindowProvider>
             </KeyboardProvider>
+        </RefsProvider>
+      </Provider>
+    );
+  },
+};
+
+export const EmailAttachmentsList: Story = {
+  render: function EmailAttachmentsComponent() {
+    return (
+      <Provider store={mockStore}>
+        <RefsProvider>
+          <KeyboardProvider>
+            <ChatWindowProvider conversationId={134}>
+              <ScrollView contentContainerStyle={tailwind.style('flex')}>
+                <PlatformSpecificKeyboardWrapperComponent
+                  style={tailwind.style('flex-1 bg-white')}
+                  interpolator="linear">
+                  <MessagesList
+                    messages={EMAIL_ATTACHMENTS_MOCKDATA}
+                    isFlashListReady={false}
+                    setFlashListReady={() => {}}
+                    onEndReached={() => {}}
+                    onStartReached={() => {}}
+                    isEmailInbox={true}
+                    currentUserId={1}
+                  />
+                </PlatformSpecificKeyboardWrapperComponent>
+              </ScrollView>
+            </ChatWindowProvider>
+          </KeyboardProvider>
         </RefsProvider>
       </Provider>
     );

--- a/src/screens/chat-screen/components/message-list/stories/mock-data/emailAttachments.ts
+++ b/src/screens/chat-screen/components/message-list/stories/mock-data/emailAttachments.ts
@@ -261,15 +261,187 @@ export const EMAIL_ATTACHMENTS = [
     },
     attachments: [
       {
+        id: 831,
+        message_id: 60916,
+        file_type: 'file',
+        account_id: 51,
+        extension: null,
+        data_url:
+          'https://staging.chatwoot.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdFdKIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--10170e22f42401a9259e17eba6e59877127353d0/requirements.pdf',
+        thumb_url:
+          'https://staging.chatwoot.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdFdKIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--10170e22f42401a9259e17eba6e59877127353d0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCam9UY21WemFYcGxYM1J2WDJacGJHeGJCMmtCK2pBPSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--31a6ed995cc4ac2dd2fa023068ee23b23efa1efb/requirements.pdf',
+        file_size: 841909,
+        width: null,
+        height: null,
+      },
+      {
+        id: 830,
+        message_id: 60916,
+        file_type: 'audio',
+        account_id: 51,
+        extension: null,
+        data_url: 'https://cdn.freesound.org/previews/769/769025_16085454-lq.mp3',
+        thumb_url: '',
+        file_size: 1693405,
+        width: null,
+        height: null,
+      },
+      {
+        id: 829,
+        message_id: 60916,
+        file_type: 'video',
+        account_id: 51,
+        extension: null,
+        data_url: 'https://videos.pexels.com/video-files/1739010/1739010-hd_1920_1080_30fps.mp4',
+        thumb_url: '',
+        file_size: 4372373,
+        width: 1920,
+        height: 1080,
+      },
+      {
         id: 828,
         message_id: 60916,
         file_type: 'image',
         account_id: 51,
         extension: null,
-        data_url:
-          'https://staging.chatwoot.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdGVKIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--62ee3b99421bfe7d8db85959ae99ab03a899f351/image.png',
-        thumb_url:
-          'https://staging.chatwoot.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdGVKIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--62ee3b99421bfe7d8db85959ae99ab03a899f351/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2RTNKbGMybDZaVjkwYjE5bWFXeHNXd2RwQWZvdyIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--988d66f5e450207265d5c21bb0edb3facb890a43/image.png',
+        data_url: 'https://random.imagecdn.app/500/500',
+        thumb_url: 'https://random.imagecdn.app/500/500',
+        file_size: 1617507,
+        width: 1600,
+        height: 900,
+      },
+    ],
+    sender: {
+      id: 110,
+      name: 'Alex',
+      available_name: 'Alex',
+      avatar_url:
+        'https://staging.chatwoot.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbktJIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--25806e8b52810484d3d6cb53af9e2a1c0cf1b43d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2RTNKbGMybDZaVjkwYjE5bWFXeHNXd2RwQWZvdyIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--988d66f5e450207265d5c21bb0edb3facb890a43/slick-deploy.png',
+      type: 'user',
+      availability_status: 'online',
+      thumbnail:
+        'https://staging.chatwoot.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbktJIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--25806e8b52810484d3d6cb53af9e2a1c0cf1b43d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2RTNKbGMybDZaVjkwYjE5bWFXeHNXd2RwQWZvdyIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--988d66f5e450207265d5c21bb0edb3facb890a43/slick-deploy.png',
+    },
+  },
+  {
+    id: 60915,
+    content:
+      'Dear Sam,\n\nThank you for the quotation. Could you share images or samples of the\nfabric for us to review before proceeding?\n\nBest,\nAlex\n\nOn Wed, 4 Dec 2024 at 17:15, Sam from CottonMart <sam@cottonmart.test> wrote:\n\n> Dear Alex,\n>\n> Thank you for your inquiry. Please find attached our quotation based on\n> your requirements. Let us know if you need further details or wish to\n> discuss specific customizations.\n>\n> Best regards,\n> Sam\n> FabricMart\n> attachment [click here to view\n> <https://staging.chatwoot.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdGFKIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940f9c3df19ce042ef3447809c9c451cfa4e905b/quotation.pdf>]\n>',
+    account_id: 51,
+    inbox_id: 992,
+    conversation_id: 134,
+    message_type: 0,
+    created_at: 1733312835,
+    updated_at: '2024-12-04T11:47:15.876Z',
+    private: false,
+    status: 'sent',
+    source_id: 'CAM_Qp+_70EiYJ_nKMgJ6MZaD58Tq3E57QERcZgnd10g@mail.gmail.com',
+    content_type: 'incoming_email',
+    content_attributes: {
+      email: {
+        bcc: null,
+        cc: null,
+        content_type: 'multipart/alternative; boundary=0000000000007191be06287054c4',
+        date: '2024-12-04T17:16:07+05:30',
+        from: ['alex@paperlayer.test'],
+        html_content: {
+          full: '<div dir="ltr"><p>Dear Sam,</p><p>Thank you for the quotation. Could you share images or samples of the fabric for us to review before proceeding?</p><p>Best,<br>Alex</p></div><br><div class="gmail_quote gmail_quote_container"><div dir="ltr" class="gmail_attr">On Wed, 4 Dec 2024 at 17:15, Sam from CottonMart &lt;<a href="mailto:sam@cottonmart.test">sam@cottonmart.test</a>&gt; wrote:<br></div><blockquote class="gmail_quote" style="margin:0px 0px 0px 0.8ex;border-left:1px solid rgb(204,204,204);padding-left:1ex">  <p>Dear Alex,</p>\n<p>Thank you for your inquiry. Please find attached our quotation based on your requirements. Let us know if you need further details or wish to discuss specific customizations.</p>\n<p>Best regards,<br>\nSam<br>\nFabricMart</p>\n\n    attachment [<a href="https://staging.chatwoot.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdGFKIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940f9c3df19ce042ef3447809c9c451cfa4e905b/quotation.pdf" target="_blank">click here to view</a>]\n</blockquote></div>\n',
+          reply:
+            'Dear Sam,\n\nThank you for the quotation. Could you share images or samples of the fabric for us to review before proceeding?\n\nBest,\nAlex\n\nOn Wed, 4 Dec 2024 at 17:15, Sam from CottonMart <sam@cottonmart.test> wrote:\n>',
+          quoted:
+            'Dear Sam,\n\nThank you for the quotation. Could you share images or samples of the fabric for us to review before proceeding?\n\nBest,\nAlex',
+        },
+        in_reply_to:
+          'conversation/758d1f24-dc76-4abc-9c41-255ed8974f8e/messages/60914@reply.chatwoot.dev',
+        message_id: 'CAM_Qp+_70EiYJ_nKMgJ6MZaD58Tq3E57QERcZgnd10g@mail.gmail.com',
+        multipart: true,
+        number_of_attachments: 0,
+        subject: 'Re: Inquiry and Quotation for Cotton Fabric',
+        text_content: {
+          full: 'Dear Sam,\n\nThank you for the quotation. Could you share images or samples of the\nfabric for us to review before proceeding?\n\nBest,\nAlex\n\nOn Wed, 4 Dec 2024 at 17:15, Sam from CottonMart <sam@cottonmart.test>\nwrote:\n\n> Dear Alex,\n>\n> Thank you for your inquiry. Please find attached our quotation based on\n> your requirements. Let us know if you need further details or wish to\n> discuss specific customizations.\n>\n> Best regards,\n> Sam\n> FabricMart\n> attachment [click here to view\n> <https://staging.chatwoot.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdGFKIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940f9c3df19ce042ef3447809c9c451cfa4e905b/quotation.pdf>]\n>\n',
+          reply:
+            'Dear Sam,\n\nThank you for the quotation. Could you share images or samples of the\nfabric for us to review before proceeding?\n\nBest,\nAlex\n\nOn Wed, 4 Dec 2024 at 17:15, Sam from CottonMart <sam@cottonmart.test> wrote:\n\n> Dear Alex,\n>\n> Thank you for your inquiry. Please find attached our quotation based on\n> your requirements. Let us know if you need further details or wish to\n> discuss specific customizations.\n>\n> Best regards,\n> Sam\n> FabricMart\n> attachment [click here to view\n> <https://staging.chatwoot.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdGFKIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940f9c3df19ce042ef3447809c9c451cfa4e905b/quotation.pdf>]\n>',
+          quoted:
+            'Dear Sam,\n\nThank you for the quotation. Could you share images or samples of the\nfabric for us to review before proceeding?\n\nBest,\nAlex',
+        },
+        to: ['sam@cottonmart.test'],
+      },
+      cc_email: null,
+      bcc_email: null,
+    },
+    sender_type: 'Contact',
+    sender_id: 111256,
+    external_source_ids: {},
+    additional_attributes: {},
+    processed_message_content:
+      'Dear Sam,\n\nThank you for the quotation. Could you share images or samples of the\nfabric for us to review before proceeding?\n\nBest,\nAlex',
+    sentiment: {},
+    conversation: {
+      assignee_id: 110,
+      unread_count: 1,
+      last_activity_at: 1733312835,
+      contact_inbox: {
+        source_id: 'alex@paperlayer.test',
+      },
+    },
+    sender: {
+      additional_attributes: {
+        source_id: 'email:CAM_Qp+8beyon41DA@mail.gmail.com',
+      },
+      custom_attributes: {},
+      email: 'alex@paperlayer.test',
+      id: 111256,
+      identifier: null,
+      name: 'Alex',
+      phone_number: null,
+      thumbnail: '',
+      type: 'contact',
+    },
+  },
+  {
+    message_type: 1,
+    content_type: 'text',
+    source_id:
+      'conversation/758d1f24-dc76-4abc-9c41-255ed8974f8e/messages/60916@reply.chatwoot.dev',
+    processed_message_content:
+      "Dear Alex,\r\n\r\nPlease find attached images of our cotton fabric samples. Let us know if you'd like physical samples sent to you. \r\n\r\nWarm regards,  \r\nSam",
+    id: 60916,
+    content:
+      "Dear Alex,\r\n\r\nPlease find attached images of our cotton fabric samples. Let us know if you'd like physical samples sent to you. \r\n\r\nWarm regards,  \r\nSam",
+    account_id: 51,
+    inbox_id: 992,
+    conversation_id: 134,
+    created_at: 1733312866,
+    updated_at: '2024-12-04T11:47:53.564Z',
+    private: false,
+    status: 'sent',
+    content_attributes: {
+      cc_emails: [],
+      bcc_emails: [],
+      to_emails: [],
+    },
+    sender_type: 'User',
+    sender_id: 1,
+    external_source_ids: {},
+    additional_attributes: {},
+    sentiment: {},
+    conversation: {
+      assignee_id: 110,
+      unread_count: 0,
+      last_activity_at: 1733312866,
+      contact_inbox: {
+        source_id: 'alex@paperlayer.test',
+      },
+    },
+    attachments: [
+      {
+        id: 828,
+        message_id: 60916,
+        file_type: 'image',
+        account_id: 51,
+        extension: null,
+        data_url: 'https://random.imagecdn.app/500/500',
+        thumb_url: 'https://random.imagecdn.app/500/500',
         file_size: 1617507,
         width: 1600,
         height: 900,

--- a/src/screens/chat-screen/components/message-list/stories/mock-data/emailAttachments.ts
+++ b/src/screens/chat-screen/components/message-list/stories/mock-data/emailAttachments.ts
@@ -261,18 +261,16 @@ export const EMAIL_ATTACHMENTS = [
     },
     attachments: [
       {
-        id: 831,
+        id: 828,
         message_id: 60916,
-        file_type: 'file',
+        file_type: 'image',
         account_id: 51,
         extension: null,
-        data_url:
-          'https://staging.chatwoot.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdFdKIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--10170e22f42401a9259e17eba6e59877127353d0/requirements.pdf',
-        thumb_url:
-          'https://staging.chatwoot.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdFdKIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--10170e22f42401a9259e17eba6e59877127353d0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCam9UY21WemFYcGxYM1J2WDJacGJHeGJCMmtCK2pBPSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--31a6ed995cc4ac2dd2fa023068ee23b23efa1efb/requirements.pdf',
-        file_size: 841909,
-        width: null,
-        height: null,
+        data_url: 'https://random.imagecdn.app/500/500',
+        thumb_url: 'https://random.imagecdn.app/500/500',
+        file_size: 1617507,
+        width: 1600,
+        height: 900,
       },
       {
         id: 830,
@@ -299,16 +297,18 @@ export const EMAIL_ATTACHMENTS = [
         height: 1080,
       },
       {
-        id: 828,
+        id: 831,
         message_id: 60916,
-        file_type: 'image',
+        file_type: 'file',
         account_id: 51,
         extension: null,
-        data_url: 'https://random.imagecdn.app/500/500',
-        thumb_url: 'https://random.imagecdn.app/500/500',
-        file_size: 1617507,
-        width: 1600,
-        height: 900,
+        data_url:
+          'https://staging.chatwoot.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdFdKIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--10170e22f42401a9259e17eba6e59877127353d0/requirements.pdf',
+        thumb_url:
+          'https://staging.chatwoot.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdFdKIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--10170e22f42401a9259e17eba6e59877127353d0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCam9UY21WemFYcGxYM1J2WDJacGJHeGJCMmtCK2pBPSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--31a6ed995cc4ac2dd2fa023068ee23b23efa1efb/requirements.pdf',
+        file_size: 841909,
+        width: null,
+        height: null,
       },
     ],
     sender: {


### PR DESCRIPTION
## Description 

Messages on Email channel inboxes never rendered their attachments in the app. The body showed, but images, files and audio were silently dropped. The same message shows them correctly in the dashboard.

`Message.tsx` picks one bubble from an `else if` chain. Email messages match `EmailBubble` (via `content_type: incoming_email`, or `isEmailInbox && !private`) before reaching the `attachments.length >= 1` branch, and `EmailBubble` never read `item.attachments`. Affects both inbound emails and outgoing agent replies. Private notes were unaffected. 

- Attachment rendering is now extracted from `ComposedBubble` into a shared `MessageAttachments` component used by both bubbles. 
- Also, to match the dashboard: attachments group by type (media → audio → files) rather than following payload order, they align with the message orientation, and email bubbles render media as fixed-size 72pt thumbnails.

Fixes [CW-7978](https://linear.app/chatwoot/issue/CW-7978/support-attachments-missing-in-app-email-inbox-messages-dont-render)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Web:
<video src="https://github.com/user-attachments/assets/07090700-809c-48ac-b2b6-5d224c379ac3" /> 

App:

| Before | After |
| :---: | :---: |
| <video src="https://github.com/user-attachments/assets/2ab3335c-934e-4a76-9000-31fdeda18746" /> | <video src="https://github.com/user-attachments/assets/b5d0b672-9b4d-4446-8812-c6b9f781375f" /> |
