### PR TITLE
fix: Android tab bar renders behind system nav buttons (edge-to-edge, targetSdk 36)

### DIFF
--- a/src/navigation/tabs/BottomTabBar.tsx
+++ b/src/navigation/tabs/BottomTabBar.tsx
@@ -9,6 +9,7 @@ import Animated, {
 import { BlurView, BlurViewProps } from '@react-native-community/blur';
 import { BottomTabBarProps } from '@react-navigation/bottom-tabs';
 import { RouteProp } from '@react-navigation/native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { selectCurrentState } from '@/store/conversation/conversationHeaderSlice';
 
 import {
@@ -117,6 +118,7 @@ const TabItem = (props: any) => {
 export const BottomTabBar = ({ state, descriptors, navigation }: BottomTabBarProps) => {
   const hapticSelection = useHaptic();
   const tabBarHeight = useTabBarHeight();
+  const { bottom } = useSafeAreaInsets();
 
   // Memoize press handlers using useCallback
   const createPressHandler = React.useCallback(
@@ -163,8 +165,8 @@ export const BottomTabBar = ({ state, descriptors, navigation }: BottomTabBarPro
         ],
         android: [
           tailwind.style(
-            'flex flex-row absolute w-full bottom-0 pl-[72px] pr-[71px] py-[11px] bg-white',
-            `h-[${tabBarHeight}px]`,
+            'flex flex-row absolute w-full bottom-0 pl-[72px] pr-[71px] pt-[11px] bg-white',
+            `h-[${tabBarHeight}px] pb-[${bottom + 11}px]`,
           ),
         ],
       })}>

--- a/src/screens/conversations/ConversationScreen.tsx
+++ b/src/screens/conversations/ConversationScreen.tsx
@@ -17,12 +17,7 @@ import { ActionTabs } from '@/components-next';
 import { Sheet } from '@/components-next/common/sheet/Sheet';
 
 import { EmptyStateIcon } from '@/svg-icons';
-import {
-  SCREENS,
-  TAB_BAR_HEIGHT,
-  LAST_ACTIVE_TIMESTAMP_KEY,
-  LAST_ACTIVE_TIMESTAMP_THRESHOLD,
-} from '@/constants';
+import { SCREENS, LAST_ACTIVE_TIMESTAMP_KEY, LAST_ACTIVE_TIMESTAMP_THRESHOLD } from '@/constants';
 import {
   ConversationListStateProvider,
   useConversationListStateContext,
@@ -53,6 +48,7 @@ import { clearAssignableAgents } from '@/store/assignable-agent/assignableAgentS
 import i18n from '@/i18n';
 import ActionBottomSheet from '@/navigation/tabs/ActionBottomSheet';
 import { getCurrentRouteName } from '@/utils/navigationUtils';
+import { useTabBarHeight } from '@/utils';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 // The screen list thats need to be checked for refreshing the conversations list
@@ -67,6 +63,7 @@ type FlashListRenderItemType = {
 
 const ConversationList = () => {
   const dispatch = useAppDispatch();
+  const tabBarHeight = useTabBarHeight();
   const [appState, setAppState] = useState(AppState.currentState);
 
   // This is used to prevent the infinite scrolling before the list is ready
@@ -124,10 +121,7 @@ const ConversationList = () => {
     if (isAllConversationsFetched || !isFlashListReady) return null;
     return (
       <Animated.View
-        style={tailwind.style(
-          'flex-1 items-center justify-center pt-8',
-          `pb-[${TAB_BAR_HEIGHT}px]`,
-        )}>
+        style={tailwind.style('flex-1 items-center justify-center pt-8', `pb-[${tabBarHeight}px]`)}>
         <ActivityIndicator size="small" />
       </Animated.View>
     );
@@ -220,7 +214,7 @@ const ConversationList = () => {
 
   return shouldShowEmptyLoader ? (
     <Animated.View
-      style={tailwind.style('flex-1 items-center justify-center', `pb-[${TAB_BAR_HEIGHT}px]`)}>
+      style={tailwind.style('flex-1 items-center justify-center', `pb-[${tabBarHeight}px]`)}>
       <ActivityIndicator />
     </Animated.View>
   ) : allConversations.length === 0 ? (
@@ -228,7 +222,7 @@ const ConversationList = () => {
       refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />}
       contentContainerStyle={tailwind.style(
         'flex-1 items-center justify-center',
-        `pb-[${TAB_BAR_HEIGHT}px]`,
+        `pb-[${tabBarHeight}px]`,
       )}>
       <EmptyStateIcon />
       <Animated.Text style={tailwind.style('pt-6 text-md  tracking-[0.32px] text-gray-800')}>
@@ -247,7 +241,7 @@ const ConversationList = () => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       renderItem={handleRender}
-      contentContainerStyle={tailwind.style(`pb-[${TAB_BAR_HEIGHT - 1}px]`)}
+      contentContainerStyle={tailwind.style(`pb-[${tabBarHeight - 1}px]`)}
     />
   );
 };

--- a/src/screens/inbox/InboxScreen.tsx
+++ b/src/screens/inbox/InboxScreen.tsx
@@ -4,7 +4,6 @@ import Animated, { SharedValue } from 'react-native-reanimated';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { FlashList, ListRenderItem } from '@shopify/flash-list';
 
-import { TAB_BAR_HEIGHT } from '@/constants';
 import { InboxListStateProvider } from '@/context';
 import type { Notification } from '@/types/Notification';
 import { tailwind } from '@/theme';
@@ -19,6 +18,7 @@ import { InboxHeader, InboxItemContainer } from './components';
 import { useInboxListStateContext } from '@/context';
 import { resetNotifications } from '@/store/notification/notificationSlice';
 import { showToast } from '@/utils/toastUtils';
+import { useTabBarHeight } from '@/utils';
 import i18n from '@/i18n';
 import { selectSortOrder } from '@/store/notification/notificationFilterSlice';
 import { selectCurrentUserAccountId } from '@/store/auth/authSelectors';
@@ -28,6 +28,7 @@ import { InboxSortTypes } from '@/store/notification/notificationTypes';
 const AnimatedFlashlist = Animated.createAnimatedComponent(FlashList<Notification>);
 
 const InboxList = () => {
+  const tabBarHeight = useTabBarHeight();
   const [pageNumber, setPageNumber] = useState(1);
 
   const [isFlashListReady, setFlashListReady] = useState(false);
@@ -57,10 +58,7 @@ const InboxList = () => {
     if (isAllNotificationsFetched || !isFlashListReady) return null;
     return (
       <Animated.View
-        style={tailwind.style(
-          'flex-1 items-center justify-center pt-8',
-          `pb-[${TAB_BAR_HEIGHT}px]`,
-        )}>
+        style={tailwind.style('flex-1 items-center justify-center pt-8', `pb-[${tabBarHeight}px]`)}>
         <ActivityIndicator size="small" />
       </Animated.View>
     );
@@ -132,7 +130,7 @@ const InboxList = () => {
 
   return shouldShowEmptyLoader ? (
     <Animated.View
-      style={tailwind.style('flex-1 items-center justify-center', `pb-[${TAB_BAR_HEIGHT}px]`)}>
+      style={tailwind.style('flex-1 items-center justify-center', `pb-[${tabBarHeight}px]`)}>
       <ActivityIndicator />
     </Animated.View>
   ) : notifications.length === 0 ? (
@@ -140,7 +138,7 @@ const InboxList = () => {
       refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />}
       contentContainerStyle={tailwind.style(
         'flex-1 items-center justify-center',
-        `pb-[${TAB_BAR_HEIGHT}px]`,
+        `pb-[${tabBarHeight}px]`,
       )}>
       <EmptyStateIcon />
       <Animated.Text style={tailwind.style('pt-6 text-md tracking-[0.32px] text-gray-800')}>
@@ -157,7 +155,7 @@ const InboxList = () => {
       onEndReachedThreshold={0.5}
       ListFooterComponent={ListFooterComponent}
       renderItem={handleRender}
-      contentContainerStyle={tailwind.style(`pb-[${TAB_BAR_HEIGHT - 1}px]`)}
+      contentContainerStyle={tailwind.style(`pb-[${tabBarHeight - 1}px]`)}
     />
   );
 };

--- a/src/screens/settings/SettingsScreen.tsx
+++ b/src/screens/settings/SettingsScreen.tsx
@@ -31,12 +31,12 @@ import {
 import { Sheet } from '@/components-next/common/sheet/Sheet';
 import { UserAvatar } from './components/UserAvatar';
 
-import { LANGUAGES, TAB_BAR_HEIGHT } from '@/constants';
+import { LANGUAGES } from '@/constants';
 import { useRefsContext } from '@/context';
 import { ChatwootIcon, NotificationIcon, SwitchIcon, TranslateIcon } from '@/svg-icons';
 import { GenericListType } from '@/types';
 
-import { useHaptic } from '@/utils';
+import { useHaptic, useTabBarHeight } from '@/utils';
 import { SettingsHeader } from './SettingsHeader';
 import { DebugActions } from './components/DebugActions';
 import {
@@ -69,6 +69,7 @@ const appVersionDetails = buildNumber ? `${appVersion} (${buildNumber})` : appVe
 const SettingsScreen = () => {
   const navigation = useNavigation();
   const dispatch = useAppDispatch();
+  const tabBarHeight = useTabBarHeight();
   const availabilityStatus =
     (useSelector(selectCurrentUserAvailability) as AvailabilityStatus) || 'offline';
 
@@ -261,7 +262,7 @@ const SettingsScreen = () => {
       <SettingsHeader />
       <Animated.ScrollView
         showsVerticalScrollIndicator={false}
-        contentContainerStyle={tailwind.style(`pb-[${TAB_BAR_HEIGHT - 1}px]`)}>
+        contentContainerStyle={tailwind.style(`pb-[${tabBarHeight - 1}px]`)}>
         <Animated.View style={tailwind.style('flex justify-center items-center pt-4 gap-4')}>
           <Animated.View>
             <UserAvatar src={avatarUrl} name={name} status={availabilityStatus} />

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,7 +1,11 @@
 import { Platform } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { TAB_BAR_HEIGHT } from '@/constants';
 
+// Android renders edge to edge, so the bar grows by the navigation bar inset to
+// keep the tab items clear of the system buttons or gesture pill.
 export const useTabBarHeight = () => {
-  return Platform.OS === 'ios' ? TAB_BAR_HEIGHT : TAB_BAR_HEIGHT - 21;
+  const { bottom } = useSafeAreaInsets();
+  return Platform.OS === 'ios' ? TAB_BAR_HEIGHT : TAB_BAR_HEIGHT - 21 + bottom;
 };


### PR DESCRIPTION
## Description

The app targets `targetSdkVersion 36`, so Android 15+ forces edge-to-edge and the window now extends under the system navigation bar. `BottomTabBar` is pinned `absolute bottom-0` with a hardcoded height and no bottom safe-area inset, so the Inbox / Conversations / Settings icons render directly on top of Android's back, home and recents buttons. Reported by a customer on a device using 3-button navigation.

`useTabBarHeight()` now adds the bottom inset on Android, and the tab bar pads its content above the nav bar so the icons keep their original content box while the white background extends behind the system buttons. The three tab screens switch their list and empty-state bottom padding from the raw `TAB_BAR_HEIGHT` constant to the hook, so the last row still clears the taller bar. iOS is unchanged, the hook returns the same value there.

Fixes: [CW-7987](https://linear.app/chatwoot/issue/CW-7987/support-android-tab-bar-renders-behind-system-nav-buttons-edge-to-edge)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

 | Before (3-button nav) | After (3-button nav) |
  | :---: | :---: |
  | <img src="https://github.com/user-attachments/assets/85c7d662-de24-4eb6-8133-edff446f4fbc" width="300" /> | <img src="https://github.com/user-attachments/assets/51687aab-6c4c-44c2-a0a1-48cc45632f3f" width="300" /> |

After (Gesture navigation (smaller inset) )
  
<img alt="after-gesture-nav" src="https://github.com/user-attachments/assets/0e14f93e-a9df-4b5b-965c-d9ce4fecd25d" width="300" />



