### PR TITLE
test: mock react-native-permissions in the settings actions spec

### DIFF
--- a/src/store/settings/specs/settingsActions.spec.ts
+++ b/src/store/settings/specs/settingsActions.spec.ts
@@ -5,6 +5,8 @@ jest.mock('@sentry/react-native', () => ({
   captureException: jest.fn(),
 }));
 
+jest.mock('react-native-permissions', () => jest.requireActual('react-native-permissions/mock'));
+
 jest.mock('@react-native-firebase/messaging', () => jest.fn());
 
 jest.mock('react-native-device-info', () => ({


### PR DESCRIPTION
`src/store/settings/specs/settingsActions.spec.ts` fails to load on `develop`:

```
Invariant Violation: TurboModuleRegistry.getEnforcing(...): 'RNPermissions' could not be found.

    > 5 | import { RESULTS, checkNotifications, requestNotifications } from 'react-native-permissions';
      at Object.require (src/store/settings/settingsActions.ts:5:1)
      at Object.require (src/store/settings/specs/settingsActions.spec.ts:1:1)
```

Two changes collided. #1157 added the `react-native-permissions` import to `settingsActions.ts`; #1151 added this spec from a branch cut before that, so its mock list does not cover the module. Under jest-expo the package resolves to its TypeScript source, and `NativeRNPermissions` calls `TurboModuleRegistry.getEnforcing('RNPermissions')` at import time, so importing `settingsActions` throws before any test runs.

This mocks the module with the mock the package ships. `jest.requireActual` rather than `require`, which `@typescript-eslint/no-require-imports` rejects.

```
$ npx jest
Test Suites: 53 passed, 53 total
Tests:       360 passed, 360 total

$ npx eslint src/store/settings/specs/settingsActions.spec.ts
(no output)
```