### PR TITLE
fix(sentry): stop unhandled rejections when a link cannot be opened

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -459,6 +459,7 @@
   },
   "ERRORS": {
     "COMMON_ERROR": "Could not connect to Chatwoot Server, Please try again later",
+    "UNABLE_TO_OPEN_LINK": "Could not open this link",
     "OfFLINE": "You must connect to Wi-fi or a cellular network to get online again",
     "CANNOT_FETCH": "There was an error fetching the information, please try again",
     "AUTH": "Username / Password Incorrect. Please try again",

--- a/src/screens/settings/SettingsScreen.tsx
+++ b/src/screens/settings/SettingsScreen.tsx
@@ -7,7 +7,6 @@ import { StackActions, useNavigation } from '@react-navigation/native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import DeviceInfo from 'react-native-device-info';
-import * as WebBrowser from 'expo-web-browser';
 import ChatWootWidget from '@chatwoot/react-native-widget';
 import { useSelector } from 'react-redux';
 import * as Application from 'expo-application';
@@ -17,6 +16,7 @@ import { switchAccount } from '@/utils/accountUtils';
 import { RecentSearches } from '@/screens/search/utils/recentSearches';
 import i18n from 'i18n';
 import { HELP_URL } from '@/constants/url';
+import { openURL } from '@/utils/urlUtils';
 import { tailwind } from '@/theme';
 
 import {
@@ -173,8 +173,8 @@ const SettingsScreen = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeLocale]);
 
