### PR TITLE
fix(sentry): guard FCM notification parsing

### DIFF
--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -135,14 +135,16 @@ export const AppNavigationContainer = () => {
       const message = await messaging().getInitialNotification();
       if (message) {
         const notification = findNotificationFromFCM({ message });
-        const camelCaseNotification = transformNotification(notification);
-        const conversationLink = findConversationLinkFromPush({
-          notification: camelCaseNotification,
-          installationUrl,
-          currentAccountId,
-        });
-        if (conversationLink) {
-          return conversationLink;
+        if (notification) {
+          const camelCaseNotification = transformNotification(notification);
+          const conversationLink = findConversationLinkFromPush({
+            notification: camelCaseNotification,
+            installationUrl,
+            currentAccountId,
+          });
+          if (conversationLink) {
+            return conversationLink;
+          }
         }
       }
       return undefined;
@@ -167,15 +169,17 @@ export const AppNavigationContainer = () => {
       const unsubscribeNotification = messaging().onNotificationOpenedApp(message => {
         if (message) {
           const notification = findNotificationFromFCM({ message });
-          const camelCaseNotification = transformNotification(notification);
+          if (notification) {
+            const camelCaseNotification = transformNotification(notification);
 
-          const conversationLink = findConversationLinkFromPush({
-            notification: camelCaseNotification,
-            installationUrl,
-            currentAccountId,
-          });
-          if (conversationLink) {
-            listener(conversationLink);
+            const conversationLink = findConversationLinkFromPush({
+              notification: camelCaseNotification,
+              installationUrl,
+              currentAccountId,
+            });
+            if (conversationLink) {
+              listener(conversationLink);
+            }
           }
         }
       });

--- a/src/utils/pushUtils.ts
+++ b/src/utils/pushUtils.ts
@@ -58,16 +58,24 @@ interface FCMMessage {
   };
 }
 
+// A push can arrive without the field the branch below reads, and its contents
+// come from the server, so a parse is never assumed to succeed.
+const parseJSON = (value?: string) => {
+  if (!value) {
+    return null;
+  }
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+};
+
 export const findNotificationFromFCM = ({ message }: { message: FCMMessage }) => {
-  let notification = null;
   // FCM HTTP v1
   if (message?.data?.payload) {
-    const parsedPayload = JSON.parse(message.data.payload);
-    notification = parsedPayload.data.notification;
+    return parseJSON(message.data.payload)?.data?.notification ?? null;
   }
   // FCM legacy. It will be deprecated soon
-  else {
-    notification = JSON.parse(message.data.notification);
-  }
-  return notification;
+  return parseJSON(message?.data?.notification);
 };

--- a/src/utils/specs/pushUtils.spec.ts
+++ b/src/utils/specs/pushUtils.spec.ts
@@ -12,6 +12,16 @@ describe('findNotificationFromFCM', () => {
     expect(result).toEqual({ id: 123, title: 'Test Notification' });
   });
 
+  it.each([
+    ['no data', {}],
+    ['no notification field', { data: {} }],
+    ['a malformed payload', { data: { payload: 'not json' } }],
+    ['a payload without a notification', { data: { payload: '{"data": {}}' } }],
+    ['a malformed legacy notification', { data: { notification: 'not json' } }],
+  ])('returns null for a message with %s', (_case, message) => {
+    expect(findNotificationFromFCM({ message })).toBeNull();
+  });
+
   it('should return notification from FCM legacy message', () => {
     const message = {
       data: {


### PR DESCRIPTION
## Description

`findNotificationFromFCM` parsed `message.data.notification` without checking it is there:

```ts
notification = JSON.parse(message.data.notification);
```

A legacy push carrying only a payload reaches `JSON.parse(undefined)`, which stringifies to `"undefined"` and throws on the first character ([CHATWOOT-MOBILE-2C8](https://chatwoot-p3.sentry.io/issues/CHATWOOT-MOBILE-2C8)). The v1 branch made the same assumption about `data` inside the parsed payload, and neither branch allowed for the server sending something unparseable.

Parsing now returns null instead of throwing, and the two call sites in the navigation linking config skip a push they cannot read rather than passing null into `transformNotification`, which would throw again in `findConversationLinkFromPush`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added five cases to `pushUtils.spec.ts` for a message with no data, no notification field, a malformed payload, a payload without a notification, and a malformed legacy notification. All five fail on the previous implementation. Full suite green.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
