### PR TITLE
fix(sentry): pass a string title to every alert dialog

### DIFF
--- a/src/screens/chat-screen/components/message-components/FileBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/FileBubble.tsx
@@ -9,6 +9,7 @@ import { tailwind } from '@/theme';
 import { Icon } from '@/components-next/common';
 import { Spinner } from '@/components-next/spinner';
 import { MESSAGE_VARIANTS } from '@/constants';
+import { errorMessage } from '@/utils/errorUtils';
 
 const generateUniqueFileName = (url: string, originalFileName: string) => {
   const hash = url.split('').reduce((acc, char) => {
@@ -41,9 +42,11 @@ export const FileBubblePreview = (props: FilePreviewProps) => {
 
   const previewFile = () => {
     try {
-      FileViewer.open(localFilePath).catch(e => Alert.alert(e));
+      FileViewer.open(localFilePath).catch(e =>
+        Alert.alert('Not able to preview file', errorMessage(e)),
+      );
     } catch (e) {
-      Alert.alert('Not able to preview file' + e);
+      Alert.alert('Not able to preview file', errorMessage(e));
     }
   };
 

--- a/src/screens/chat-screen/conversation-actions/ConversationActions.tsx
+++ b/src/screens/chat-screen/conversation-actions/ConversationActions.tsx
@@ -15,6 +15,7 @@ import {
 import { TAB_BAR_HEIGHT } from '@/constants';
 import { tailwind } from '@/theme';
 import i18n from '@/i18n';
+import { errorMessage } from '@/utils/errorUtils';
 import { ConversationStatus } from '@/types';
 import { useChatWindowContext } from '@/context';
 import { useAppDispatch, useAppSelector } from '@/hooks';
@@ -70,7 +71,7 @@ export const ConversationActions = () => {
         url,
       });
     } catch (error) {
-      Alert.alert((error as Error).message);
+      Alert.alert(i18n.t('COMMON.ERROR_TITLE'), errorMessage(error));
     }
   };
 

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -7,6 +7,30 @@ interface ErrorHandler {
   (e: Error, isFatal: boolean): void;
 }
 
+/**
+ * Coerces a caught value into a string for display.
+ *
+ * Rejections reach the app as Errors, as plain objects from native modules, or
+ * as bare strings. Alert passes its arguments across the bridge untouched, and
+ * Android's DialogModule reads them as strings, so a non-string title or
+ * message crashes the process.
+ */
+export const errorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (error && typeof error === 'object' && 'message' in error) {
+    const { message } = error as { message: unknown };
+    if (typeof message === 'string') {
+      return message;
+    }
+  }
+  return i18n.t('COMMON.ERROR');
+};
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const errorHandler: ErrorHandler = (e, isFatal) => {
   Sentry.captureException(e);

--- a/src/utils/specs/errorUtils.spec.ts
+++ b/src/utils/specs/errorUtils.spec.ts
@@ -1,0 +1,28 @@
+import { errorMessage } from '@/utils/errorUtils';
+
+describe('#errorMessage', () => {
+  it('returns the message of an Error', () => {
+    expect(errorMessage(new Error('No app associated with this mime type'))).toBe(
+      'No app associated with this mime type',
+    );
+  });
+
+  it('returns a string unchanged', () => {
+    expect(errorMessage('File load error')).toBe('File load error');
+  });
+
+  it('returns the message of a native module rejection', () => {
+    expect(errorMessage({ code: 'ENOENT', message: 'File does not exist' })).toBe(
+      'File does not exist',
+    );
+  });
+
+  it('falls back when the object has no string message', () => {
+    expect(errorMessage({ message: { detail: 'nested' } })).toBe('Error');
+  });
+
+  it('falls back for null and undefined', () => {
+    expect(errorMessage(null)).toBe('Error');
+    expect(errorMessage(undefined)).toBe('Error');
+  });
+});


### PR DESCRIPTION
## Description

Opening a file attachment that no installed app can handle rejects with an error object, and `FileBubble` passed that object straight into `Alert.alert` as the title. `Alert` forwards its arguments across the bridge untouched, so Android's `DialogModule` read the title as a string, failed the cast, and killed the process. It accounts for 2.2K events across 90 users.

Give both preview failures a real title and render the error as the message. `ConversationActions` had the same shape via an `as Error` cast that produced an undefined title when a share rejected with anything other than an Error, so it moves to the same helper.

Fixes [CHATWOOT-MOBILE-C0](https://chatwoot-p3.sentry.io/issues/6310670698).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
