### PR TITLE
fix: restore the cropped bulk action menu on iOS

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -4,7 +4,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
   return {
     name: 'Chatwoot',
     slug: process.env.EXPO_PUBLIC_APP_SLUG || 'chatwoot-mobile',
-    version: '4.9.1',
+    version: '4.9.2',
     orientation: 'portrait',
     icon: './assets/icon.png',
     userInterfaceStyle: 'light',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/mobile-app",
-  "version": "4.9.1",
+  "version": "4.9.2",
   "packageManager": "pnpm@10.11.0",
   "scripts": {
     "start": "expo start --dev-client",

--- a/src/components-next/action-tabs/ActionTabs.tsx
+++ b/src/components-next/action-tabs/ActionTabs.tsx
@@ -208,9 +208,9 @@ const styles = StyleSheet.create({
     Platform.select({
       ios: {
         shadowColor: '#000000',
-        shadowOffset: { width: 0, height: 4 },
-        shadowRadius: 12,
-        shadowOpacity: 0.12,
+        shadowOffset: { width: 0, height: 8 },
+        shadowRadius: 10,
+        shadowOpacity: 0.25,
       },
       android: {
         elevation: 4,

--- a/src/components-next/action-tabs/ActionTabs.tsx
+++ b/src/components-next/action-tabs/ActionTabs.tsx
@@ -178,7 +178,7 @@ export const ActionTabs = () => {
       style={Platform.select({
         ios: [
           tailwind.style(
-            'flex flex-row rounded-[30px] items-center absolute justify-between w-[220px] px-6 py-[15px] bg-white',
+            'flex flex-row rounded-[30px] items-center absolute justify-between w-[220px] px-6 py-[15px]',
             `h-[${ACTION_TAB_HEIGHT}px] bottom-[${bottom + 8}px] left-[${
               (SCREEN_WIDTH - 220) / 2
             }px]`,

--- a/src/components-next/action-tabs/ActionTabs.tsx
+++ b/src/components-next/action-tabs/ActionTabs.tsx
@@ -87,11 +87,8 @@ const ActionTabBarBackground = (props: ActionTabBarBackgroundProps) => {
     };
   });
 
-  // BlurView does not reliably apply flex/positioning styles under the New
-  // Architecture, so the layout lives on a plain Animated.View and BlurView is
-  // only an absolute-fill background behind the action items. The blur is
-  // clipped by its own wrapper rather than by the outer view, because
-  // overflow-hidden on the shadow-casting view would clip the shadow away.
+  // Layout and shadow sit on the Animated.View. BlurView fills it as a
+  // background, clipped to the corner radius by its own wrapper.
   return Platform.OS === 'ios' ? (
     <Animated.View style={[style, animatedTabBarStyle, styles.listShadow]}>
       <Animated.View style={tailwind.style('absolute inset-0 rounded-[30px] overflow-hidden')}>

--- a/src/components-next/action-tabs/ActionTabs.tsx
+++ b/src/components-next/action-tabs/ActionTabs.tsx
@@ -23,8 +23,6 @@ const ACTION_TAB_HEIGHT = 58;
 
 const SCREEN_WIDTH = Dimensions.get('screen').width;
 
-const AnimatedBlurView = Animated.createAnimatedComponent(BlurView);
-
 const tabExitSpringConfig = { damping: 20, stiffness: 360, mass: 1 };
 const tabEnterSpringConfig = { damping: 30, stiffness: 360, mass: 1 };
 
@@ -89,10 +87,18 @@ const ActionTabBarBackground = (props: ActionTabBarBackgroundProps) => {
     };
   });
 
+  // BlurView does not reliably apply flex/positioning styles under the New
+  // Architecture, so the layout lives on a plain Animated.View and BlurView is
+  // only an absolute-fill background behind the action items. The blur is
+  // clipped by its own wrapper rather than by the outer view, because
+  // overflow-hidden on the shadow-casting view would clip the shadow away.
   return Platform.OS === 'ios' ? (
-    <AnimatedBlurView {...{ blurAmount, blurType }} style={[style, animatedTabBarStyle]}>
+    <Animated.View style={[style, animatedTabBarStyle, styles.listShadow]}>
+      <Animated.View style={tailwind.style('absolute inset-0 rounded-[30px] overflow-hidden')}>
+        <BlurView {...{ blurAmount, blurType }} style={tailwind.style('flex-1 bg-[#00000009]')} />
+      </Animated.View>
       {children}
-    </AnimatedBlurView>
+    </Animated.View>
   ) : (
     <Animated.View style={[style, animatedTabBarStyle, styles.listShadow]}>
       {children}
@@ -175,7 +181,7 @@ export const ActionTabs = () => {
       style={Platform.select({
         ios: [
           tailwind.style(
-            'flex flex-row rounded-[30px] items-center absolute justify-between w-[220px] px-6 py-[15px] bg-[#00000009]',
+            'flex flex-row rounded-[30px] items-center absolute justify-between w-[220px] px-6 py-[15px] bg-white',
             `h-[${ACTION_TAB_HEIGHT}px] bottom-[${bottom + 8}px] left-[${
               (SCREEN_WIDTH - 220) / 2
             }px]`,
@@ -201,11 +207,10 @@ const styles = StyleSheet.create({
   listShadow:
     Platform.select({
       ios: {
-        shadowColor: '#00000040',
-        shadowOffset: { width: 0, height: 0.15 },
-        shadowRadius: 2,
-        shadowOpacity: 0.35,
-        elevation: 2,
+        shadowColor: '#000000',
+        shadowOffset: { width: 0, height: 4 },
+        shadowRadius: 12,
+        shadowOpacity: 0.12,
       },
       android: {
         elevation: 4,


### PR DESCRIPTION
## Description

The bulk action menu on the conversation list rendered cropped on iOS, so the actions were not tappable.

`ActionTabs` still used `BlurView` as its layout container, which does not reliably apply flex/positioning styles under the New Architecture. The layout now lives on a plain `Animated.View` with `BlurView` as an absolute-fill background, matching the fix already applied to `BottomTabBar`. The pill also gets its shadow on iOS so it is visible against the white list.

Fixes [CW-8031](https://linear.app/chatwoot/issue/CW-8031/the-mobile-app-bulk-actions-menu-is-unusable-in-the-latest-version)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Long pressed a conversation to enter select mode and confirmed the action pill renders at full size, centred above the safe area, with all three actions opening their sheets. Verified on a physical iPhone, a Pixel 4a, and an iPhone 17 simulator on iOS 26.2.

| Before | After |
| --- | --- |
| <img width="300" alt="before" src="https://github.com/user-attachments/assets/df1f494d-762a-4dda-beb4-7bdb1f7ace95" /> | <img width="300" alt="after" src="https://github.com/user-attachments/assets/75b5c6bd-010c-4b85-86d0-b033ca66327a" /> |

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have tested in both Android and iOS platform
- [x] My changes generate no new warnings
