### PR TITLE
fix(sentry): stop reporting unactionable push registration failures to sentry

### DIFF
--- a/src/store/settings/settingsActions.ts
+++ b/src/store/settings/settingsActions.ts
@@ -24,6 +24,7 @@ import I18n from '@/i18n';
 import { URL_TYPE } from '@/constants/url';
 import { checkValidUrl, extractDomain, handleApiError } from './settingsUtils';
 import { showToast } from '@/utils/toastUtils';
+import { isUnactionablePushError } from '@/utils/sentryUtils';
 
 const createSettingsThunk = <TResponse, TPayload>(
   type: string,
@@ -129,7 +130,9 @@ export const settingsActions = {
         await SettingsService.saveDeviceDetails(pushData);
         return { fcmToken };
       } catch (error) {
-        Sentry.captureException(error);
+        if (!isUnactionablePushError(error)) {
+          Sentry.captureException(error);
+        }
         return rejectWithValue(
           error instanceof Error ? error.message : 'Error saving device details',
         );

--- a/src/utils/sentryUtils.ts
+++ b/src/utils/sentryUtils.ts
@@ -9,3 +9,39 @@ import axios from 'axios';
  */
 export const isTransportError = (error: unknown): boolean =>
   axios.isCancel(error) || (axios.isAxiosError(error) && !error.response);
+
+/**
+ * Push registration failures that no app-side change can resolve: the device
+ * cannot reach Firebase, or has no Google Play Services to register with.
+ *
+ * Matched on the native message because Firebase collapses all of them into the
+ * single `messaging/unknown` code.
+ */
+const UNACTIONABLE_PUSH_MESSAGES = [
+  // Android: registration rejected, or Play Services missing entirely
+  'SERVICE_NOT_AVAILABLE',
+  'MISSING_INSTANCEID_SERVICE',
+  'AUTHENTICATION_FAILED',
+  'TOO_MANY_REGISTRATIONS',
+  // iOS: the Firebase installations handshake never completed
+  'The request timed out',
+  'The network connection was lost',
+  'The Internet connection appears to be offline',
+];
+
+const isFirebaseMessagingError = (error: unknown): boolean => {
+  const code = (error as { code?: unknown })?.code;
+  return typeof code === 'string' && code.startsWith('messaging/');
+};
+
+/**
+ * True when a push token could not be fetched for reasons that track device
+ * environment rather than app defects, so they are excluded from error reporting.
+ */
+export const isUnactionablePushError = (error: unknown): boolean => {
+  if (!isFirebaseMessagingError(error)) {
+    return false;
+  }
+  const message = error instanceof Error ? error.message : '';
+  return UNACTIONABLE_PUSH_MESSAGES.some(pattern => message.includes(pattern));
+};


### PR DESCRIPTION
## Description 

saveDeviceDetails reports every FCM token fetch failure to Sentry, which accounts for 29K events across 438 users. Most of them cannot be resolved from the app: the device is on a network that cannot reach Firebase, or has no Google Play Services to register with.

Skip reporting those, matching on the native message since Firebase collapses them all into a single messaging/unknown code. Failures that do point at an app defect, such as the iOS APNs token race, are still reported.

Fixes [CW-7954](https://linear.app/chatwoot/issue/CW-7954/sentry-messagingunknown-fcm-gettoken-timeout) , [CHATWOOT-MOBILE-A](https://chatwoot-p3.sentry.io/issues/6138252944)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
