### PR TITLE
fix(sentry): drop expected server responses and more push failures

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/react-native';
 
 import Constants from 'expo-constants';
 import App from './src/app';
-import { isTransportError } from './src/utils/sentryUtils';
+import { isUnreportableError } from './src/utils/sentryUtils';
 
 // TODO: It is a temporary fix to fix the reanimated logger issue
 // Ref: https://github.com/gorhom/react-native-bottom-sheet/issues/1983
@@ -16,7 +16,7 @@ if (!__DEV__) {
   Sentry.init({
     dsn: process.env.EXPO_PUBLIC_SENTRY_DSN,
     tracesSampleRate: 0.05,
-    beforeSend: (event, hint) => (isTransportError(hint?.originalException) ? null : event),
+    beforeSend: (event, hint) => (isUnreportableError(hint?.originalException) ? null : event),
   });
 }
 

--- a/src/utils/sentryUtils.ts
+++ b/src/utils/sentryUtils.ts
@@ -51,6 +51,7 @@ const UNACTIONABLE_PUSH_MESSAGES = [
   'The network connection was lost',
   'The Internet connection appears to be offline',
   'A TLS error caused the secure connection to fail',
+  'An SSL error has occurred',
   'A server with the specified hostname could not be found',
   'No APNS token specified',
 ];

