### PR TITLE
fix: message bubble vanishing

### DIFF
--- a/src/screens/chat-screen/components/message-item/Message.tsx
+++ b/src/screens/chat-screen/components/message-item/Message.tsx
@@ -127,7 +127,7 @@ const MessageWrapper = ({
   const { zoomStyle, highlightStyle } = useTargetMessageAnimation({
     isTargetMessage,
   });
-  const entranceStyle = useMessageEntrance(item.id);
+  const entering = useMessageEntrance(item.id);
 
   const flexOrientationClass = () => {
     const map = {
@@ -147,16 +147,14 @@ const MessageWrapper = ({
 
   return (
     <Animated.View
-      style={[
-        tailwind.style(
-          'my-[1px]',
-          flexOrientationClass(),
-          shouldGroupWithPrevious && orientation === ORIENTATION.LEFT ? 'ml-7' : '',
-          !shouldGroupWithPrevious && !shouldGroupWithNext ? 'mb-2' : 'mb-1',
-          item.private ? 'my-1' : '',
-        ),
-        entranceStyle,
-      ]}>
+      entering={entering}
+      style={tailwind.style(
+        'my-[1px]',
+        flexOrientationClass(),
+        shouldGroupWithPrevious && orientation === ORIENTATION.LEFT ? 'ml-7' : '',
+        !shouldGroupWithPrevious && !shouldGroupWithNext ? 'mb-2' : 'mb-1',
+        item.private ? 'my-1' : '',
+      )}>
       <View style={tailwind.style('flex flex-row')}>
         {!shouldGroupWithPrevious && shouldShowAvatar ? (
           <View style={tailwind.style('flex items-end justify-end mr-1')}>

--- a/src/screens/chat-screen/components/message-item/useMessageEntrance.ts
+++ b/src/screens/chat-screen/components/message-item/useMessageEntrance.ts
@@ -1,24 +1,20 @@
 import { useLayoutEffect } from 'react';
-import { useSharedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated';
+import { FadeIn } from 'react-native-reanimated';
 
-// Ids whose entrance already played; a recycled or remounted row starts fully
-// visible instead of re-initialising to opacity 0.
+// Message ids whose entrance already played; a recycled or refetched row appears
+// instantly instead of fading in again.
 const enteredIds = new Set<number>();
 
-// Fades a message row in on mount the first time its id is seen. Runs in a
-// layout effect so the fade starts before the first paint (matching the feel of
-// a native entering animation) rather than a frame later.
+// Returns a declarative entering animation the first time a message id is seen, and
+// undefined afterwards. Unlike a manual opacity shared value, Reanimated drives the
+// fade to the row's natural opacity on the UI thread, so an interrupted animation can
+// never leave a row stuck invisible.
 export function useMessageEntrance(itemId: number) {
-  const opacity = useSharedValue(enteredIds.has(itemId) ? 1 : 0);
+  const isFirstEntrance = !enteredIds.has(itemId);
 
   useLayoutEffect(() => {
-    if (enteredIds.has(itemId)) {
-      opacity.value = 1;
-      return;
-    }
     enteredIds.add(itemId);
-    opacity.value = withTiming(1, { duration: 350 });
-  }, [itemId, opacity]);
+  }, [itemId]);
 
-  return useAnimatedStyle(() => ({ opacity: opacity.value }));
+  return isFirstEntrance ? FadeIn.duration(350) : undefined;
 }


### PR DESCRIPTION
## Description 

- Use declarative entering animation for message rows
- Replace the manual opacity shared value with Reanimated's FadeIn entering animation so an interrupted entrance can't leave a row stuck invisible.

Fixes [CW-7985](https://linear.app/chatwoot/issue/CW-7985/message-bubble-vanishing-issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Issue


https://github.com/user-attachments/assets/87783fdf-54ee-43cd-b222-43990ba13d5f

