### PR TITLE
fix: support conversation links through custom scheme

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -196,7 +196,8 @@ export const URL_REGEX = {
   CONVERSATION: 'app/accounts/[-0-9]+/conversations/[-0-9]',
 };
 
-export const SSO_CALLBACK_URL = 'chatwootapp://auth/saml';
+export const CHATWOOT_APP_URL = 'chatwootapp://';
+export const SSO_CALLBACK_URL = `${CHATWOOT_APP_URL}auth/saml`;
 
 export const CONVERSATION_TOGGLE_STATUS = {
   open: 'RESOLVE',

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -74,7 +74,10 @@ export const AppNavigationContainer = () => {
 
       const { accountId, conversationId, primaryActorId, primaryActorType } = params;
 
-      const targetAccountId = resolveAccountSwitch(accountId);
+      const { hasAccess, accountId: targetAccountId } = resolveAccountSwitch(accountId);
+      if (!hasAccess) {
+        return;
+      }
       if (targetAccountId) {
         switchAccount(dispatch, targetAccountId);
       }

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -13,6 +13,7 @@ import * as SplashScreen from 'expo-splash-screen';
 
 import { NavigationContainer } from '@react-navigation/native';
 import { AppTabs } from './tabs/AppTabs';
+import { getLinkingPrefixes, linkingConfig } from './linking';
 import i18n from 'i18n';
 import { navigationRef } from '@/utils/navigationUtils';
 import { findConversationLinkFromPush, findNotificationFromFCM } from '@/utils/pushUtils';
@@ -55,20 +56,8 @@ export const AppNavigationContainer = () => {
   const currentAccountId = useAppSelector(selectCurrentUserAccountId);
 
   const linking = {
-    prefixes: [installationUrl, SSO_CALLBACK_URL],
-    config: {
-      screens: {
-        ChatScreen: {
-          path: 'app/accounts/:accountId/conversations/:conversationId/:primaryActorId?/:primaryActorType?',
-          parse: {
-            accountId: (accountId: string) => parseInt(accountId),
-            conversationId: (conversationId: string) => parseInt(conversationId),
-            primaryActorId: (primaryActorId: string) => parseInt(primaryActorId),
-            primaryActorType: (primaryActorType: string) => decodeURIComponent(primaryActorType),
-          },
-        },
-      },
-    },
+    prefixes: getLinkingPrefixes(installationUrl),
+    config: linkingConfig,
     // getStateFromPath: App running, receives deep link - handles SSO callbacks and conversation navigation
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     getStateFromPath: (path: string, config: any) => {

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -6,18 +6,16 @@ import {
   onNotificationOpenedApp,
   setBackgroundMessageHandler,
 } from '@react-native-firebase/messaging';
-import { getStateFromPath } from '@react-navigation/native';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { useFonts } from 'expo-font';
 import * as SplashScreen from 'expo-splash-screen';
 
 import { NavigationContainer } from '@react-navigation/native';
 import { AppTabs } from './tabs/AppTabs';
-import { getLinkingPrefixes, linkingConfig } from './linking';
+import { getConversationParamsFromPath, getLinkingPrefixes, linkingConfig } from './linking';
 import i18n from 'i18n';
 import { navigationRef } from '@/utils/navigationUtils';
 import { findConversationLinkFromPush, findNotificationFromFCM } from '@/utils/pushUtils';
-import { extractConversationIdFromUrl } from '@/utils/conversationUtils';
 import { useAppSelector } from '@/hooks';
 import { selectInstallationUrl, selectLocale } from '@/store/settings/settingsSelectors';
 import { selectCurrentUserAccountId } from '@/store/auth/authSelectors';
@@ -59,8 +57,7 @@ export const AppNavigationContainer = () => {
     prefixes: getLinkingPrefixes(installationUrl),
     config: linkingConfig,
     // getStateFromPath: App running, receives deep link - handles SSO callbacks and conversation navigation
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    getStateFromPath: (path: string, config: any) => {
+    getStateFromPath: (path: string) => {
       // Handle SSO callback - App running, receives deep link
       if (path.includes(SSO_CALLBACK_URL) || path.includes('auth/saml')) {
         const ssoParams = SsoUtils.parseCallbackUrl(`chatwootapp://${path}`);
@@ -70,26 +67,12 @@ export const AppNavigationContainer = () => {
         return undefined;
       }
 
-      let primaryActorId = null;
-      let primaryActorType = null;
-      let accountId = null;
-      const state = getStateFromPath(path, config);
-      const { routes } = state || {};
-
-      const conversationId = extractConversationIdFromUrl({
-        url: path,
-      });
-
-      if (!conversationId) {
+      const params = getConversationParamsFromPath(path);
+      if (!params) {
         return;
       }
 
-      if (routes && routes[0]) {
-        const { params } = routes[0];
-        primaryActorId = (params as { primaryActorId?: number })?.primaryActorId;
-        primaryActorType = (params as { primaryActorType?: string })?.primaryActorType;
-        accountId = (params as { accountId?: number })?.accountId;
-      }
+      const { accountId, conversationId, primaryActorId, primaryActorType } = params;
 
       const targetAccountId = resolveAccountSwitch(accountId);
       if (targetAccountId) {

--- a/src/navigation/linking.ts
+++ b/src/navigation/linking.ts
@@ -1,0 +1,17 @@
+import { CHATWOOT_APP_URL } from '@/constants';
+
+export const getLinkingPrefixes = (installationUrl: string) => [installationUrl, CHATWOOT_APP_URL];
+
+export const linkingConfig = {
+  screens: {
+    ChatScreen: {
+      path: 'app/accounts/:accountId/conversations/:conversationId/:primaryActorId?/:primaryActorType?',
+      parse: {
+        accountId: (accountId: string) => parseInt(accountId),
+        conversationId: (conversationId: string) => parseInt(conversationId),
+        primaryActorId: (primaryActorId: string) => parseInt(primaryActorId),
+        primaryActorType: (primaryActorType: string) => decodeURIComponent(primaryActorType),
+      },
+    },
+  },
+};

--- a/src/navigation/linking.ts
+++ b/src/navigation/linking.ts
@@ -1,4 +1,13 @@
+import { getStateFromPath } from '@react-navigation/native';
+
 import { CHATWOOT_APP_URL } from '@/constants';
+
+type ConversationLinkParams = {
+  accountId: number;
+  conversationId: number;
+  primaryActorId?: number;
+  primaryActorType?: string;
+};
 
 export const getLinkingPrefixes = (installationUrl: string) => [installationUrl, CHATWOOT_APP_URL];
 
@@ -14,4 +23,20 @@ export const linkingConfig = {
       },
     },
   },
+};
+
+export const getConversationParamsFromPath = (path: string): ConversationLinkParams | null => {
+  const state = getStateFromPath(path, linkingConfig);
+  const route = state?.routes[0];
+
+  if (route?.name !== 'ChatScreen') {
+    return null;
+  }
+
+  const params = route.params as ConversationLinkParams | undefined;
+  if (!params || !Number.isInteger(params.accountId) || !Number.isInteger(params.conversationId)) {
+    return null;
+  }
+
+  return params;
 };

--- a/src/navigation/specs/linking.spec.ts
+++ b/src/navigation/specs/linking.spec.ts
@@ -1,7 +1,5 @@
-import { getStateFromPath } from '@react-navigation/native';
-
 import { CHATWOOT_APP_URL, SSO_CALLBACK_URL } from '@/constants';
-import { getLinkingPrefixes, linkingConfig } from '@/navigation/linking';
+import { getConversationParamsFromPath, getLinkingPrefixes } from '@/navigation/linking';
 
 describe('navigation linking', () => {
   const installationUrl = 'https://chat.example.com/';
@@ -18,20 +16,16 @@ describe('navigation linking', () => {
     const url = `${CHATWOOT_APP_URL}app/accounts/42/conversations/314`;
     const path = url.slice(CHATWOOT_APP_URL.length);
 
-    expect(getStateFromPath(path, linkingConfig)).toMatchObject({
-      routes: [
-        {
-          name: 'ChatScreen',
-          params: {
-            accountId: 42,
-            conversationId: 314,
-          },
-        },
-      ],
+    expect(getConversationParamsFromPath(path)).toMatchObject({
+      accountId: 42,
+      conversationId: 314,
     });
   });
 
-  it('ignores custom-scheme links outside the configured conversation route', () => {
-    expect(getStateFromPath('settings', linkingConfig)).toBeUndefined();
-  });
+  it.each(['settings', 'settings/conversations/314', 'foo/conversations/314'])(
+    'ignores custom-scheme path %s outside the configured conversation route',
+    path => {
+      expect(getConversationParamsFromPath(path)).toBeNull();
+    },
+  );
 });

--- a/src/navigation/specs/linking.spec.ts
+++ b/src/navigation/specs/linking.spec.ts
@@ -1,0 +1,37 @@
+import { getStateFromPath } from '@react-navigation/native';
+
+import { CHATWOOT_APP_URL, SSO_CALLBACK_URL } from '@/constants';
+import { getLinkingPrefixes, linkingConfig } from '@/navigation/linking';
+
+describe('navigation linking', () => {
+  const installationUrl = 'https://chat.example.com/';
+
+  it('accepts web links from the configured installation and custom-scheme links', () => {
+    expect(getLinkingPrefixes(installationUrl)).toEqual([installationUrl, CHATWOOT_APP_URL]);
+  });
+
+  it('keeps the SSO callback on the custom scheme', () => {
+    expect(SSO_CALLBACK_URL).toBe(`${CHATWOOT_APP_URL}auth/saml`);
+  });
+
+  it('parses a custom-scheme conversation link', () => {
+    const url = `${CHATWOOT_APP_URL}app/accounts/42/conversations/314`;
+    const path = url.slice(CHATWOOT_APP_URL.length);
+
+    expect(getStateFromPath(path, linkingConfig)).toMatchObject({
+      routes: [
+        {
+          name: 'ChatScreen',
+          params: {
+            accountId: 42,
+            conversationId: 314,
+          },
+        },
+      ],
+    });
+  });
+
+  it('ignores custom-scheme links outside the configured conversation route', () => {
+    expect(getStateFromPath('settings', linkingConfig)).toBeUndefined();
+  });
+});

--- a/src/utils/accountUtils.ts
+++ b/src/utils/accountUtils.ts
@@ -31,17 +31,23 @@ export const switchAccount = (dispatch: AppDispatch, accountId: number) => {
   dispatch(authActions.setActiveAccount({ profile: { account_id: accountId } }));
 };
 
-// Returns null when no switch is needed or possible: id missing, already active, or not a member.
-export const resolveAccountSwitch = (accountId?: number | null): number | null => {
+type AccountSwitchResolution =
+  | { hasAccess: false; accountId: null }
+  | { hasAccess: true; accountId: number | null };
+
+export const resolveAccountSwitch = (accountId?: number | null): AccountSwitchResolution => {
   if (!accountId) {
-    return null;
+    return { hasAccess: false, accountId: null };
   }
   const { user } = getStore().getState().auth;
-  if (!user || Number(user.account_id) === Number(accountId)) {
-    return null;
+  if (!user) {
+    return { hasAccess: false, accountId: null };
+  }
+  if (Number(user.account_id) === Number(accountId)) {
+    return { hasAccess: true, accountId: null };
   }
   const hasAccess = (user.accounts ?? []).some(
     (account: Account) => Number(account.id) === Number(accountId),
   );
-  return hasAccess ? accountId : null;
+  return hasAccess ? { hasAccess: true, accountId } : { hasAccess: false, accountId: null };
 };

--- a/src/utils/specs/accountUtils.spec.ts
+++ b/src/utils/specs/accountUtils.spec.ts
@@ -1,0 +1,41 @@
+import { getStore } from '@/store/storeAccessor';
+import { resolveAccountSwitch } from '@/utils/accountUtils';
+
+jest.mock('@/store/storeAccessor', () => ({
+  getStore: jest.fn(),
+}));
+
+const mockGetStore = getStore as jest.MockedFunction<typeof getStore>;
+
+const setActiveAccount = (accountId: number, accountIds: number[]) => {
+  mockGetStore.mockReturnValue({
+    getState: () => ({
+      auth: {
+        user: {
+          account_id: accountId,
+          accounts: accountIds.map(id => ({ id })),
+        },
+      },
+    }),
+  } as ReturnType<typeof getStore>);
+};
+
+describe('resolveAccountSwitch', () => {
+  it('allows navigation without a switch for the active account', () => {
+    setActiveAccount(1, [1, 2]);
+
+    expect(resolveAccountSwitch(1)).toEqual({ hasAccess: true, accountId: null });
+  });
+
+  it('allows navigation and returns an accessible account to switch to', () => {
+    setActiveAccount(1, [1, 2]);
+
+    expect(resolveAccountSwitch(2)).toEqual({ hasAccess: true, accountId: 2 });
+  });
+
+  it('rejects navigation to an inaccessible account', () => {
+    setActiveAccount(1, [1, 2]);
+
+    expect(resolveAccountSwitch(3)).toEqual({ hasAccess: false, accountId: null });
+  });
+});


### PR DESCRIPTION
## Description

The official mobile app can connect to self-hosted Chatwoot installations, but arbitrary self-hosted HTTPS domains cannot be declared in the official APK for Android App Links.

The app already registers the `chatwootapp` scheme natively, while React Navigation currently accepts only the full SAML callback URL as a prefix. As a result, domain-independent conversation links are ignored.

This change:

- registers `chatwootapp://` as the navigation prefix;
- keeps the existing installation URL and SAML callback behavior;
- reuses the existing account and conversation route parsing;
- ignores custom-scheme paths outside the configured conversation route; and
- extracts the static linking configuration into a focused, testable module.

It enables links such as:

`chatwootapp://app/accounts/42/conversations/314`

A separate web-side follow-up can use this capability for an explicit Open in app action. This PR does not attempt to make arbitrary self-hosted HTTPS domains verified App Links.

The existing custom mobile app documentation already describes `chatwootapp://` as the internal-routing mechanism, so no documentation change is required.

Fixes #1165

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `pnpm test --runInBand` — 53 suites and 332 tests passed.
- `pnpm exec eslint src/constants/index.ts src/navigation/index.tsx src/navigation/linking.ts src/navigation/specs/linking.spec.ts src/utils/accountUtils.ts src/utils/specs/accountUtils.spec.ts` — passed.
- `pnpm exec expo export --platform android` — production bundle exported successfully.
- `pnpm exec expo export --platform ios` — production bundle exported successfully.
- Added focused tests for installation URL preservation, custom-scheme registration, SAML callback preservation, conversation parsing, and rejection of unrelated routes, and inaccessible-account handling.

No physical Android or iOS device was available in this environment. The Android behavior can be reproduced after installing a development build with:

`adb shell am start -a android.intent.action.VIEW -d "chatwootapp://app/accounts/42/conversations/314"`

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code where the behavior is not self-explanatory
- [x] Existing documentation already covers the custom scheme and route format
- [ ] I have tested on physical Android and iOS devices
- [x] My changes generate no new warnings
- [x] This mobile change has no downstream dependency