### PR TITLE
chore: move the eslint-disable onto the line it suppresses

### DIFF
--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -64,8 +64,8 @@ export const AppNavigationContainer = () => {
         },
       },
     },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     // getStateFromPath: App running, receives deep link - handles SSO callbacks and conversation navigation
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     getStateFromPath: (path: string, config: any) => {
       // Handle SSO callback - App running, receives deep link
       if (path.includes(SSO_CALLBACK_URL) || path.includes('auth/saml')) {


### PR DESCRIPTION
## Description

`src/navigation/index.tsx` failed lint with `Unexpected any` on the `getStateFromPath` signature. A second comment sat between the `eslint-disable-next-line` and the line it was written for, so the directive applied to the comment and the rule fired anyway. Moving it onto the signature clears the file.

The `any` itself is unchanged; typing `config` is a separate call.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`npx eslint src/navigation/index.tsx` is clean; it reports one error on develop.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
