### PR TITLE
fix(sentry): render and copy non-string attribute values

### DIFF
--- a/src/components-next/list-components/AttributeList.tsx
+++ b/src/components-next/list-components/AttributeList.tsx
@@ -9,6 +9,7 @@ import { tailwind } from '@/theme';
 import { AttributeListType } from '@/types';
 import { Icon } from '@/components-next/common';
 import { showToast } from '@/utils/toastUtils';
+import { formatAttributeValue } from '@/utils/attributeUtils';
 
 type AttributeItemProps = {
   listItem: AttributeListType;
@@ -41,7 +42,7 @@ const AttributeItem = (props: AttributeItemProps) => {
     if (listItem.type === 'checkbox') {
       return listItem.subtitle ? 'Yes' : 'No';
     }
-    return listItem.subtitle;
+    return formatAttributeValue(listItem.subtitle);
   }, [listItem.type, listItem.subtitle, formattedDate]);
 
   return (

--- a/src/utils/attributeUtils.ts
+++ b/src/utils/attributeUtils.ts
@@ -1,0 +1,21 @@
+/**
+ * Custom attribute values arrive from the API as arbitrary JSON, so a value
+ * reaching the attribute list can be a number, a boolean, or an object. Text
+ * rendering and the clipboard both take a string.
+ */
+export const formatAttributeValue = (value: unknown): string => {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return '';
+    }
+  }
+  return String(value);
+};

--- a/src/utils/specs/attributeUtils.spec.ts
+++ b/src/utils/specs/attributeUtils.spec.ts
@@ -1,0 +1,35 @@
+import { formatAttributeValue } from '../attributeUtils';
+
+describe('formatAttributeValue', () => {
+  it('passes a string through', () => {
+    expect(formatAttributeValue('Premium')).toBe('Premium');
+  });
+
+  it.each([
+    [39.99, '39.99'],
+    [762781672, '762781672'],
+    [0, '0'],
+    [true, 'true'],
+  ])('renders %p as text', (value, expected) => {
+    expect(formatAttributeValue(value)).toBe(expected);
+  });
+
+  it('renders an object as JSON', () => {
+    expect(formatAttributeValue({ menu: 1, opciones: 2 })).toBe('{"menu":1,"opciones":2}');
+  });
+
+  it('renders an array as JSON', () => {
+    expect(formatAttributeValue(['a', 'b'])).toBe('["a","b"]');
+  });
+
+  it('returns an empty string for a circular object', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(formatAttributeValue(circular)).toBe('');
+  });
+
+  it.each([[null], [undefined]])('returns an empty string for %p', value => {
+    expect(formatAttributeValue(value)).toBe('');
+  });
+});


### PR DESCRIPTION
## Description

Custom attribute values arrive from the API as arbitrary JSON, and `ConversationMetaInformation` casts them into `AttributeListType`, whose `subtitle` is declared as a string:

```ts
list={allAttributes as AttributeListType[]}
```

`AttributeList` renders that value in a `Text` and copies it to the clipboard, so a value that is not a string breaks both:

- An object value threw `Objects are not valid as a React child`, taking down the conversation actions screen ([CHATWOOT-MOBILE-29V](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-29V), [CHATWOOT-MOBILE-2BW](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-2BW)).
- A number value threw inside `Clipboard.setString`'s host function, and the surrounding `try/catch` swallowed it, so the copy silently did nothing ([CHATWOOT-MOBILE-2A5](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-2A5)).

Both paths read the same memo, which now formats the value for display: strings pass through, objects render as JSON, and everything else is coerced.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added `attributeUtils.spec.ts` covering strings, numbers, booleans, objects, arrays, a circular object, and empty values. Full suite green.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
