### PR TITLE
fix(sentry): guard SLA indicator against a missing applied SLA record

### DIFF
--- a/src/screens/conversations/components/conversation-item/ConversationItemDetail.tsx
+++ b/src/screens/conversations/components/conversation-item/ConversationItemDetail.tsx
@@ -77,7 +77,9 @@ export const ConversationItemDetail = memo((props: ConversationDetailSubCellProp
 
   const hasLabels = labels.length > 0;
 
-  const hasSLA = !!slaPolicyId && shouldShowSLA;
+  // A conversation can carry a policy id without the applied SLA record being
+  // serialised, so the record itself gates the indicator.
+  const hasSLA = !!slaPolicyId && !!appliedSla && shouldShowSLA;
 
   if (!lastMessage) {
     return null;
@@ -127,10 +129,10 @@ export const ConversationItemDetail = memo((props: ConversationDetailSubCellProp
           <AnimatedNativeView
             style={tailwind.style('flex flex-row h-6 justify-between items-center gap-2')}>
             <AnimatedNativeView style={tailwind.style('flex flex-row flex-1 gap-2 items-center')}>
-              {hasSLA && (
+              {hasSLA && appliedSla && (
                 <SLAIndicator
                   slaPolicyId={slaPolicyId}
-                  appliedSla={appliedSla as SLA}
+                  appliedSla={appliedSla}
                   appliedSlaConversationDetails={
                     appliedSlaConversationDetails as {
                       firstReplyCreatedAt: number;


### PR DESCRIPTION
## Description

`ConversationItemDetail` shows the SLA indicator whenever a conversation has a `slaPolicyId`, but a conversation can carry a policy id without the applied SLA record being serialised. The `appliedSla as SLA` cast hid that from the type checker, so the indicator rendered with a null record and `SLAIndicator` threw on `appliedSla.id`. Because the read sits inside a self-rescheduling timer, three users produced 1.9K events.

Gate the indicator on the applied SLA record itself rather than the policy id, and drop the cast so the type checker enforces it from here on.

Fixes [CHATWOOT-MOBILE-F](https://chatwoot-p3.sentry.io/issues/6157315856) and [CHATWOOT-MOBILE-28W](https://chatwoot-p3.sentry.io/issues/7681657910).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