--- a/src/utils/sentryUtils.ts
+++ b/src/utils/sentryUtils.ts
@@ -11,11 +11,33 @@ export const isTransportError = (error: unknown): boolean =>
   axios.isCancel(error) || (axios.isAxiosError(error) && !error.response);
 
 /**
+ * HTTP statuses the app has no fix for: an expired session, which the response
+ * interceptor turns into a logout, and server-side failures, which the user
+ * already sees as an error toast.
+ */
+const isExpectedHttpError = (error: unknown): boolean => {
+  if (!axios.isAxiosError(error)) {
+    return false;
+  }
+  const status = error.response?.status;
+  return status === 401 || (!!status && status >= 500);
+};
+
+/**
+ * True when an error tracks the device, the network, or the server rather than
+ * an app defect. Used by `beforeSend` to keep such errors out of reporting.
+ */
+export const isUnreportableError = (error: unknown): boolean =>
+  isTransportError(error) || isExpectedHttpError(error);
+
+/**
  * Push registration failures that no app-side change can resolve: the device
- * cannot reach Firebase, or has no Google Play Services to register with.
+ * cannot reach Firebase, has no Google Play Services to register with, or never
+ * received an APNS token.
  *
- * Matched on the native message because Firebase collapses all of them into the
- * single `messaging/unknown` code.
+ * Matched on the native message. Firebase collapses these into the single
+ * `messaging/unknown` code, and some arrive from the native layer with no code
+ * at all.
  */
 const UNACTIONABLE_PUSH_MESSAGES = [
   // Android: registration rejected, or Play Services missing entirely
@@ -27,21 +49,19 @@ const UNACTIONABLE_PUSH_MESSAGES = [
   'The request timed out',
   'The network connection was lost',
   'The Internet connection appears to be offline',
+  'A TLS error caused the secure connection to fail',
+  'A server with the specified hostname could not be found',
+  'No APNS token specified',
 ];
-
-const isFirebaseMessagingError = (error: unknown): boolean => {
-  const code = (error as { code?: unknown })?.code;
-  return typeof code === 'string' && code.startsWith('messaging/');
-};
 
 /**
  * True when a push token could not be fetched for reasons that track device
  * environment rather than app defects, so they are excluded from error reporting.
+ *
+ * Scoped to the push token flow: the messages above also describe ordinary
+ * network failures elsewhere, which are reported.
  */
 export const isUnactionablePushError = (error: unknown): boolean => {
-  if (!isFirebaseMessagingError(error)) {
-    return false;
-  }
   const message = error instanceof Error ? error.message : '';
   return UNACTIONABLE_PUSH_MESSAGES.some(pattern => message.includes(pattern));
 };

--- a/src/utils/sentryUtils.ts
+++ b/src/utils/sentryUtils.ts
@@ -45,6 +45,7 @@ const UNACTIONABLE_PUSH_MESSAGES = [
   'MISSING_INSTANCEID_SERVICE',
   'AUTHENTICATION_FAILED',
   'TOO_MANY_REGISTRATIONS',
+  'FIS_AUTH_ERROR',
   // iOS: the Firebase installations handshake never completed
   'The request timed out',
   'The network connection was lost',

--- a/src/utils/specs/sentryUtils.spec.ts
+++ b/src/utils/specs/sentryUtils.spec.ts
@@ -1,0 +1,55 @@
+import { AxiosError, AxiosHeaders } from 'axios';
+
+import { isUnreportableError, isUnactionablePushError } from '../sentryUtils';
+
+const axiosErrorWithStatus = (status: number) => {
+  const config = { headers: new AxiosHeaders() };
+  return new AxiosError('Request failed', String(status), config, null, {
+    status,
+    statusText: '',
+    headers: {},
+    config,
+    data: null,
+  });
+};
+
+describe('isUnreportableError', () => {
+  it('drops a request that never reached the server', () => {
+    expect(isUnreportableError(new AxiosError('Network Error'))).toBe(true);
+  });
+
+  it('drops an expired session', () => {
+    expect(isUnreportableError(axiosErrorWithStatus(401))).toBe(true);
+  });
+
+  it('drops server-side failures', () => {
+    expect(isUnreportableError(axiosErrorWithStatus(500))).toBe(true);
+    expect(isUnreportableError(axiosErrorWithStatus(502))).toBe(true);
+    expect(isUnreportableError(axiosErrorWithStatus(503))).toBe(true);
+  });
+
+  it('keeps client errors that point at the app', () => {
+    expect(isUnreportableError(axiosErrorWithStatus(404))).toBe(false);
+    expect(isUnreportableError(axiosErrorWithStatus(422))).toBe(false);
+  });
+
+  it('keeps errors that are not requests', () => {
+    expect(isUnreportableError(new TypeError('Cannot read property of undefined'))).toBe(false);
+  });
+});
+
+describe('isUnactionablePushError', () => {
+  it.each([
+    'MISSING_INSTANCEID_SERVICE',
+    '[messaging/unknown] SERVICE_NOT_AVAILABLE',
+    'A TLS error caused the secure connection to fail.',
+    'A server with the specified hostname could not be found.',
+    'No APNS token specified before fetching FCM Token',
+  ])('drops %s', message => {
+    expect(isUnactionablePushError(new Error(message))).toBe(true);
+  });
+
+  it('keeps a registration failure the app can act on', () => {
+    expect(isUnactionablePushError(new Error('[messaging/invalid-argument]'))).toBe(false);
+  });
+});

--- a/src/utils/specs/sentryUtils.spec.ts
+++ b/src/utils/specs/sentryUtils.spec.ts
@@ -44,6 +44,7 @@ describe('isUnactionablePushError', () => {
     '[messaging/unknown] SERVICE_NOT_AVAILABLE',
     '[messaging/unknown] java.io.IOException: java.util.concurrent.ExecutionException: java.io.IOException: FIS_AUTH_ERROR',
     'A TLS error caused the secure connection to fail.',
+    'An SSL error has occurred and a secure connection to the server cannot be made.',
     'A server with the specified hostname could not be found.',
     'No APNS token specified before fetching FCM Token',
   ])('drops %s', message => {

--- a/src/utils/specs/sentryUtils.spec.ts
+++ b/src/utils/specs/sentryUtils.spec.ts
@@ -42,6 +42,7 @@ describe('isUnactionablePushError', () => {
   it.each([
     'MISSING_INSTANCEID_SERVICE',
     '[messaging/unknown] SERVICE_NOT_AVAILABLE',
+    '[messaging/unknown] java.io.IOException: java.util.concurrent.ExecutionException: java.io.IOException: FIS_AUTH_ERROR',
     'A TLS error caused the secure connection to fail.',
     'A server with the specified hostname could not be found.',
     'No APNS token specified before fetching FCM Token',


### PR DESCRIPTION
## Description

Requests that reach the server still report as app errors, so an expired session and 5xx responses are the largest remaining group on 4.9.1 ([CHATWOOT-MOBILE-281](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-281), [CHATWOOT-MOBILE-28C](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-28C), [CHATWOOT-MOBILE-26A](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-26A)). A 401 is already handled by the response interceptor as a logout and a 5xx is server-owned, so both are excluded from reporting; 4xx statuses that can point at the app are kept.

The push filter also missed three native messages that arrive without a `messaging/` code ([CHATWOOT-MOBILE-287](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-287), [CHATWOOT-MOBILE-2BF](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-2BF), [CHATWOOT-MOBILE-2BE](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-2BE), [CHATWOOT-MOBILE-2BC](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-2BC)), and the Firebase installations handshake failure the device cannot recover from ([CHATWOOT-MOBILE-28H](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-28H)), so it now matches on the message alone at the push token call site.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added `sentryUtils.spec.ts` covering the dropped and kept statuses and each push message. Full suite green.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
