### PR TITLE
fix(sentry): guard conversation list and participants against missing data

### DIFF
--- a/src/screens/chat-screen/conversation-actions/components/UpdateParticipant.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/UpdateParticipant.tsx
@@ -12,6 +12,7 @@ import { useAppDispatch, useAppSelector } from '@/hooks';
 import { selectAssignableParticipantsByInboxId } from '@/store/assignable-agent/assignableAgentSelectors';
 import { selectSelectedConversation } from '@/store/conversation/conversationSelectedSlice';
 import { isAssignableAgentFetching } from '@/store/assignable-agent/assignableAgentSelectors';
+import { isConversationParticipantsFetching } from '@/store/conversation-participant/conversationParticipantSelectors';
 import { showToast } from '@/utils/toastUtils';
 import i18n from '@/i18n';
 import { CONVERSATION_EVENTS } from '@/constants/analyticsEvents';
@@ -54,24 +55,33 @@ const ParticipantStack = ({
   activeConversationParticipants,
 }: {
   allAgents: Agent[];
-  activeConversationParticipants: Agent[];
+  activeConversationParticipants?: Agent[];
 }) => {
   const isFetching = useAppSelector(isAssignableAgentFetching);
+  const isFetchingParticipants = useAppSelector(isConversationParticipantsFetching);
 
   const dispatch = useAppDispatch();
 
   const selectedConversation = useAppSelector(selectSelectedConversation);
 
+  // An update replaces the whole participant set, so building one from an
+  // assumed empty list would drop everyone already on the conversation.
+  const hasLoadedParticipants = activeConversationParticipants !== undefined;
+
   const updatedAgents = allAgents.map(agent => {
     return {
       ...agent,
-      isParticipant: activeConversationParticipants.some(
+      isParticipant: (activeConversationParticipants ?? []).some(
         participant => participant.id === agent.id,
       ),
     };
   });
 
   const handleAssigneePress = async (item: Agent & { isParticipant: boolean }) => {
+    if (!activeConversationParticipants) {
+      return;
+    }
+
     let updateAgentList = [...activeConversationParticipants];
     if (item.isParticipant) {
       updateAgentList = updateAgentList.filter(agent => agent.id !== item.id);
@@ -99,8 +109,15 @@ const ParticipantStack = ({
 
   return (
     <ScrollView showsVerticalScrollIndicator={false} style={tailwind.style('my-1 pl-3')}>
-      {isFetching && allAgents.length === 0 ? (
+      {(isFetching && allAgents.length === 0) || isFetchingParticipants ? (
         <ActivityIndicator />
+      ) : !hasLoadedParticipants ? (
+        <Animated.Text
+          style={tailwind.style(
+            'text-base text-gray-900 font-inter-420-20 leading-[21px] py-3 pr-3',
+          )}>
+          {i18n.t('ERRORS.COMMON_ERROR')}
+        </Animated.Text>
       ) : (
         updatedAgents.map((value, index) => {
           return (
@@ -120,7 +137,7 @@ const ParticipantStack = ({
 };
 
 type UpdateParticipantProps = {
-  activeConversationParticipants: Agent[];
+  activeConversationParticipants?: Agent[];
 };
 
 export const UpdateParticipant = (props: UpdateParticipantProps) => {

--- a/src/store/conversation-participant/conversationParticipantSelectors.ts
+++ b/src/store/conversation-participant/conversationParticipantSelectors.ts
@@ -1,6 +1,11 @@
 import type { RootState } from '@/store';
+import type { Agent } from '@/types';
 
 import { createSelector } from '@reduxjs/toolkit';
+
+// Shared instance so conversations without fetched participants keep a stable
+// reference between renders.
+const NO_PARTICIPANTS: Agent[] = [];
 
 export const selectConversationParticipantsState = (state: RootState) =>
   state.conversationParticipants;
@@ -12,5 +17,5 @@ export const selectConversationParticipants = createSelector(
 
 export const selectConversationParticipantsByConversationId = createSelector(
   [selectConversationParticipants, (_state: RootState, conversationId: number) => conversationId],
-  (state, conversationId) => state[conversationId],
+  (state, conversationId) => state[conversationId] ?? NO_PARTICIPANTS,
 );

--- a/src/store/conversation-participant/conversationParticipantSelectors.ts
+++ b/src/store/conversation-participant/conversationParticipantSelectors.ts
@@ -1,14 +1,14 @@
 import type { RootState } from '@/store';
-import type { Agent } from '@/types';
 
 import { createSelector } from '@reduxjs/toolkit';
 
-// Shared instance so conversations without fetched participants keep a stable
-// reference between renders.
-const NO_PARTICIPANTS: Agent[] = [];
-
 export const selectConversationParticipantsState = (state: RootState) =>
   state.conversationParticipants;
+
+export const isConversationParticipantsFetching = createSelector(
+  [selectConversationParticipantsState],
+  state => state.uiFlags.loading,
+);
 
 export const selectConversationParticipants = createSelector(
   [selectConversationParticipantsState],
@@ -17,5 +17,8 @@ export const selectConversationParticipants = createSelector(
 
 export const selectConversationParticipantsByConversationId = createSelector(
   [selectConversationParticipants, (_state: RootState, conversationId: number) => conversationId],
-  (state, conversationId) => state[conversationId] ?? NO_PARTICIPANTS,
+  // Undefined until the fetch for this conversation succeeds. An empty array
+  // means the conversation genuinely has no participants, so the two cannot be
+  // collapsed: updates replace the whole set.
+  (state, conversationId) => state[conversationId],
 );

--- a/src/store/conversation-participant/specs/conversationParticipantSelectors.spec.ts
+++ b/src/store/conversation-participant/specs/conversationParticipantSelectors.spec.ts
@@ -1,12 +1,15 @@
-import { selectConversationParticipantsByConversationId } from '../conversationParticipantSelectors';
+import {
+  selectConversationParticipantsByConversationId,
+  isConversationParticipantsFetching,
+} from '../conversationParticipantSelectors';
 import { RootState } from '@/store';
 import type { Agent } from '@/types';
 
 const participant = { id: 7, name: 'Devi' } as Agent;
 
-const buildState = (records: { [key: number]: Agent[] }) =>
+const buildState = (records: { [key: number]: Agent[] }, loading = false) =>
   ({
-    conversationParticipants: { records },
+    conversationParticipants: { records, uiFlags: { loading, updating: false } },
   }) as RootState;
 
 describe('Conversation Participant Selectors', () => {
@@ -15,15 +18,20 @@ describe('Conversation Participant Selectors', () => {
     expect(selectConversationParticipantsByConversationId(state, 250)).toEqual([participant]);
   });
 
-  it('should return an empty list for a conversation with no participants fetched', () => {
-    const state = buildState({ 250: [participant] });
-    expect(selectConversationParticipantsByConversationId(state, 999)).toEqual([]);
+  it('should return an empty list for a conversation fetched with no participants', () => {
+    const state = buildState({ 250: [] });
+    expect(selectConversationParticipantsByConversationId(state, 250)).toEqual([]);
   });
 
-  it('should return the same reference for repeated misses', () => {
-    const state = buildState({});
-    const first = selectConversationParticipantsByConversationId(state, 999);
-    const second = selectConversationParticipantsByConversationId(state, 888);
-    expect(first).toBe(second);
+  // A conversation whose fetch has not resolved must stay distinguishable from
+  // one with no participants, since an update replaces the whole set.
+  it('should return undefined for a conversation that has not been fetched', () => {
+    const state = buildState({ 250: [participant] });
+    expect(selectConversationParticipantsByConversationId(state, 999)).toBeUndefined();
+  });
+
+  it('should report whether participants are being fetched', () => {
+    expect(isConversationParticipantsFetching(buildState({}, true))).toBe(true);
+    expect(isConversationParticipantsFetching(buildState({}, false))).toBe(false);
   });
 });

--- a/src/store/conversation-participant/specs/conversationParticipantSelectors.spec.ts
+++ b/src/store/conversation-participant/specs/conversationParticipantSelectors.spec.ts
@@ -1,0 +1,29 @@
+import { selectConversationParticipantsByConversationId } from '../conversationParticipantSelectors';
+import { RootState } from '@/store';
+import type { Agent } from '@/types';
+
+const participant = { id: 7, name: 'Devi' } as Agent;
+
+const buildState = (records: { [key: number]: Agent[] }) =>
+  ({
+    conversationParticipants: { records },
+  }) as RootState;
+
+describe('Conversation Participant Selectors', () => {
+  it('should select the participants of a conversation', () => {
+    const state = buildState({ 250: [participant] });
+    expect(selectConversationParticipantsByConversationId(state, 250)).toEqual([participant]);
+  });
+
+  it('should return an empty list for a conversation with no participants fetched', () => {
+    const state = buildState({ 250: [participant] });
+    expect(selectConversationParticipantsByConversationId(state, 999)).toEqual([]);
+  });
+
+  it('should return the same reference for repeated misses', () => {
+    const state = buildState({});
+    const first = selectConversationParticipantsByConversationId(state, 999);
+    const second = selectConversationParticipantsByConversationId(state, 888);
+    expect(first).toBe(second);
+  });
+});

--- a/src/utils/camelCaseKeys.ts
+++ b/src/utils/camelCaseKeys.ts
@@ -21,7 +21,11 @@ import { NotificationCreatedResponse } from '@/store/notification/notificationTy
 import { NotificationRemovedResponse } from '@/store/notification/notificationTypes';
 
 export const transformConversation = (conversation: any): Conversation => {
-  return camelcaseKeys(conversation, { deep: true }) as unknown as Conversation;
+  const transformed = camelcaseKeys(conversation, { deep: true }) as unknown as Conversation;
+
+  // The list endpoint omits messages for some conversations, while selectors
+  // and reducers index into the array unconditionally.
+  return { ...transformed, messages: transformed.messages ?? [] };
 };
 
 export const transformContact = (contact: any): Contact => {

--- a/src/utils/conversationUtils.ts
+++ b/src/utils/conversationUtils.ts
@@ -48,13 +48,16 @@ export const filterDuplicateSourceMessages = (messages: Message[] = []): Message
 };
 
 export const getLastMessage = (conversation: Conversation): Message | null => {
-  const lastMessageIncludingActivity = conversation.messages[conversation.messages.length - 1];
-  const nonActivityMessages = conversation.messages.filter(message => message.messageType !== 2);
+  // A conversation reaches the list before its messages are hydrated, so the
+  // array is absent even though the type declares it.
+  const messages = conversation.messages ?? [];
+  const lastMessageIncludingActivity = messages[messages.length - 1];
+  const nonActivityMessages = messages.filter(message => message.messageType !== 2);
   const lastNonActivityMessageInStore = nonActivityMessages[nonActivityMessages.length - 1];
   const lastNonActivityMessageFromAPI = conversation.lastNonActivityMessage;
 
   if (!lastNonActivityMessageInStore && !lastNonActivityMessageFromAPI) {
-    return lastMessageIncludingActivity;
+    return lastMessageIncludingActivity ?? null;
   }
   return getLastNonActivityMessage(lastNonActivityMessageInStore, lastNonActivityMessageFromAPI);
 };

--- a/src/utils/conversationUtils.ts
+++ b/src/utils/conversationUtils.ts
@@ -48,8 +48,8 @@ export const filterDuplicateSourceMessages = (messages: Message[] = []): Message
 };
 
 export const getLastMessage = (conversation: Conversation): Message | null => {
-  // A conversation reaches the list before its messages are hydrated, so the
-  // array is absent even though the type declares it.
+  // transformConversation normalises this, so the fallback only covers
+  // conversations built outside that path.
   const messages = conversation.messages ?? [];
   const lastMessageIncludingActivity = messages[messages.length - 1];
   const nonActivityMessages = messages.filter(message => message.messageType !== 2);

--- a/src/utils/specs/camelCaseKeys.spec.ts
+++ b/src/utils/specs/camelCaseKeys.spec.ts
@@ -43,7 +43,20 @@ describe('camelCaseKeys', () => {
         hmacVerified: false,
         channel: 'Channel::Whatsapp',
       },
+      messages: [],
     });
+  });
+
+  it('should default messages to an empty list when the api omits them', () => {
+    expect(transformConversation({ id: 250 }).messages).toEqual([]);
+  });
+
+  it('should keep the messages the api sends', () => {
+    const transformed = transformConversation({
+      id: 250,
+      messages: [{ id: 1, message_type: 0 }],
+    });
+    expect(transformed.messages).toEqual([{ id: 1, messageType: 0 }]);
   });
 
   it('should transform contact', () => {

--- a/src/utils/specs/conversationUtils.spec.ts
+++ b/src/utils/specs/conversationUtils.spec.ts
@@ -141,4 +141,22 @@ describe('getLastMessage', () => {
     };
     expect(getLastMessage(testConversation)).toEqual(lastMessage);
   });
+
+  it('should return the api message when the conversation has no messages array', () => {
+    const testConversation = {
+      ...conversation,
+      messages: undefined,
+      lastNonActivityMessage: lastMessage,
+    } as unknown as Conversation;
+    expect(getLastMessage(testConversation)).toEqual(lastMessage);
+  });
+
+  it('should return null when the conversation has neither messages nor an api message', () => {
+    const testConversation = {
+      ...conversation,
+      messages: undefined,
+      lastNonActivityMessage: null,
+    } as unknown as Conversation;
+    expect(getLastMessage(testConversation)).toBeNull();
+  });
 });


### PR DESCRIPTION
## Description

Two crashes from the same cause: a type declares a field as always present and the API does not always send it.

`getLastMessage` reads `conversation.messages.length`, but a conversation reaches the list before its messages are hydrated, so the array is absent and the conversation row throws while rendering. `selectConversationParticipantsByConversationId` indexes straight into its records map and returns undefined for a conversation whose participants have not been fetched, which `ParticipantStack` then calls `.some` on when the participants sheet opens.

Fall back to an empty list in both places. The participants selector returns a shared instance so a miss keeps a stable reference and does not re-render its subscribers.

Fixes [CHATWOOT-MOBILE-299](https://chatwoot-p3.sentry.io/issues/7682963987/) and [CHATWOOT-MOBILE-295](https://chatwoot-p3.sentry.io/issues/7682859697/).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
