### PR TITLE
fix(sentry): build the websocket URL from the normalized host

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -13,6 +13,7 @@ import {
 import { appReducer } from '@/store/reducers';
 import { setStore } from './storeAccessor';
 import { contactListenerMiddleware } from './contact/contactListener';
+import { repairPersistedWebSocketUrl } from './settings/settingsUtils';
 
 // Disable this in testing environment
 const shouldLoadDebugger = __DEV__ && !process.env.JEST_WORKER_ID;
@@ -34,7 +35,7 @@ const persistConfig = {
         ...initialState,
       };
     }
-    return state;
+    return repairPersistedWebSocketUrl(state);
   },
 };
 

--- a/src/store/settings/settingsActions.ts
+++ b/src/store/settings/settingsActions.ts
@@ -22,7 +22,7 @@ import type {
 } from './settingsTypes';
 import I18n from '@/i18n';
 import { URL_TYPE } from '@/constants/url';
-import { checkValidUrl, extractDomain, handleApiError } from './settingsUtils';
+import { checkValidUrl, extractDomain, handleApiError, buildWebSocketUrl } from './settingsUtils';
 import { showToast } from '@/utils/toastUtils';
 import { isUnactionablePushError } from '@/utils/sentryUtils';
 
@@ -47,7 +47,7 @@ export const settingsActions = {
       try {
         const installationUrl = extractDomain({ url });
         const INSTALLATION_URL = `${URL_TYPE}${installationUrl}/`;
-        const WEB_SOCKET_URL = `wss://${installationUrl}/cable`;
+        const WEB_SOCKET_URL = buildWebSocketUrl(installationUrl);
 
         if (!checkValidUrl({ url: INSTALLATION_URL })) {
           throw new Error(I18n.t('CONFIGURE_URL.ERROR'));

--- a/src/store/settings/settingsActions.ts
+++ b/src/store/settings/settingsActions.ts
@@ -45,13 +45,14 @@ export const settingsActions = {
     'settings/setInstallationUrl',
     async (url, { rejectWithValue }) => {
       try {
-        if (!checkValidUrl({ url })) {
+        const installationUrl = extractDomain({ url });
+        const INSTALLATION_URL = `${URL_TYPE}${installationUrl}/`;
+        const WEB_SOCKET_URL = `wss://${installationUrl}/cable`;
+
+        if (!checkValidUrl({ url: INSTALLATION_URL })) {
           throw new Error(I18n.t('CONFIGURE_URL.ERROR'));
         }
 
-        const installationUrl = extractDomain({ url });
-        const INSTALLATION_URL = `${URL_TYPE}${installationUrl}/`;
-        const WEB_SOCKET_URL = `wss://${url}/cable`;
         const isValid = await SettingsService.verifyInstallationUrl(INSTALLATION_URL);
 
         if (!isValid) {

--- a/src/store/settings/settingsUtils.ts
+++ b/src/store/settings/settingsUtils.ts
@@ -1,5 +1,6 @@
 import { showToast } from '@/utils/toastUtils';
 import I18n from '@/i18n';
+import { URL_TYPE } from '@/constants/url';
 
 export const handleApiError = (error: unknown, customErrorMsg?: string) => {
   const errorMessage = error instanceof Error ? error.message : I18n.t('CONFIGURE_URL.ERROR');
@@ -7,23 +8,54 @@ export const handleApiError = (error: unknown, customErrorMsg?: string) => {
   return errorMessage;
 };
 
+const SCHEME = /^[a-z][a-z0-9+.-]*:\/\//i;
+
 /**
- * The host of a Chatwoot installation. The field accepts a bare host, and a
- * keyboard or a paste can add surrounding whitespace, so the input is trimmed
- * before any scheme is stripped.
+ * The host of a Chatwoot installation, including a port when one is given.
+ *
+ * The field takes a bare host, but a paste can carry a scheme, a path, a
+ * trailing slash or surrounding whitespace. Parsing as a URL normalizes all of
+ * them; input without a scheme gets one so it parses as a host rather than a
+ * path. Input carrying a scheme it cannot be parsed with holds no host and
+ * resolves to an empty string; anything else is returned trimmed, for
+ * `checkValidUrl` to reject.
  */
 export const extractDomain = ({ url }: { url: string }) => {
   const trimmedUrl = url.trim();
-  const domain = trimmedUrl.match(/:\/\/(www[0-9]?\.)?(.[^/:]+)/i);
-  if (
-    domain != null &&
-    domain.length > 2 &&
-    typeof domain[2] === 'string' &&
-    domain[2].length > 0
-  ) {
-    return domain[2];
+  const hasScheme = SCHEME.test(trimmedUrl);
+
+  try {
+    const { host } = new URL(hasScheme ? trimmedUrl : `${URL_TYPE}${trimmedUrl}`);
+    return host;
+  } catch {
+    return hasScheme ? '' : trimmedUrl;
   }
-  return trimmedUrl;
+};
+
+/**
+ * The Action Cable endpoint for a host. Always derived from the extracted host,
+ * since a scheme left in the value produces an endpoint that never connects.
+ */
+export const buildWebSocketUrl = (host: string) => `wss://${host}/cable`;
+
+/**
+ * Replaces a persisted websocket URL that disagrees with the stored host, which
+ * cannot connect. `settings` survives logout, so such a value would otherwise
+ * persist for the lifetime of the install.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const repairPersistedWebSocketUrl = (state: any) => {
+  const { baseUrl, webSocketUrl } = state?.settings ?? {};
+  if (!baseUrl) {
+    return state;
+  }
+
+  const expectedUrl = buildWebSocketUrl(baseUrl);
+  if (webSocketUrl === expectedUrl) {
+    return state;
+  }
+
+  return { ...state, settings: { ...state.settings, webSocketUrl: expectedUrl } };
 };
 
 /**

--- a/src/store/settings/settingsUtils.ts
+++ b/src/store/settings/settingsUtils.ts
@@ -24,6 +24,13 @@ export const extractDomain = ({ url }: { url: string }) => {
   const trimmedUrl = url.trim();
   const hasScheme = SCHEME.test(trimmedUrl);
 
+  // The URL parser strips tabs and line breaks out of its input, which joins the
+  // text around them into a host that was never entered. Such a value is returned
+  // unparsed, for `checkValidUrl` to reject.
+  if (/\s/.test(trimmedUrl)) {
+    return trimmedUrl;
+  }
+
   try {
     const { host } = new URL(hasScheme ? trimmedUrl : `${URL_TYPE}${trimmedUrl}`);
     return host;

--- a/src/store/settings/settingsUtils.ts
+++ b/src/store/settings/settingsUtils.ts
@@ -7,13 +7,14 @@ export const handleApiError = (error: unknown, customErrorMsg?: string) => {
   return errorMessage;
 };
 
+/**
+ * The host of a Chatwoot installation. The field accepts a bare host, and a
+ * keyboard or a paste can add surrounding whitespace, so the input is trimmed
+ * before any scheme is stripped.
+ */
 export const extractDomain = ({ url }: { url: string }) => {
-  const isValidUrl = checkValidUrl({ url });
-
-  if (!isValidUrl) {
-    return url;
-  }
-  const domain = url.match(/:\/\/(www[0-9]?\.)?(.[^/:]+)/i);
+  const trimmedUrl = url.trim();
+  const domain = trimmedUrl.match(/:\/\/(www[0-9]?\.)?(.[^/:]+)/i);
   if (
     domain != null &&
     domain.length > 2 &&
@@ -22,13 +23,20 @@ export const extractDomain = ({ url }: { url: string }) => {
   ) {
     return domain[2];
   }
-  return url;
+  return trimmedUrl;
 };
 
-export const checkValidUrl = ({ url }: { url: string }) => {
+/**
+ * Takes an absolute URL. Whitespace is rejected on its own, since the URL
+ * constructor accepts more than the platform's networking stack does.
+ */
+export const checkValidUrl = ({ url }: { url: string }): boolean => {
+  if (!url || /\s/.test(url)) {
+    return false;
+  }
   try {
     return Boolean(new URL(url));
-  } catch (e) {
-    return e;
+  } catch {
+    return false;
   }
 };

--- a/src/store/settings/specs/settingsActions.spec.ts
+++ b/src/store/settings/specs/settingsActions.spec.ts
@@ -1,0 +1,79 @@
+import { settingsActions } from '../settingsActions';
+import { SettingsService } from '../settingsService';
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+
+jest.mock('@react-native-firebase/messaging', () => jest.fn());
+
+jest.mock('react-native-device-info', () => ({
+  getSystemName: jest.fn(),
+  getManufacturer: jest.fn(),
+  getModel: jest.fn(),
+  getApiLevel: jest.fn(),
+  getBrand: jest.fn(),
+  getBuildNumber: jest.fn(),
+  getUniqueId: jest.fn(),
+}));
+
+jest.mock('@/i18n', () => ({
+  t: (key: string) => key,
+}));
+
+jest.mock('@/utils/toastUtils', () => ({
+  showToast: jest.fn(),
+}));
+
+jest.mock('../settingsService', () => ({
+  SettingsService: {
+    verifyInstallationUrl: jest.fn(),
+  },
+}));
+
+const setInstallationUrl = (url: string) =>
+  settingsActions.setInstallationUrl(url)(jest.fn(), () => ({}), undefined);
+
+describe('setInstallationUrl', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (SettingsService.verifyInstallationUrl as jest.Mock).mockResolvedValue(true);
+  });
+
+  it('builds both URLs from the host', async () => {
+    const action = await setInstallationUrl('app.chatwoot.com');
+
+    expect(action.payload).toEqual({
+      installationUrl: 'https://app.chatwoot.com/',
+      webSocketUrl: 'wss://app.chatwoot.com/cable',
+      baseUrl: 'app.chatwoot.com',
+    });
+  });
+
+  it('keeps a pasted scheme out of the websocket URL', async () => {
+    const action = await setInstallationUrl('https://app.chatwoot.com');
+
+    expect(action.payload).toEqual({
+      installationUrl: 'https://app.chatwoot.com/',
+      webSocketUrl: 'wss://app.chatwoot.com/cable',
+      baseUrl: 'app.chatwoot.com',
+    });
+  });
+
+  it('keeps surrounding whitespace out of the websocket URL', async () => {
+    const action = await setInstallationUrl('   https://app.chatwoot.com');
+
+    expect(action.payload).toEqual({
+      installationUrl: 'https://app.chatwoot.com/',
+      webSocketUrl: 'wss://app.chatwoot.com/cable',
+      baseUrl: 'app.chatwoot.com',
+    });
+  });
+
+  it('rejects a host holding whitespace without calling the server', async () => {
+    const action = await setInstallationUrl('app chatwoot.com');
+
+    expect(action.type).toBe('settings/setInstallationUrl/rejected');
+    expect(SettingsService.verifyInstallationUrl).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/settings/specs/settingsUtils.spec.ts
+++ b/src/store/settings/specs/settingsUtils.spec.ts
@@ -52,6 +52,18 @@ describe('extractDomain', () => {
   it('returns unparseable input for the validator to reject', () => {
     expect(extractDomain({ url: 'app chatwoot com' })).toBe('app chatwoot com');
   });
+
+  it.each([
+    ['trusted.example\n.evil.example'],
+    ['trusted.example\t.evil.example'],
+    ['trusted.example\r.evil.example'],
+    ['https://trusted.example\n.evil.example'],
+  ])('does not join %j around its whitespace into another host', url => {
+    const host = extractDomain({ url });
+
+    expect(host).toBe(url.trim());
+    expect(checkValidUrl({ url: `https://${host}/` })).toBe(false);
+  });
 });
 
 describe('buildWebSocketUrl', () => {

--- a/src/store/settings/specs/settingsUtils.spec.ts
+++ b/src/store/settings/specs/settingsUtils.spec.ts
@@ -1,0 +1,38 @@
+import { checkValidUrl, extractDomain } from '../settingsUtils';
+
+describe('extractDomain', () => {
+  it.each([
+    ['app.chatwoot.com', 'app.chatwoot.com'],
+    ['https://app.chatwoot.com', 'app.chatwoot.com'],
+    ['https://app.chatwoot.com/', 'app.chatwoot.com'],
+    ['https://www.chatwoot.com', 'chatwoot.com'],
+  ])('reads the host of %s', (url, expected) => {
+    expect(extractDomain({ url })).toBe(expected);
+  });
+
+  it.each([
+    ['   https://app.chatwoot.com', 'app.chatwoot.com'],
+    ['  app.chatwoot.com  ', 'app.chatwoot.com'],
+    ['https://app.chatwoot.com\n', 'app.chatwoot.com'],
+  ])('drops the whitespace around %j', (url, expected) => {
+    expect(extractDomain({ url })).toBe(expected);
+  });
+});
+
+describe('checkValidUrl', () => {
+  it('accepts an absolute URL', () => {
+    expect(checkValidUrl({ url: 'https://app.chatwoot.com/' })).toBe(true);
+  });
+
+  it('rejects a URL holding whitespace', () => {
+    expect(checkValidUrl({ url: 'https://   https://app.chatwoot.com/' })).toBe(false);
+  });
+
+  it('rejects an unparseable URL', () => {
+    expect(checkValidUrl({ url: 'app.chatwoot.com' })).toBe(false);
+  });
+
+  it('rejects an empty URL', () => {
+    expect(checkValidUrl({ url: '' })).toBe(false);
+  });
+});

--- a/src/store/settings/specs/settingsUtils.spec.ts
+++ b/src/store/settings/specs/settingsUtils.spec.ts
@@ -1,13 +1,40 @@
-import { checkValidUrl, extractDomain } from '../settingsUtils';
+import {
+  buildWebSocketUrl,
+  checkValidUrl,
+  extractDomain,
+  repairPersistedWebSocketUrl,
+} from '../settingsUtils';
 
 describe('extractDomain', () => {
   it.each([
     ['app.chatwoot.com', 'app.chatwoot.com'],
     ['https://app.chatwoot.com', 'app.chatwoot.com'],
-    ['https://app.chatwoot.com/', 'app.chatwoot.com'],
-    ['https://www.chatwoot.com', 'chatwoot.com'],
+    ['http://app.chatwoot.com', 'app.chatwoot.com'],
+    ['HTTPS://App.Chatwoot.COM', 'app.chatwoot.com'],
   ])('reads the host of %s', (url, expected) => {
     expect(extractDomain({ url })).toBe(expected);
+  });
+
+  it.each([
+    ['https://app.chatwoot.com/', 'app.chatwoot.com'],
+    ['app.chatwoot.com/', 'app.chatwoot.com'],
+    ['https://app.chatwoot.com/app/accounts/1', 'app.chatwoot.com'],
+    ['app.chatwoot.com/app/accounts/1', 'app.chatwoot.com'],
+    ['https://app.chatwoot.com/#/app', 'app.chatwoot.com'],
+  ])('drops the path of %s', (url, expected) => {
+    expect(extractDomain({ url })).toBe(expected);
+  });
+
+  it.each([
+    ['https://chatwoot.example.com:3000', 'chatwoot.example.com:3000'],
+    ['chatwoot.example.com:3000', 'chatwoot.example.com:3000'],
+    ['https://chatwoot.example.com:3000/', 'chatwoot.example.com:3000'],
+  ])('keeps the port of %s', (url, expected) => {
+    expect(extractDomain({ url })).toBe(expected);
+  });
+
+  it('keeps a www host, which is a different host from the bare domain', () => {
+    expect(extractDomain({ url: 'https://www.chatwoot.com' })).toBe('www.chatwoot.com');
   });
 
   it.each([
@@ -16,6 +43,62 @@ describe('extractDomain', () => {
     ['https://app.chatwoot.com\n', 'app.chatwoot.com'],
   ])('drops the whitespace around %j', (url, expected) => {
     expect(extractDomain({ url })).toBe(expected);
+  });
+
+  it.each([['https://'], ['https:// ']])('holds no host for the scheme %j alone', url => {
+    expect(extractDomain({ url })).toBe('');
+  });
+
+  it('returns unparseable input for the validator to reject', () => {
+    expect(extractDomain({ url: 'app chatwoot com' })).toBe('app chatwoot com');
+  });
+});
+
+describe('buildWebSocketUrl', () => {
+  it.each([
+    ['app.chatwoot.com', 'wss://app.chatwoot.com/cable'],
+    ['chatwoot.example.com:3000', 'wss://chatwoot.example.com:3000/cable'],
+  ])('builds the cable endpoint for %s', (host, expected) => {
+    expect(buildWebSocketUrl(host)).toBe(expected);
+  });
+});
+
+describe('repairPersistedWebSocketUrl', () => {
+  const stateWith = (settings: Record<string, string>) => ({ settings, auth: { user: 1 } });
+
+  it('rebuilds a websocket URL that kept the scheme of the configured value', () => {
+    const state = stateWith({
+      baseUrl: 'app.chatwoot.com',
+      installationUrl: 'https://app.chatwoot.com/',
+      webSocketUrl: 'wss://https://app.chatwoot.com/cable',
+    });
+
+    expect(repairPersistedWebSocketUrl(state).settings).toEqual({
+      baseUrl: 'app.chatwoot.com',
+      installationUrl: 'https://app.chatwoot.com/',
+      webSocketUrl: 'wss://app.chatwoot.com/cable',
+    });
+  });
+
+  it('leaves the rest of the persisted state untouched', () => {
+    const state = stateWith({ baseUrl: 'app.chatwoot.com', webSocketUrl: 'wss://stale/cable' });
+
+    expect(repairPersistedWebSocketUrl(state).auth).toEqual(state.auth);
+  });
+
+  it('returns the same state when the websocket URL already matches the host', () => {
+    const state = stateWith({
+      baseUrl: 'app.chatwoot.com',
+      webSocketUrl: 'wss://app.chatwoot.com/cable',
+    });
+
+    expect(repairPersistedWebSocketUrl(state)).toBe(state);
+  });
+
+  it('returns the same state when no host has been configured', () => {
+    const state = stateWith({ baseUrl: '', webSocketUrl: '' });
+
+    expect(repairPersistedWebSocketUrl(state)).toBe(state);
   });
 });
 


### PR DESCRIPTION
## Description

`setInstallationUrl` derived the REST URL from the extracted host, but the websocket URL from the raw field input:

```ts
const installationUrl = extractDomain({ url });
const INSTALLATION_URL = `${URL_TYPE}${installationUrl}/`;
const WEB_SOCKET_URL = `wss://${url}/cable`;
```

A host entered with its scheme produced `wss://https://host/cable`. REST calls kept working while Action Cable never connected, so an open conversation showed no incoming messages until the agent left and reopened it — reported on both platforms against self-hosted installations in #1114 / [PLA-186](https://linear.app/chatwoot/issue/PLA-186), where the URL was entered as `https://<host>`. A host entered with leading whitespace produced `wss://   https://host/cable`, which OkHttp rejects with an uncaught `IllegalArgumentException` on Android ([CHATWOOT-MOBILE-1P1](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-1P1), fatal).

Both URLs now come from the extracted host.

`extractDomain` located the host with a regex anchored on `://`, so it only normalized input that carried a scheme. It now parses the value as a URL, prefixing the configured scheme when the input omits one. That also drops paths, trailing slashes and fragments from a bare host, keeps a port, and no longer strips a `www.` prefix — which addressed a different host from the one entered. Input that carries a scheme it cannot be parsed with holds no host, and is rejected rather than passed through.

`checkValidUrl` returned the caught error instead of `false`, so the guard never rejected anything. It returns a boolean, runs against the absolute URL rather than the bare host, and rejects whitespace on its own, since the URL constructor accepts more than the networking stack does.

`settings` is persisted and is preserved across logout, so a websocket URL already stored in the broken form would outlive this fix. It is rebuilt from the stored host on rehydrate, so affected installations recover on update without reconfiguring the URL.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`pnpm test` — 48 suites, 304 tests green.

`settingsUtils.spec.ts` and `settingsActions.spec.ts` cover a bare host, a host with its scheme, surrounding and interior whitespace, paths, trailing slashes, fragments, ports, `www` hosts, scheme-only input, and the rehydrate repair.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

Closes #1114
