### PR TITLE
fix(sentry): guard missing attachment sources and typing names

### DIFF
--- a/src/screens/chat-screen/components/message-components/MessageAttachments.tsx
+++ b/src/screens/chat-screen/components/message-components/MessageAttachments.tsx
@@ -70,6 +70,10 @@ export const MessageAttachments = (props: MessageAttachmentsProps) => {
         );
       }
 
+      if (!attachment.dataUrl) {
+        return null;
+      }
+
       return (
         <Animated.View key={key} style={tailwind.style(mediaItemStyle)}>
           {isThumbnail ? (
@@ -79,6 +83,10 @@ export const MessageAttachments = (props: MessageAttachmentsProps) => {
           )}
         </Animated.View>
       );
+    }
+
+    if (!attachment.dataUrl) {
+      return null;
     }
 
     return (

--- a/src/screens/chat-screen/components/message-components/MessageAttachments.tsx
+++ b/src/screens/chat-screen/components/message-components/MessageAttachments.tsx
@@ -7,6 +7,7 @@ import { tailwind } from '@/theme';
 import { ImageMetadata, Message } from '@/types';
 import { Icon } from '@/components-next';
 import { ATTACHMENT_TYPES, ORIENTATION, TEXT_MAX_WIDTH } from '@/constants';
+import { groupAttachmentsByType } from '@/utils/attachmentUtils';
 import i18n from '@/i18n';
 
 import { ImageBubbleContainer, ImageThumbnail } from './ImageBubble';
@@ -30,24 +31,6 @@ const isInstagramStoryExpired = (messageTimestamp: number) => {
   return differenceInHours(currentTime, messageTime) > 24;
 };
 
-// Attachments render grouped by type rather than in payload order: media, then audio,
-// then files.
-const MEDIA_TYPES = [ATTACHMENT_TYPES.IMAGE, ATTACHMENT_TYPES.VIDEO, ATTACHMENT_TYPES.IG_REEL];
-
-const groupByType = (attachments: ImageMetadata[]) => {
-  const ofType = (...types: string[]) =>
-    attachments.filter(attachment => types.includes(attachment.fileType));
-
-  return {
-    media: ofType(...MEDIA_TYPES).sort(
-      (a, b) => MEDIA_TYPES.indexOf(a.fileType) - MEDIA_TYPES.indexOf(b.fileType),
-    ),
-    recordings: ofType(ATTACHMENT_TYPES.AUDIO),
-    files: ofType(ATTACHMENT_TYPES.FILE),
-    locations: ofType(ATTACHMENT_TYPES.LOCATION),
-  };
-};
-
 export const MessageAttachments = (props: MessageAttachmentsProps) => {
   const { item, variant, orientation = ORIENTATION.LEFT, mediaSize = 'default' } = props;
   const { attachments, private: isPrivate, contentAttributes, createdAt } = item;
@@ -62,7 +45,7 @@ export const MessageAttachments = (props: MessageAttachmentsProps) => {
   // Rows stay stretched so percentage-width media resolves against the bubble; the
   // contents are aligned inside each row instead.
   const rowAlignment = orientation === ORIENTATION.RIGHT ? 'justify-end' : 'justify-start';
-  const { media, recordings, files, locations } = groupByType(attachments);
+  const { media, recordings, files, locations } = groupAttachmentsByType(attachments);
 
   // Thumbnails sit side by side and wrap; full-width media stacks.
   const mediaItemStyle = isThumbnail ? '' : `flex flex-row my-2 ${rowAlignment}`;

--- a/src/utils/attachmentUtils.ts
+++ b/src/utils/attachmentUtils.ts
@@ -1,0 +1,30 @@
+import { ATTACHMENT_TYPES } from '@/constants';
+import { ImageMetadata } from '@/types';
+
+// Attachments render grouped by type rather than in payload order: media, then
+// audio, then files.
+const VISUAL_MEDIA_TYPES = [
+  ATTACHMENT_TYPES.IMAGE,
+  ATTACHMENT_TYPES.VIDEO,
+  ATTACHMENT_TYPES.IG_REEL,
+];
+
+// Media, audio and file bubbles hand the source to a native viewer, player or
+// file path, so an attachment without one cannot render. Locations carry
+// coordinates instead of a source.
+const withSource = (attachments: ImageMetadata[]) =>
+  attachments.filter(attachment => attachment.dataUrl);
+
+export const groupAttachmentsByType = (attachments: ImageMetadata[]) => {
+  const ofType = (...types: string[]) =>
+    attachments.filter(attachment => types.includes(attachment.fileType));
+
+  return {
+    media: withSource(ofType(...VISUAL_MEDIA_TYPES)).sort(
+      (a, b) => VISUAL_MEDIA_TYPES.indexOf(a.fileType) - VISUAL_MEDIA_TYPES.indexOf(b.fileType),
+    ),
+    recordings: withSource(ofType(ATTACHMENT_TYPES.AUDIO)),
+    files: withSource(ofType(ATTACHMENT_TYPES.FILE)),
+    locations: ofType(ATTACHMENT_TYPES.LOCATION),
+  };
+};

--- a/src/utils/attachmentUtils.ts
+++ b/src/utils/attachmentUtils.ts
@@ -9,22 +9,21 @@ const VISUAL_MEDIA_TYPES = [
   ATTACHMENT_TYPES.IG_REEL,
 ];
 
-// Media, audio and file bubbles hand the source to a native viewer, player or
-// file path, so an attachment without one cannot render. Locations carry
+// Audio and file bubbles hand the source to a native player or file path, so an
+// attachment without one cannot render. Media is filtered where it is rendered,
+// since an expired story shows a placeholder that needs no source. Locations carry
 // coordinates instead of a source.
-const withSource = (attachments: ImageMetadata[]) =>
-  attachments.filter(attachment => attachment.dataUrl);
 
 export const groupAttachmentsByType = (attachments: ImageMetadata[]) => {
   const ofType = (...types: string[]) =>
     attachments.filter(attachment => types.includes(attachment.fileType));
 
   return {
-    media: withSource(ofType(...VISUAL_MEDIA_TYPES)).sort(
+    media: ofType(...VISUAL_MEDIA_TYPES).sort(
       (a, b) => VISUAL_MEDIA_TYPES.indexOf(a.fileType) - VISUAL_MEDIA_TYPES.indexOf(b.fileType),
     ),
-    recordings: withSource(ofType(ATTACHMENT_TYPES.AUDIO)),
-    files: withSource(ofType(ATTACHMENT_TYPES.FILE)),
+    recordings: ofType(ATTACHMENT_TYPES.AUDIO).filter(({ dataUrl }) => dataUrl),
+    files: ofType(ATTACHMENT_TYPES.FILE).filter(({ dataUrl }) => dataUrl),
     locations: ofType(ATTACHMENT_TYPES.LOCATION),
   };
 };

--- a/src/utils/specs/attachmentUtils.spec.ts
+++ b/src/utils/specs/attachmentUtils.spec.ts
@@ -1,0 +1,41 @@
+import { ATTACHMENT_TYPES } from '@/constants';
+import type { ImageMetadata } from '@/types';
+import { groupAttachmentsByType } from '../attachmentUtils';
+
+const attachment = (fileType: string, dataUrl: string | null, id: number) =>
+  ({ fileType, dataUrl, id }) as unknown as ImageMetadata;
+
+describe('groupAttachmentsByType', () => {
+  it('drops media without a source', () => {
+    const withSource = attachment(ATTACHMENT_TYPES.IMAGE, 'https://cdn/1.png', 1);
+    const grouped = groupAttachmentsByType([
+      withSource,
+      attachment(ATTACHMENT_TYPES.IMAGE, null, 2),
+    ]);
+
+    expect(grouped.media).toEqual([withSource]);
+  });
+
+  it('drops audio and files without a source', () => {
+    const grouped = groupAttachmentsByType([
+      attachment(ATTACHMENT_TYPES.AUDIO, null, 1),
+      attachment(ATTACHMENT_TYPES.FILE, null, 2),
+    ]);
+
+    expect(grouped.recordings).toEqual([]);
+    expect(grouped.files).toEqual([]);
+  });
+
+  it('keeps a location, which carries coordinates instead of a source', () => {
+    const location = attachment(ATTACHMENT_TYPES.LOCATION, null, 1);
+
+    expect(groupAttachmentsByType([location]).locations).toEqual([location]);
+  });
+
+  it('keeps images ahead of videos', () => {
+    const video = attachment(ATTACHMENT_TYPES.VIDEO, 'https://cdn/1.mp4', 1);
+    const image = attachment(ATTACHMENT_TYPES.IMAGE, 'https://cdn/2.png', 2);
+
+    expect(groupAttachmentsByType([video, image]).media).toEqual([image, video]);
+  });
+});

--- a/src/utils/specs/attachmentUtils.spec.ts
+++ b/src/utils/specs/attachmentUtils.spec.ts
@@ -6,14 +6,14 @@ const attachment = (fileType: string, dataUrl: string | null, id: number) =>
   ({ fileType, dataUrl, id }) as unknown as ImageMetadata;
 
 describe('groupAttachmentsByType', () => {
-  it('drops media without a source', () => {
+  it('keeps media without a source, so an expired story still reaches its placeholder', () => {
     const withSource = attachment(ATTACHMENT_TYPES.IMAGE, 'https://cdn/1.png', 1);
-    const grouped = groupAttachmentsByType([
-      withSource,
-      attachment(ATTACHMENT_TYPES.IMAGE, null, 2),
-    ]);
+    const withoutSource = attachment(ATTACHMENT_TYPES.IMAGE, null, 2);
 
-    expect(grouped.media).toEqual([withSource]);
+    expect(groupAttachmentsByType([withSource, withoutSource]).media).toEqual([
+      withSource,
+      withoutSource,
+    ]);
   });
 
   it('drops audio and files without a source', () => {

--- a/src/utils/specs/typingUtils.spec.ts
+++ b/src/utils/specs/typingUtils.spec.ts
@@ -82,4 +82,21 @@ describe('#getTypingUsersText', () => {
       }),
     ).toEqual('John and 3 others are typing');
   });
+
+  it('falls back to an empty name when a typing user has none', () => {
+    expect(
+      getTypingUsersText({
+        users: [
+          {
+            name: null,
+            type: 'user',
+            email: 'john@example.com',
+            id: 1,
+            phoneNumber: '1234567890',
+            thumbnail: 'https://example.com/thumbnail.jpg',
+          },
+        ],
+      } as unknown as Parameters<typeof getTypingUsersText>[0]),
+    ).toEqual(' is typing');
+  });
 });

--- a/src/utils/typingUtils.ts
+++ b/src/utils/typingUtils.ts
@@ -4,6 +4,10 @@ export const isContactTyping = (typingUsers: TypingUser[], userId: number) => {
   return typingUsers.some(user => user.id === userId && user.type === 'contact');
 };
 
+// A typing user can reach the client without a name.
+const displayName = (user: TypingUser) =>
+  String(user?.name ?? '').replace(/^./, str => str.toUpperCase());
+
 export const getTypingUsersText = ({ users }: { users: TypingUser[] }) => {
   if (!users) {
     return '';
@@ -13,21 +17,17 @@ export const getTypingUsersText = ({ users }: { users: TypingUser[] }) => {
     const count = users.length;
     if (count === 1) {
       const [user] = users;
-      return `${user.name.toString().replace(/^./, str => str.toUpperCase())} is typing`;
+      return `${displayName(user)} is typing`;
     }
 
     if (count === 2) {
       const [first, second] = users;
-      return `${first.name.toString().replace(/^./, str => str.toUpperCase())} and ${second.name
-        .toString()
-        .replace(/^./, str => str.toUpperCase())} are typing`;
+      return `${displayName(first)} and ${displayName(second)} are typing`;
     }
 
     const [user] = users;
     const rest = users.length - 1;
-    return `${user.name
-      .toString()
-      .replace(/^./, str => str.toUpperCase())} and ${rest} others are typing`;
+    return `${displayName(user)} and ${rest} others are typing`;
   }
   return false;
 };


### PR DESCRIPTION
## Description

`MessageAttachments` passes `attachment.dataUrl` straight to the image, video and file bubbles, which hand it to a native viewer, player or file path. An attachment without one takes down the message list through the error boundary:

- Galeria resolves `Image.resolveAssetSource(url).uri` on a null url ([CHATWOOT-MOBILE-2BV](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-2BV), [CHATWOOT-MOBILE-29G](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-29G))
- expo-video rejects the player constructor ([CHATWOOT-MOBILE-2BK](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-2BK))
- `FileBubblePreview` reads `fileSrc.split('/')` ([CHATWOOT-MOBILE-29X](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-29X))

Grouping now drops attachments without a source. Locations keep theirs, since they carry coordinates instead.

`getTypingUsersText` called `user.name.toString()`, which crashed the conversation list when a typing user arrived without a name ([CHATWOOT-MOBILE-2B3](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-2B3)).

The grouping moved to a util so it can be tested without loading the native modules the bubbles import.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added `attachmentUtils.spec.ts` covering media, audio and files without a source, locations, and media ordering, plus a null-name case in `typingUtils.spec.ts`. Full suite green.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
