### PR TITLE
chore: version update 4.9.3

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -4,7 +4,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
   return {
     name: 'Chatwoot',
     slug: process.env.EXPO_PUBLIC_APP_SLUG || 'chatwoot-mobile',
-    version: '4.9.2',
+    version: '4.9.3',
     orientation: 'portrait',
     icon: './assets/icon.png',
     userInterfaceStyle: 'light',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/mobile-app",
-  "version": "4.9.2",
+  "version": "4.9.3",
   "packageManager": "pnpm@10.11.0",
   "scripts": {
     "start": "expo start --dev-client",


### PR DESCRIPTION
Bumps `app.config.ts` and `package.json` from 4.9.2 to 4.9.3.

Shipping in this release:

- #1151
- #1164
- #1163
- #1161
- #1157
- #1155
- #1154
- #1153
- #1150
- #1149
- #1148
- #1152
- #1112
- #1125