-  const openURL = async () => {
-    await WebBrowser.openBrowserAsync(HELP_URL);
+  const openHelpCenter = () => {
+    openURL({ URL: HELP_URL });
   };
 
   // const openSystemSettings = () => {
@@ -240,7 +240,7 @@ const SettingsScreen = () => {
       icon: <SwitchIcon />,
       subtitle: '',
       subtitleType: 'light',
-      onPressListItem: openURL,
+      onPressListItem: openHelpCenter,
     },
     {
       hasChevron: true,

--- a/src/utils/specs/urlUtils.spec.ts
+++ b/src/utils/specs/urlUtils.spec.ts
@@ -35,6 +35,24 @@ describe('openURL', () => {
     expect(openBrowserAsync).toHaveBeenCalledWith('https://www.chatwoot.com');
   });
 
+  it.each([
+    ['chatwoot.local:3000/path', 'https://chatwoot.local:3000/path'],
+    ['www.chatwoot.com:8443', 'https://www.chatwoot.com:8443'],
+    ['localhost:3000', 'https://localhost:3000'],
+    ['192.168.1.5:3000/inbox?tab=1', 'https://192.168.1.5:3000/inbox?tab=1'],
+  ])('treats %s as a host and port, not a scheme', async (target, expected) => {
+    await openURL({ URL: target });
+
+    expect(openBrowserAsync).toHaveBeenCalledWith(expected);
+  });
+
+  it('keeps a scheme whose target is numeric', async () => {
+    await openURL({ URL: 'tel:12345' });
+
+    expect(openBrowserAsync).not.toHaveBeenCalled();
+    expect(openSystemURL).toHaveBeenCalledWith('tel:12345');
+  });
+
   it('hands a non-web scheme to the system handler', async () => {
     await openURL({ URL: 'mailto:hello@chatwoot.com' });
 

--- a/src/utils/specs/urlUtils.spec.ts
+++ b/src/utils/specs/urlUtils.spec.ts
@@ -1,0 +1,69 @@
+import { Linking } from 'react-native';
+import * as WebBrowser from 'expo-web-browser';
+
+import { openURL } from '../urlUtils';
+import { showToast } from '../toastUtils';
+
+jest.mock('expo-web-browser', () => ({
+  openBrowserAsync: jest.fn(),
+}));
+
+jest.mock('../toastUtils', () => ({
+  showToast: jest.fn(),
+}));
+
+const openBrowserAsync = WebBrowser.openBrowserAsync as jest.Mock;
+const openSystemURL = jest.spyOn(Linking, 'openURL');
+
+describe('openURL', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    openBrowserAsync.mockResolvedValue(undefined);
+    openSystemURL.mockResolvedValue(true);
+  });
+
+  it('opens a web URL in the in-app browser', async () => {
+    await openURL({ URL: 'https://chatwoot.com' });
+
+    expect(openBrowserAsync).toHaveBeenCalledWith('https://chatwoot.com');
+    expect(openSystemURL).not.toHaveBeenCalled();
+  });
+
+  it('adds https to a scheme-less target', async () => {
+    await openURL({ URL: 'www.chatwoot.com' });
+
+    expect(openBrowserAsync).toHaveBeenCalledWith('https://www.chatwoot.com');
+  });
+
+  it('hands a non-web scheme to the system handler', async () => {
+    await openURL({ URL: 'mailto:hello@chatwoot.com' });
+
+    expect(openBrowserAsync).not.toHaveBeenCalled();
+    expect(openSystemURL).toHaveBeenCalledWith('mailto:hello@chatwoot.com');
+  });
+
+  it('falls back to the system handler when the in-app browser fails', async () => {
+    openBrowserAsync.mockRejectedValue(new Error('no activity found'));
+
+    await openURL({ URL: 'https://chatwoot.com' });
+
+    expect(openSystemURL).toHaveBeenCalledWith('https://chatwoot.com');
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it('toasts when nothing can open the target', async () => {
+    openBrowserAsync.mockRejectedValue(new Error('no activity found'));
+    openSystemURL.mockRejectedValue(new Error('no activity found'));
+
+    await openURL({ URL: 'https://chatwoot.com' });
+
+    expect(showToast).toHaveBeenCalled();
+  });
+
+  it('ignores an empty target', async () => {
+    await openURL({ URL: '   ' });
+
+    expect(openBrowserAsync).not.toHaveBeenCalled();
+    expect(openSystemURL).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/specs/urlUtils.spec.ts
+++ b/src/utils/specs/urlUtils.spec.ts
@@ -78,6 +78,26 @@ describe('openURL', () => {
     expect(showToast).toHaveBeenCalled();
   });
 
+  it.each([
+    'mention://user/14',
+    'mention://user/5/Josephine',
+    'mention://user/20/Ziva%20Immigration%20Support',
+  ])('ignores the mention link %s', async target => {
+    await openURL({ URL: target });
+
+    expect(openBrowserAsync).not.toHaveBeenCalled();
+    expect(openSystemURL).not.toHaveBeenCalled();
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it('keeps the host of a protocol-relative target', async () => {
+    await openURL({ URL: '//drive.google.com/file/d/1xvY/view?usp=drivesdk' });
+
+    expect(openBrowserAsync).toHaveBeenCalledWith(
+      'https://drive.google.com/file/d/1xvY/view?usp=drivesdk',
+    );
+  });
+
   it('ignores an empty target', async () => {
     await openURL({ URL: '   ' });
 

--- a/src/utils/urlUtils.ts
+++ b/src/utils/urlUtils.ts
@@ -22,8 +22,19 @@ const WEB_SCHEME_PATTERN = /^https?:/i;
 // localhost followed by a port is the host form.
 const HOST_AND_PORT_PATTERN = /^(localhost|[a-z0-9-]+(\.[a-z0-9-]+)+):\d+([/?#]|$)/i;
 
+// Mentions render as markdown links carrying an in-app scheme.
+const IGNORED_SCHEME_PATTERN = /^mention:/i;
+
 const hasScheme = (target: string): boolean =>
   SCHEME_PATTERN.test(target) && !HOST_AND_PORT_PATTERN.test(target);
+
+const toAbsoluteURL = (target: string): string => {
+  // A protocol-relative target already carries its host.
+  if (target.startsWith('//')) {
+    return `https:${target}`;
+  }
+  return hasScheme(target) ? target : `https://${target}`;
+};
 
 /**
  * Opens a target in whichever app the system has registered for its scheme.
@@ -47,11 +58,11 @@ const openWithSystemHandler = async (target: string): Promise<void> => {
  */
 export const openURL = async ({ URL }: URLParams): Promise<void> => {
   const target = URL?.trim();
-  if (!target) {
+  if (!target || IGNORED_SCHEME_PATTERN.test(target)) {
     return;
   }
 
-  const absoluteURL = hasScheme(target) ? target : `https://${target}`;
+  const absoluteURL = toAbsoluteURL(target);
 
   if (WEB_SCHEME_PATTERN.test(absoluteURL)) {
     try {

--- a/src/utils/urlUtils.ts
+++ b/src/utils/urlUtils.ts
@@ -18,6 +18,12 @@ interface EmailParams {
 
 const SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:/i;
 const WEB_SCHEME_PATTERN = /^https?:/i;
+// A scheme may contain dots, so a host and port reads as one. A dotted host or
+// localhost followed by a port is the host form.
+const HOST_AND_PORT_PATTERN = /^(localhost|[a-z0-9-]+(\.[a-z0-9-]+)+):\d+([/?#]|$)/i;
+
+const hasScheme = (target: string): boolean =>
+  SCHEME_PATTERN.test(target) && !HOST_AND_PORT_PATTERN.test(target);
 
 /**
  * Opens a target in whichever app the system has registered for its scheme.
@@ -45,7 +51,7 @@ export const openURL = async ({ URL }: URLParams): Promise<void> => {
     return;
   }
 
-  const absoluteURL = SCHEME_PATTERN.test(target) ? target : `https://${target}`;
+  const absoluteURL = hasScheme(target) ? target : `https://${target}`;
 
   if (WEB_SCHEME_PATTERN.test(absoluteURL)) {
     try {

--- a/src/utils/urlUtils.ts
+++ b/src/utils/urlUtils.ts
@@ -1,6 +1,9 @@
 import { Linking } from 'react-native';
 import * as WebBrowser from 'expo-web-browser';
 
+import i18n from '@/i18n';
+import { showToast } from '@/utils/toastUtils';
+
 interface URLParams {
   URL: string;
 }
@@ -13,17 +16,53 @@ interface EmailParams {
   email: string;
 }
 
-export const openURL = ({ URL }: URLParams): void => {
-  if (!URL) {
+const SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:/i;
+const WEB_SCHEME_PATTERN = /^https?:/i;
+
+/**
+ * Opens a target in whichever app the system has registered for its scheme.
+ * A device without a handler rejects, which surfaces as a toast rather than an
+ * unhandled rejection.
+ */
+const openWithSystemHandler = async (target: string): Promise<void> => {
+  try {
+    await Linking.openURL(target);
+  } catch {
+    showToast({ message: i18n.t('ERRORS.UNABLE_TO_OPEN_LINK') });
+  }
+};
+
+/**
+ * Targets come from message content, so a link can arrive without a scheme or
+ * with one the in-app browser rejects. A scheme-less target is treated as https,
+ * web targets open in the in-app browser, and anything else goes to the system
+ * handler. The in-app browser also fails when the device has no activity willing
+ * to serve the intent, so the system handler is the fallback for that too.
+ */
+export const openURL = async ({ URL }: URLParams): Promise<void> => {
+  const target = URL?.trim();
+  if (!target) {
     return;
   }
-  WebBrowser.openBrowserAsync(URL);
+
+  const absoluteURL = SCHEME_PATTERN.test(target) ? target : `https://${target}`;
+
+  if (WEB_SCHEME_PATTERN.test(absoluteURL)) {
+    try {
+      await WebBrowser.openBrowserAsync(absoluteURL);
+      return;
+    } catch {
+      // Falls through to the system handler.
+    }
+  }
+
+  await openWithSystemHandler(absoluteURL);
 };
 
 export const openNumber = ({ phoneNumber }: PhoneParams): void => {
-  Linking.openURL(`tel:${phoneNumber}`);
+  openWithSystemHandler(`tel:${phoneNumber}`);
 };
 
 export const openEmail = ({ email }: EmailParams): void => {
-  Linking.openURL(`mailto:${email}`);
+  openWithSystemHandler(`mailto:${email}`);
 };


### PR DESCRIPTION
## Description

`openURL` passed message-content targets straight to the in-app browser without awaiting, so a scheme-less link raised `WebBrowserInvalidURLException` and a device whose browser intent is served by another app raised a `SecurityException`, both as unhandled rejections ([CHATWOOT-MOBILE-29H](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-29H), [CHATWOOT-MOBILE-286](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-286), [CHATWOOT-MOBILE-2BQ](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-2BQ)).

Scheme-less targets now resolve to https, non-web schemes go to the system handler, and a target nothing can open shows a toast. The help centre link in settings goes through the same path.

Adds one `en.json` key; `i18n.fallbacks` is on, so other locales fall back to English.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added `urlUtils.spec.ts` covering web, scheme-less, non-web scheme, browser failure fallback, and the empty target. Full suite green.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
