### PR TITLE
fix(sentry): guard three crashes reported on 4.9.1

### DIFF
--- a/src/screens/conversations/components/conversation-actions/UpdateAssignee.tsx
+++ b/src/screens/conversations/components/conversation-actions/UpdateAssignee.tsx
@@ -10,7 +10,10 @@ import { SelfAssign, TickIcon } from '@/svg-icons';
 
 import { assignableAgentActions } from '@/store/assignable-agent/assignableAgentActions';
 import { useAppDispatch, useAppSelector } from '@/hooks';
-import { selectAssignableAgentsByInboxId } from '@/store/assignable-agent/assignableAgentSelectors';
+import {
+  selectAssignableAgents,
+  selectAssignableAgentsByInboxId,
+} from '@/store/assignable-agent/assignableAgentSelectors';
 import {
   selectSelectedIds,
   selectSelectedInboxes,
@@ -117,7 +120,11 @@ export const UpdateAssignee = () => {
     }
   };
 
-  const selfAgent = agents.find(agent => agent.id === userId);
+  // Read from the unfiltered records so the row stays available while searching.
+  const agentRecords = useAppSelector(selectAssignableAgents);
+  const selfAgent = inboxIds
+    .flatMap(id => agentRecords[id] || [])
+    .find(agent => agent.id === userId);
 
   return (
     <React.Fragment>
@@ -131,10 +138,10 @@ export const UpdateAssignee = () => {
           <ActivityIndicator />
         ) : (
           <>
-            {!isSelfAssign && (
+            {!isSelfAssign && selfAgent && (
               <Pressable
                 style={tailwind.style('flex flex-row items-center')}
-                onPress={() => handleAssigneePress(selfAgent as Agent)}>
+                onPress={() => handleAssigneePress(selfAgent)}>
                 <Animated.View style={tailwind.style('p-0.5')}>
                   <Icon icon={<SelfAssign />} size={24} />
                 </Animated.View>

--- a/src/screens/inbox/components/InboxItem.tsx
+++ b/src/screens/inbox/components/InboxItem.tsx
@@ -15,11 +15,11 @@ import { Dimensions } from 'react-native';
 type InboxItemProps = {
   isRead: boolean;
   conversationId: number;
-  sender: {
+  sender?: {
     name: string;
     thumbnail: string;
   };
-  assignee: {
+  assignee?: {
     name: string;
     thumbnail: string;
   };
@@ -62,7 +62,7 @@ export const InboxItemComponent = (props: InboxItemProps) => {
                 'text-base font-inter-medium-24 tracking-[0.24px] text-gray-950 capitalize',
                 `max-w-[${width - 250}px]`,
               )}>
-              {sender.name || ''}
+              {sender?.name || ''}
             </Animated.Text>
             <NativeView style={tailwind.style('flex flex-row items-center gap-0.5')}>
               <Animated.Text style={tailwind.style('text-sm font-inter-420-20 text-gray-700')}>
@@ -93,7 +93,7 @@ export const InboxItemComponent = (props: InboxItemProps) => {
           <Animated.View style={tailwind.style('flex flex-row items-center gap-1.5 flex-1')}>
             {hasAssignee && (
               <Avatar
-                src={assignee.thumbnail ? { uri: assignee.thumbnail } : undefined}
+                src={assignee?.thumbnail ? { uri: assignee.thumbnail } : undefined}
                 size="md"
                 name={assignee?.name || ''}
               />

--- a/src/store/conversation/conversationSelectors.ts
+++ b/src/store/conversation/conversationSelectors.ts
@@ -86,11 +86,15 @@ export const getFilteredConversations = createDraftSafeSelector(
       sortType = 'latest';
     }
 
-    const sortedConversations = conversations.sort(comparator[sortType as keyof SortComparator]);
+    // Ids can outlive their record, so entries without one are dropped before
+    // sorting. The copy keeps the sort off the memoized input array.
+    const sortedConversations = [...conversations]
+      .filter(Boolean)
+      .sort(comparator[sortType as keyof SortComparator]);
 
     if (assigneeType === 'me') {
       return sortedConversations.filter(conversation => {
-        const { assignee } = conversation.meta;
+        const assignee = conversation.meta?.assignee;
 
         const shouldFilter = shouldApplyFilters(conversation, filters);
         const isAssignedToMe = assignee && assignee.id === userId;
@@ -100,7 +104,7 @@ export const getFilteredConversations = createDraftSafeSelector(
     }
     if (assigneeType === 'unassigned') {
       return sortedConversations.filter(conversation => {
-        const isUnAssigned = !conversation.meta.assignee;
+        const isUnAssigned = !conversation.meta?.assignee;
         const shouldFilter = shouldApplyFilters(conversation, filters);
         return isUnAssigned && shouldFilter;
       });

--- a/src/store/conversation/specs/conversationSelectors.spec.ts
+++ b/src/store/conversation/specs/conversationSelectors.spec.ts
@@ -1,0 +1,50 @@
+import type { RootState } from '@/store';
+import type { Conversation } from '@/types';
+import { getFilteredConversations, selectAllConversations } from '../conversationSelectors';
+import { defaultFilterState } from '../conversationFilterSlice';
+import { conversation } from './conversationMockData';
+
+const buildState = (entities: Record<number, Conversation | undefined>) =>
+  ({
+    conversations: {
+      ids: Object.keys(entities).map(Number),
+      entities,
+    },
+  }) as unknown as RootState;
+
+describe('getFilteredConversations', () => {
+  const assignedToMe = { ...conversation, id: 1 };
+  const userId = assignedToMe.meta.assignee.id;
+
+  it('skips ids without a record', () => {
+    const state = buildState({ 1: assignedToMe, 2: undefined });
+
+    expect(getFilteredConversations(state, defaultFilterState, userId)).toEqual([assignedToMe]);
+  });
+
+  it('skips records without meta', () => {
+    const withoutMeta = { ...conversation, id: 3, meta: undefined } as unknown as Conversation;
+    const state = buildState({ 1: assignedToMe, 3: withoutMeta });
+
+    expect(getFilteredConversations(state, defaultFilterState, userId)).toEqual([assignedToMe]);
+  });
+
+  it('treats a record without meta as unassigned', () => {
+    const withoutMeta = { ...conversation, id: 3, meta: undefined } as unknown as Conversation;
+    const state = buildState({ 1: assignedToMe, 3: withoutMeta });
+    const filters = { ...defaultFilterState, assignee_type: 'unassigned' };
+
+    expect(getFilteredConversations(state, filters, userId)).toEqual([withoutMeta]);
+  });
+
+  it('leaves the memoized source array unsorted', () => {
+    const older = { ...conversation, id: 1, lastActivityAt: 1 };
+    const newer = { ...conversation, id: 2, lastActivityAt: 2 };
+    const state = buildState({ 1: older, 2: newer });
+    const source = selectAllConversations(state);
+
+    getFilteredConversations(state, defaultFilterState, userId);
+
+    expect(source.map(({ id }) => id)).toEqual([1, 2]);
+  });
+});


### PR DESCRIPTION
## Description

Guards three null dereferences crashing on 4.9.1:

- `InboxItem` reads `sender.name`, but its container derives sender from `primaryActor?.meta?.sender` ([CHATWOOT-MOBILE-28N](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-28N)).
- `getFilteredConversations` sorts and filters entity records without checking each id resolves to one, and sorts the memoized array in place ([CHATWOOT-MOBILE-2B5](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-2B5)).
- `UpdateAssignee` derives `selfAgent` from the search-filtered agent list and casts it with `as Agent`, so the self-assign row is pressable with no agent behind it whenever the search term does not match the current user's name ([CHATWOOT-MOBILE-R](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-R)).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added `conversationSelectors.spec.ts`; the four cases fail on the old selector and pass on the new one. Full suite green.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
