### PR TITLE
fix(sentry): memoize markdown bubble to stop repeated text layout

### DIFF
--- a/src/screens/chat-screen/components/message-components/MarkdownBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/MarkdownBubble.tsx
@@ -24,16 +24,15 @@ const variantTextMap = {
   [MESSAGE_VARIANTS.EMAIL]: 'text-gray-950',
 };
 
-export const MarkdownBubble = (props: MarkdownBubbleProps) => {
-  const { messageContent, variant } = props;
-  const handleURL = (url: string) => {
-    openURL({ URL: url });
-    return true;
-  };
+const handleURL = (url: string) => {
+  openURL({ URL: url });
+  return true;
+};
 
+const buildStyles = (variant: string) => {
   const textStyle = tailwind.style(variantTextMap[variant]);
 
-  const styles = StyleSheet.create({
+  return StyleSheet.create({
     text: {
       fontSize: 16,
       letterSpacing: 0.32,
@@ -77,9 +76,38 @@ export const MarkdownBubble = (props: MarkdownBubbleProps) => {
       ...textStyle,
     },
   });
+};
+
+// Markdown compares its props by identity, and on a miss it re-tokenises the
+// message and rebuilds the Text tree beneath it. A fresh tree is a new
+// attributed string on the native side, which iOS lays out again on the main
+// thread. Styles are built once per variant so a re-render of the surrounding
+// row does not invalidate the whole tree.
+const stylesByVariant = new Map<string, ReturnType<typeof buildStyles>>();
+
+const getStyles = (variant: string) => {
+  const cachedStyles = stylesByVariant.get(variant);
+  if (cachedStyles) {
+    return cachedStyles;
+  }
+
+  const styles = buildStyles(variant);
+  stylesByVariant.set(variant, styles);
+  return styles;
+};
+
+export const MarkdownBubble = React.memo((props: MarkdownBubbleProps) => {
+  const { messageContent, variant } = props;
+
   return (
-    <Markdown mergeStyle markdownit={markdownItInstance} onLinkPress={handleURL} style={styles}>
+    <Markdown
+      mergeStyle
+      markdownit={markdownItInstance}
+      onLinkPress={handleURL}
+      style={getStyles(variant)}>
       {messageContent}
     </Markdown>
   );
-};
+});
+
+MarkdownBubble.displayName = 'MarkdownBubble';


### PR DESCRIPTION
## Description

`MarkdownBubble` built its stylesheet and its link handler inside the render body, so both changed identity on every render. `Markdown` compares props by identity, and on a miss it re-tokenises the message and rebuilds the Text tree beneath it. A fresh tree is a new attributed string natively, which iOS lays out again on the main thread inside `drawRect`, so every re-render of a message row paid a full text layout for each visible bubble. Attachments finishing their download re-render the whole list, which is where the 2 second hangs come from.

Build the styles once per variant, lift the link handler to module scope, and memoize the component so a row re-render no longer invalidates the tree. Nothing renders differently.

Fixes [CHATWOOT-MOBILE-28T](https://chatwoot-p3.sentry.io/issues/7681340205).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
